### PR TITLE
Fix jsfiddle example not loading over SSL

### DIFF
--- a/src/guide/transitions.md
+++ b/src/guide/transitions.md
@@ -439,4 +439,4 @@ Vue.transition('stagger', {
 
 Example:
 
-<iframe width="100%" height="200" style="margin-left:10px" src="http://jsfiddle.net/yyx990803/mvo99bse/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+<iframe width="100%" height="200" style="margin-left:10px" src="https://jsfiddle.net/yyx990803/mvo99bse/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>


### PR DESCRIPTION
The JSFiddle example for staggered transitions was using `http` instead of `https`.