### PR TITLE
Modify #ad width

### DIFF
--- a/themes/vue/source/css/index.styl
+++ b/themes/vue/source/css/index.styl
@@ -311,6 +311,7 @@ html, body
             font-size 1.4em
     #ad
         position static
+        padding 10px 0
         .carbon-img, .carbon-text, .carbon-poweredby
             display inline-bloc
 


### PR DESCRIPTION
hello :)

I modified `#ad` width because `#ad` was overflowed at mobile screen.


## before
![scroll-test](https://cloud.githubusercontent.com/assets/3367801/15043256/6096a17a-1306-11e6-8832-41b16e84d4eb.gif)

## check browsers
- safari (iPhone 6s plus iOS 9.3)
- chrome (nexus 5x)