### PR TITLE
Remove the description unsuited for Vue 2 any more

### DIFF
--- a/src/guide/syntax.md
+++ b/src/guide/syntax.md
@@ -116,7 +116,7 @@ Some directives can take an "argument", denoted by a colon after the directive n
 <a v-bind:href="url"></a>
 ```
 
-Here `href` is the argument, which tells the `v-bind` directive to bind the element's `href` attribute to the value of the expression `url`. You may have noticed this achieves the same result as an attribute interpolation using `{% raw %}href="{{url}}"{% endraw %}`: that is correct, and in fact, attribute interpolations are translated into `v-bind` bindings internally.
+Here `href` is the argument, which tells the `v-bind` directive to bind the element's `href` attribute to the value of the expression `url`.
 
 Another example is the `v-on` directive, which listens to DOM events:
 


### PR DESCRIPTION
Removed content:
" You may have noticed this achieves the same result as an attribute interpolation using href="{{url}}": that is correct, and in fact, attribute interpolations are translated into v-bind bindings internally."

This content in contradiction with "Mustaches cannot be used inside HTML attributes, instead use a v-bind directive.".