### PR TITLE
Make the React example less esoteric

### DIFF
--- a/src/guide/comparison.md
+++ b/src/guide/comparison.md
@@ -59,19 +59,14 @@ render () {
   const { items } = this.props
 
   return (
-    <div className='list-container'>{
-      items.length
-        ? <ul>{
-            items.map(item => {
-              return (
-                <li key={item.id}>
-                  { item.name }
-                </li>
-              )
-            })
-          }</ul>
+    <div className='list-container'>
+      {items.length
+        ? <ul>
+            {items.map(item => <li key={item.id}>{item.name}</li>)}
+          </ul>
         : <p>No items found.</p>
-    }</div>
+      }
+    </div>
   )
 }
 ```


### PR DESCRIPTION
I've never seen React code which uses curly braces the way they're used in this example.

This change doesn't put curly braces on the same line as parent elements and uses the arrow function's implicit `return` when mapping the list, while retaining the other decisions which have been made:

- pointless, line-eating `(` `)` wrappers (which *do* seem to be in common use)
- using a ternary
- spacing of the ternary parts