### PR TITLE
[2.0] Replace references to npmcdn with unpkg

### DIFF
--- a/src/guide/comparison.md
+++ b/src/guide/comparison.md
@@ -155,7 +155,7 @@ React is renowned for its steep learning curve. Before you can really get starte
 While Vue scales up just as well as, if not better than React, it also scales down just as well as jQuery. That's right - all you have to do is drop a single script tag into a page:
 
 ``` html
-<script src="https://npmcdn.com/vue@next/dist/vue.js"></script>
+<script src="https://unpkg.com/vue@next/dist/vue.js"></script>
 ```
 
 Then you can start writing Vue code and even ship the minified version to production without feeling guilty or having to worry about performance problems.

--- a/src/guide/computed.md
+++ b/src/guide/computed.md
@@ -171,8 +171,8 @@ For example:
 <!-- and collections of general-purpose utility methods, Vue core -->
 <!-- is able to remain small by not reinventing them. This also   -->
 <!-- gives you the freedom to just use what you're familiar with. -->
-<script src="https://npmcdn.com/axios@0.12.0/dist/axios.min.js"></script>
-<script src="https://npmcdn.com/lodash@4.13.1/lodash.min.js"></script>
+<script src="https://unpkg.com/axios@0.12.0/dist/axios.min.js"></script>
+<script src="https://unpkg.com/lodash@4.13.1/lodash.min.js"></script>
 <script>
 var watchExampleVM = new Vue({
   el: '#watch-example',
@@ -230,8 +230,8 @@ Result:
   </p>
   <p>{{ answer }}</p>
 </div>
-<script src="https://npmcdn.com/axios@0.12.0/dist/axios.min.js"></script>
-<script src="https://npmcdn.com/lodash@4.13.1/lodash.min.js"></script>
+<script src="https://unpkg.com/axios@0.12.0/dist/axios.min.js"></script>
+<script src="https://unpkg.com/lodash@4.13.1/lodash.min.js"></script>
 <script>
 var watchExampleVM = new Vue({
   el: '#watch-example',

--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -30,7 +30,7 @@ Simply download and include with a script tag. `Vue` will be registered as a glo
 
 Available on [jsdelivr](//cdn.jsdelivr.net/vue/{{vue_version}}/vue.min.js) or [cdnjs](//cdnjs.cloudflare.com/ajax/libs/vue/{{vue_version}}/vue.min.js) (takes some time to sync so the latest version might not be available yet).
 
-Also available on [npmcdn](https://npmcdn.com/vue/dist/vue.min.js), which will reflect the latest version as soon as it is published to npm. You can also browse the source of the npm package at [npmcdn.com/vue/](https://npmcdn.com/vue/).
+Also available on [unpkg](https://unpkg.com/vue/dist/vue.min.js), which will reflect the latest version as soon as it is published to npm. You can also browse the source of the npm package at [unpkg.com/vue/](https://unpkg.com/vue/).
 
 ### CSP environments
 

--- a/src/guide/transitioning-state.md
+++ b/src/guide/transitioning-state.md
@@ -18,7 +18,7 @@ All of these are either already stored as raw numbers or can be converted into n
 Watchers allow us to animate changes of any numerical property into another property. That may sound complicated in the abstract, so let's dive into an example using Tween.js:
 
 ``` html
-<script src="https://npmcdn.com/tween.js@16.3.4"></script>
+<script src="https://unpkg.com/tween.js@16.3.4"></script>
 
 <div id="animated-number-demo">
   <input v-model.number="number" type="number" step="20">
@@ -54,7 +54,7 @@ new Vue({
 ```
 
 {% raw %}
-<script src="https://npmcdn.com/tween.js@16.3.4"></script>
+<script src="https://unpkg.com/tween.js@16.3.4"></script>
 <div id="animated-number-demo" class="demo">
   <input v-model.number="number" type="number" step="20">
   <p>{{ animatedNumber }}</p>
@@ -90,8 +90,8 @@ new Vue({
 When you update the number, the change is animated below the input. This makes for a nice demo, but what about something that isn't directly stored as a number, like any valid CSS color for example? Here's how we could accomplish this with the addition of Color.js:
 
 ``` html
-<script src="https://npmcdn.com/tween.js@16.3.4"></script>
-<script src="https://npmcdn.com/color-js@1.0.3/color.js"></script>
+<script src="https://unpkg.com/tween.js@16.3.4"></script>
+<script src="https://unpkg.com/color-js@1.0.3/color.js"></script>
 
 <div id="example-7">
   <input
@@ -167,8 +167,8 @@ new Vue({
 ```
 
 {% raw %}
-<script src="https://npmcdn.com/tween.js@16.3.4"></script>
-<script src="https://npmcdn.com/color-js@1.0.3/color.js"></script>
+<script src="https://unpkg.com/tween.js@16.3.4"></script>
+<script src="https://unpkg.com/color-js@1.0.3/color.js"></script>
 <div id="example-7" class="demo">
   <input
     v-model="colorQuery"
@@ -381,7 +381,7 @@ See [this fiddle](https://jsfiddle.net/chrisvfritz/fbvusejy/) for the complete c
 Managing many state transitions can quickly increase the complexity of a Vue instance or component. Fortunately, many animations can be extracted out into dedicated child components. Let's do this with the animated integer from our earlier example:
 
 ``` html
-<script src="https://npmcdn.com/tween.js@16.3.4"></script>
+<script src="https://unpkg.com/tween.js@16.3.4"></script>
 
 <div id="example-8">
   <input v-model.number="firstNumber" type="number" step="20"> +
@@ -456,7 +456,7 @@ new Vue({
 ```
 
 {% raw %}
-<script src="https://npmcdn.com/tween.js@16.3.4"></script>
+<script src="https://unpkg.com/tween.js@16.3.4"></script>
 <div id="example-8" class="demo">
   <input v-model.number="firstNumber" type="number" step="20"> +
   <input v-model.number="secondNumber" type="number" step="20"> =

--- a/src/guide/transitions.md
+++ b/src/guide/transitions.md
@@ -328,7 +328,7 @@ These will override the conventional class names. This is especially useful when
 Here's an example:
 
 ``` html
-<link href="https://npmcdn.com/animate.css@3.5.1/animate.min.css" rel="stylesheet" type="text/css">
+<link href="https://unpkg.com/animate.css@3.5.1/animate.min.css" rel="stylesheet" type="text/css">
 
 <div id="example-3">
   <button @click="show = !show">
@@ -354,7 +354,7 @@ new Vue({
 ```
 
 {% raw %}
-<link href="https://npmcdn.com/animate.css@3.5.1" rel="stylesheet" type="text/css">
+<link href="https://unpkg.com/animate.css@3.5.1" rel="stylesheet" type="text/css">
 <div id="example-3" class="demo">
   <button @click="show = !show">
     Toggle render


### PR DESCRIPTION
npmcdn.com has been recently renamed to unpkg.com. This commit replaces
all references to npmcdn with unpkg on `2.0` branch.