### PR TITLE
add $slots property to API docs

### DIFF
--- a/src/api/index.md
+++ b/src/api/index.md
@@ -894,6 +894,51 @@ type: api
 
   The direct child components of the current instance. **Note there's no order guarantee for `$children`, and it is not reactive.** If you find yourself trying to use `$children` for data binding, consider using an Array and `v-for` to generate child components, and use the Array as the source of truth.
 
+### vm.$slots
+
+- **Type:** `Object`
+
+- **Read only**
+
+- **Details:**
+
+  A hash of VNode children of component that should resolve with slot. VNode children resolved with Single Slot are stored as the `default` key. VNode children resolve with Named Slot are stored as the key that specified with `slot` attribute. those VNode children are stored an Array.
+
+- **Example:**
+
+  ```html
+  <div id="slots-demo">
+    ...
+    <my-component1>
+      <p slot="slot1">named slot content1</p>
+      <div>single slot content</div>
+      <p slot="slot2">named slot content2</div></p>
+    </my-component1>
+    ...
+  </div>
+  ```
+  ```js
+  new Vue({
+    ...
+    components: {
+      'my-component1': {
+        render: function (createElement) {
+          console.log('single slot', this.$slots.default)
+          console.log('named slot: slot1', this.$slots.slots1)
+          console.log('named slot: slot2', this.$slots.slots1)
+          return this.$slots.default
+        }
+      }
+    },
+    ...
+  }).$mount('#slots-demo')
+  ```
+
+- **See also:**
+  - [Render Functions](/guide/render-function.html)
+  - [Content Distribution with Slots](/guide/components.html#Content-Distribution-with-Slots)
+  - [slot](#slot)
+
 ### vm.$refs
 
 - **Type:** `Object`

--- a/src/guide/render-function.md
+++ b/src/guide/render-function.md
@@ -84,7 +84,7 @@ Vue.component('anchored-heading', {
 })
 ```
 
-Much simpler! Sort of. The code is shorter, but also requires greater familiarity with Vue instance properties. In this case, you have to know that when you pass children without a `slot` attribute into a component, like the `Hello world!` inside of `anchored-heading`, those children are stored on the component instance at `$slots.default`. If you haven't already, **it's recommended to read through the [instance properties API](/api/#Instance-Properties) before diving into render functions.**
+Much simpler! Sort of. The code is shorter, but also requires greater familiarity with Vue instance properties. In this case, you have to know that when you pass children without a `slot` attribute into a component, like the `Hello world!` inside of `anchored-heading`, those children are stored on the component instance at `$slots.default`. If you haven't already, **it's recommended to read through the [instance properties API](/api/#vm-slots) before diving into render functions.**
 
 ## `createElement` Arguments
 


### PR DESCRIPTION
I realized that $slots property is nothing in `guide/api/index.md`, when I found that dead link in [render function](http://rc.vuejs.org/guide/render-function.html).