### PR TITLE
Show sidebar scrollbar when header is hidden

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -102,8 +102,6 @@ $header-height = 40px
     overflow-y auto
     -webkit-overflow-scrolling touch
     -ms-overflow-style none
-    &::-webkit-scrollbar
-        width: 0 !important
     h2
         margin-top .2em
     ul


### PR DESCRIPTION
Related to: https://github.com/vuejs/vuejs.org/issues/245

In Firefox, when the header is hidden the sidebar scrollbar appears. On Chrome it does not. This pull request should fix it in Chrome.