### PR TITLE
Rename dependency to dependencies.

### DIFF
--- a/themes/vue/layout/index.ejs
+++ b/themes/vue/layout/index.ejs
@@ -113,7 +113,7 @@
     </div>
     <div class="feat">
       <h2><span class="icon compact"></span>Compact</h2>
-      <p>~24kb min+gzip, no dependency.</p>
+      <p>~24kb min+gzip, no dependencies.</p>
     </div>
     <div class="feat">
       <h2><span class="icon fast"></span>Fast</h2>


### PR DESCRIPTION
More grammatically correct, otherwise the other option is "not a single dependency".