### PR TITLE
added activate hook into API hooks list

### DIFF
--- a/src/api/index.md
+++ b/src/api/index.md
@@ -658,6 +658,16 @@ type: api
 
 - **See also:** [Lifecycle Diagram](/guide/instance.html#Lifecycle-Diagram)
 
+### activate
+
+- **Type:** `Function`
+
+- **Details:**
+
+  Called after compilation is finished, right before `ready` hook.
+
+- **See also:** [Guide](/guide/components.html#activate-Hook)
+
 ### ready
 
 - **Type:** `Function`


### PR DESCRIPTION
To my point of view the hook is missing in the hooks list at API page. Fixed that :)