### PR TITLE
Change yesno.wtf API to https

### DIFF
--- a/src/guide/computed.md
+++ b/src/guide/computed.md
@@ -203,7 +203,7 @@ var watchExampleVM = new Vue({
           return
         }
         vm.answer = 'Thinking...'
-        axios.get('http://yesno.wtf/api')
+        axios.get('https://yesno.wtf/api')
           .then(function (response) {
             vm.answer = _.capitalize(response.data.answer)
           })
@@ -254,7 +254,7 @@ var watchExampleVM = new Vue({
           return
         }
         vm.answer = 'Thinking...'
-        axios.get('http://yesno.wtf/api')
+        axios.get('https://yesno.wtf/api')
           .then(function (response) {
             vm.answer = _.capitalize(response.data.answer)
           })


### PR DESCRIPTION
yesno.wtf API has been moved permanently from http to https, rendering
the YesNo mini app broken. This commit fixes the issue.