### PR TITLE
[1.x] Replace references to npmcdn with unpkg

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -30,7 +30,7 @@ Simply download and include with a script tag. `Vue` will be registered as a glo
 
 Available on [jsdelivr](//cdn.jsdelivr.net/vue/{{vue_version}}/vue.min.js) or [cdnjs](//cdnjs.cloudflare.com/ajax/libs/vue/{{vue_version}}/vue.min.js) (takes some time to sync so the latest version might not be available yet).
 
-Also available on [npmcdn](https://npmcdn.com/vue/dist/vue.min.js), which will reflect the latest version as soon as it is published to npm. You can also browse the source of the npm package at [npmcdn.com/vue/](https://npmcdn.com/vue/).
+Also available on [unpkg](https://unpkg.com/vue/dist/vue.min.js), which will reflect the latest version as soon as it is published to npm. You can also browse the source of the npm package at [unpkg.com/vue/](https://unpkg.com/vue/).
 
 ### CSP-compliant build
 


### PR DESCRIPTION
npmcdn.com has been recently renamed to unpkg.com. This commit replaces
all references to npmcdn with unpkg on `1.x` branch.