### PR TITLE
#nav li, lead to wrap when using Chinese language in firefox.

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -27,6 +27,7 @@ $header-height = 40px
         display inline-block
         position relative
         margin 0 .6em
+        white-space nowrap
 
 .nav-link
     padding-bottom 3px


### PR DESCRIPTION
add "nowrap" to prevent this case.