### PR TITLE
Update the guide and API for two-way binding with v-with in 0.11.5

### DIFF
--- a/source/api/directives.md
+++ b/source/api/directives.md
@@ -186,8 +186,6 @@ For detailed examples, see [Displaying a List](/guide/list.html).
 
 Allows a child ViewModel to inherit data from the parents. You can either pass in an Object which will be used as the `data` option, or bind individual parent properties to the child with different keys. This directive must be used in combination with `v-component`.
 
-The data inheritance is one-way: when parent property changes, the child will be notified of the change and update accordingly; however if the child sets the property to something else, it will not affect the parent, and the modified property will be overwritten the next time parent property changes.
-
 Example inheriting an object:
 
 ``` js

--- a/source/guide/components.md
+++ b/source/guide/components.md
@@ -118,7 +118,7 @@ var parent = new Vue({
 
 #### Passing Down Individual Properties
 
-`v-with` can also be used with an argument in the form of `v-with="childProp: parentProp"`. This means passing down `parent[parentProp]` to the child as `child[childProp]`. Note this data inheritance is one-way: when `parentProp` changes, `childProp` will be updated accordingly, however not the other way around.
+`v-with` can also be used with an argument in the form of `v-with="childProp: parentProp"`. This means passing down `parent[parentProp]` to the child as `child[childProp]`, creating a two-way binding (as of 0.11.5).
 
 **Example:**
 


### PR DESCRIPTION
Why was it changed to a unidirectional flow in 0.11 anyway? Why was it changed back?