### PR TITLE
Fix `v-for`'s documentation (Example #2)

### DIFF
--- a/src/guide/list.md
+++ b/src/guide/list.md
@@ -61,7 +61,7 @@ Inside `v-for` blocks we have full access to parent scope properties, plus a spe
 ``` html
 <ul id="example-2">
   <li v-for="item in items">
-    {{ parentMessage }} {{ $index }} {{ item.message }}
+    {{ parentMessage }} - {{ $index }} - {{ item.message }}
   </li>
 </ul>
 ```


### PR DESCRIPTION
No major fix.  Just a minor error in the example I noticed.

The HTML provided in the example doesn't contain the hyphens that the output does...