### PR TITLE
update $remove arguments reference

### DIFF
--- a/source/api/instance-methods.md
+++ b/source/api/instance-methods.md
@@ -190,9 +190,10 @@ Insert the vm's `$el` before target element.
 
 Insert the vm's `$el` after target element.
 
-### vm.$remove( [callback] )
+### vm.$remove( [callback], withTransition )
 
 - **callback** `Function` *optional*
+- **withTransition** `Boolean` *optional*
 
 Remove the vm's `$el` from the DOM.
 


### PR DESCRIPTION
Additionally I have found in [this](http://vuejs.org/examples/firebase.html) example ```app.users.$remove(user)``` where user seems an object. I'm not sure about that one as in the code I don't see cb being used in some other way.