### PR TITLE
Update ad so it doesn't overlap content

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -279,7 +279,6 @@ $header-height = 40px
 @media screen and (max-width: 720px)
     #ad
         width 100%
-        margin-bottom -25px
     body
         -webkit-text-size-adjust none
         font-size 14px


### PR DESCRIPTION
Removed negative bottom margin from ad so that it doesn't overlap the content of the docs on smaller (<=720px) screens.