### PR TITLE
Add link to the API reference.

### DIFF
--- a/src/guide/instance.md
+++ b/src/guide/instance.md
@@ -16,7 +16,7 @@ var vm = new Vue({
 
 A Vue instance is essentially a **ViewModel** as defined in the [MVVM pattern](https://en.wikipedia.org/wiki/Model_View_ViewModel), hence the variable name `vm` you will see throughout the docs.
 
-When you instantiate a Vue instance, you need to pass in an **options object** which can contain options for data, template, element to mount on, methods, lifecycle callbacks and more. The full list of options can be found in the API reference.
+When you instantiate a Vue instance, you need to pass in an **options object** which can contain options for data, template, element to mount on, methods, lifecycle callbacks and more. The full list of options can be found in the [API reference](/api).
 
 The `Vue` constructor can be extended to create reusable **component constructors** with pre-defined options:
 


### PR DESCRIPTION
Hi there,

I was just playing with vue.js and noticed a missing link to the API reference so I thought I'd add one.

Also, would it make sense for the API links in the markdown to link to http://vuejs.org/api/ instead? (rather than just relative links to the website itself which is what all the other links currently do?) I think it might make sense as it means browsing the links when viewing the markdown files on GitHub is broken. If you'd prefer the API links altered to vuejs.org let me know and I'll close this PR and open a new one.

Thanks for vue - really enjoying playing with it 👍  :)