### PR TITLE
Fix broken links in installation guide

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -69,7 +69,7 @@ For Browserify, you can use [aliasify](https://github.com/benbria/aliasify) to a
 
 Some environments, such as Google Chrome Apps, enforce Content Security Policy (CSP), which prohibits the use of `new Function()` for evaluating expressions. The standalone build depends on this feature to compile templates, so is unusable in these environments.
 
-On the other hand, the runtime-only build is fully CSP-compliant. When using the runtime-only build with [Webpack + vue-loader](https://github.com/vuejs-templates/webpack-simple-2.0) or [Browserify + vueify](https://github.com/vuejs-templates/browserify-simple-2.0), your templates will be precompiled into `render` functions which work perfectly in CSP environments.
+On the other hand, the runtime-only build is fully CSP-compliant. When using the runtime-only build with [Webpack + vue-loader](https://github.com/vuejs-templates/webpack-simple) or [Browserify + vueify](https://github.com/vuejs-templates/browserify-simple), your templates will be precompiled into `render` functions which work perfectly in CSP environments.
 
 ## CLI
 


### PR DESCRIPTION
[webpack-simple](https://github.com/vuejs-templates/webpack-simple) and [browserify-simple](https://github.com/vuejs-templates/browserify-simple) are Vue 2.0 compatible now.