### PR TITLE
set the background-color to white

### DIFF
--- a/themes/vue/source/css/_common.styl
+++ b/themes/vue/source/css/_common.styl
@@ -7,6 +7,7 @@ body
     -webkit-font-smoothing antialiased
     -moz-osx-font-smoothing grayscale
     color $medium
+    background-color white
     margin 0
 
 a


### PR DESCRIPTION
Set the background-color to white so that users whom changed the *default* background-color of their browser (ie. dark theme) can still see the website has intended by the designer.

For instance, when setting the *default* background-color to a dark themed one in Firefox, the website looks like this :
![dark_theme_and_vuejs org](https://cloud.githubusercontent.com/assets/7248877/18938926/0a0b347e-8598-11e6-98d3-170e4c72853a.png)

This pull request just set the css `background-color` property to `white`, so that the user default background-color is not used.