### PR TITLE
define SPA

### DIFF
--- a/src/guide/syntax.md
+++ b/src/guide/syntax.md
@@ -138,7 +138,7 @@ Of course, this seems pointless because we can just do `href="/a/b/c"` instead o
 
 ## Shorthands
 
-The `v-` prefix serves as a visual cue for identifying Vue-specific attributes in your templates. This is useful when you are using Vue.js to apply dynamic behavior to some existing markup, but can feel verbose for some frequently used directives. At the same time, the need for the `v-` prefix becomes less important when you are building an SPA where Vue.js manages every template. Therefore, Vue.js provides special shorthands for two of the most often used directives, `v-bind` and `v-on`:
+The `v-` prefix serves as a visual cue for identifying Vue-specific attributes in your templates. This is useful when you are using Vue.js to apply dynamic behavior to some existing markup, but can feel verbose for some frequently used directives. At the same time, the need for the `v-` prefix becomes less important when you are building an [SPA](https://en.wikipedia.org/wiki/Single-page_application) where Vue.js manages every template. Therefore, Vue.js provides special shorthands for two of the most often used directives, `v-bind` and `v-on`:
 
 ### `v-bind` Shorthand
 


### PR DESCRIPTION
The initialism 'SPA' was used without a definition in syntax.md.  Add a simple Wikipedia link to define it, much in the way XSS was defined earlier in the page.