### PR TITLE
Use if statement instead of ternary

### DIFF
--- a/src/guide/comparison.md
+++ b/src/guide/comparison.md
@@ -56,14 +56,12 @@ Take this example below:
 
 ``` jsx
 render() {
-  const { items } = this.props
+  let { items } = this.props
 
   let children
   if (items.length > 0) {
     children = items.map(item =>
-      <li key={item.id}>
-        {item.name}
-      </li>
+      <li key={item.id}>{item.name}</li>
     )
   } else {
     children = <p>No items found.</p>

--- a/src/guide/comparison.md
+++ b/src/guide/comparison.md
@@ -55,17 +55,23 @@ With React's JSX, there are minor differences from HTML, such as using `classNam
 Take this example below:
 
 ``` jsx
-render () {
+render() {
   const { items } = this.props
 
+  let children
+  if (items.length > 0) {
+    children = items.map(item =>
+      <li key={item.id}>
+        {item.name}
+      </li>
+    )
+  } else {
+    children = <p>No items found.</p>
+  }
+ 
   return (
     <div className='list-container'>
-      {items.length
-        ? <ul>
-            {items.map(item => <li key={item.id}>{item.name}</li>)}
-          </ul>
-        : <p>No items found.</p>
-      }
+      {children}
     </div>
   )
 }


### PR DESCRIPTION
I think this is more consistent with how people use React in practice.

React is JS, and it is expected that you use ternaries in the same case as you would use them in JS: only if they help readability. In this case they seem to obscure it.

You still get to say that React is verbose after this change ;-)