### PR TITLE
Add Algolia docsearch

### DIFF
--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -8,12 +8,14 @@
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
         <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600|Roboto Mono' rel='stylesheet' type='text/css'>
         <link href='http://fonts.googleapis.com/css?family=Dosis:300,500&text=Vue.js' rel='stylesheet' type='text/css'>
+        <link href="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" rel='stylesheet' type='text/css'>
         <link rel="icon" href="/images/logo.png" type="image/x-icon">
         <script>
             window.PAGE_TYPE = "<%- page.type %>"
         </script>
         <%- css(isIndex ? 'css/index' : 'css/page') %>
         <%- partial('partials/ga') %>
+        <script type="text/javascript" src="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
         <script src="/js/vue.js"></script>
     </head>
     <body>

--- a/themes/vue/source/css/_common.styl
+++ b/themes/vue/source/css/_common.styl
@@ -165,6 +165,34 @@ a.button
         border-right 4px solid transparent
         border-top 5px solid #ccc
 
+    .algolia-autocomplete
+    	line-height: normal
+
+    @media (min-width: 768px)
+    	.aa-dropdown-menu
+        	min-width: 515px
+
+    .algolia-docsearch-suggestion
+        border-color: #42b983
+
+    .algolia-docsearch-suggestion--subcategory-column
+        border-color: #42b983
+
+    .algolia-docsearch-suggestion--category-header
+    	background: #42b983
+
+    .algolia-docsearch-footer
+        border-color: #42b983
+
+    .algolia-docsearch-suggestion--category-header .algolia-docsearch-suggestion--highlight
+        background rgba(255, 255, 255, 0.6)
+
+    .algolia-docsearch-suggestion--highlight
+        color: #2c815b
+
+    .aa-cursor .algolia-docsearch-suggestion--content
+        color: #000
+
 #donate
     height 24px
     .wrapper

--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -12,12 +12,12 @@
    */
 
   function initSearch () {
-    (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
-    (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
-    e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
-    })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
-
-    _st('install','HgpxvBc7pUaPUWmG9sgv','2.0.0');
+    docsearch({
+      appId: 'BH4D9OD16A',
+      apiKey: '85cc3221c9f23bfbaa4e3913dd7625ea',
+      indexName: 'vuejs',
+      inputSelector: '#search-query'
+    });
   }
 
   /**


### PR DESCRIPTION
This PR add [Algolia docsearch](https://community.algolia.com/docsearch/) to the vuejs doc.

You can see it live here: [https://vuejs.algolia.com/guide/](https://vuejs.algolia.com/guide/)

Here is a preview:

![mzvzyfxja0](https://cloud.githubusercontent.com/assets/1689007/12882352/5a644eb4-ce51-11e5-8b34-b1a90c43ebaf.gif)