### PR TITLE
Updated the demo to use v-class

### DIFF
--- a/source/guide/index.md
+++ b/source/guide/index.md
@@ -126,7 +126,7 @@ This simple mechanism enables declarative reuse and composition of Vue instances
     <li
       v-repeat="todos"
       v-on="click: done = !done"
-      class="{{done ? 'done' : ''}}">
+      v-class="done: done">
       {{content}}
     </li>
   </ul>


### PR DESCRIPTION
I noticed you were using `class="{{done ? 'done' : ''}}"` instead of `v-class="done: done"`. I wasn't sure if there was a particular reason for this but I figured I'd submit a pull request either way.