### PR TITLE
Remove unnecessary boolean check

### DIFF
--- a/src/guide/syntax.md
+++ b/src/guide/syntax.md
@@ -85,7 +85,7 @@ new Vue({
   ...
   filters: {
     capitalize: function (value) {
-      if (!value && value !== 0) return ''
+      if (!value) return ''
       value = value.toString()
       return value.charAt(0).toUpperCase() + value.slice(1)
     }


### PR DESCRIPTION
`!value` should already cover `value !== 0`, unless my headache is failing me. 