### PR TITLE
Use the resolved URL for itunescn

### DIFF
--- a/themes/vue/layout/partials/sponsors.ejs
+++ b/themes/vue/layout/partials/sponsors.ejs
@@ -3,7 +3,7 @@
 <a href="https://strikingly.com/s/careers?utm_source=v" target="_blank" style="top:3px">
   <img src="/images/strikingly.png">
 </a>
-<a href="https://itunescn.com/" target="_blank" style="top:2px">
+<a href="https://www.itunescn.com/" target="_blank" style="top:2px">
   <img src="/images/itunescn.png">
 </a>
 <a href="https://jsfiddle.net/" target="_blank">


### PR DESCRIPTION
I noticed that itunescn's sponsor link was having trouble resolving to its final destination. 

It's probably better for everyone to point to the resulting URL. :)

```
$ curl -I https://itunescn.com/

HTTP/1.1 301 Moved Permanently
…
Location: http://www.itunescn.com/
```
etc...


The URL that the server seems to want to send you to eventually is reflected in the PR.