### PR TITLE
vueify@next needs global envify

### DIFF
--- a/src/guide/single-file-components.md
+++ b/src/guide/single-file-components.md
@@ -81,8 +81,16 @@ module.exports = {
 
 ### Browserify
 
-Just run your bundling command with `NODE_ENV` set to `"production"`. Vue automatically applies [envify](https://github.com/hughsk/envify) transform to itself and makes warning blocks unreachable. For example:
+- Run your bundling command with `NODE_ENV` set to `"production"`. This tells `vueify` to avoid including hot-reload and development related code.
+- Apply a global [envify](https://github.com/hughsk/envify) transform to your bundle. This allows the minifier to strip out all the warnings in Vue's source code wrapped in env variable conditional blocks. For example:
+
 
 ``` bash
-NODE_ENV=production browserify -e main.js | uglifyjs -c -m > build.js
+NODE_ENV=production browserify -g envify -e main.js | uglifyjs -c -m > build.js
+```
+
+- To extract styles to a separate css file use a extract-css plugin which is included in vueify.
+
+``` bash
+NODE_ENV=production browserify -g envify -p [ vueify/plugins/extract-css -o build.css ] -e main.js | uglifyjs -c -m > build.js
 ```


### PR DESCRIPTION
With browserify & Vue 2.0 you actually need to install `envify` yourself and apply it as global transform like [described here](https://github.com/vuejs/vueify/tree/next#building-for-production-1).

And there's also extract-css plugin included now so browserify users can extract styles into file as well.