### PR TITLE
Update list.md to correctly reflect param order

### DIFF
--- a/src/guide/list.md
+++ b/src/guide/list.md
@@ -60,7 +60,7 @@ Inside `v-for` blocks we have full access to parent scope properties. `v-for` al
 
 ``` html
 <ul id="example-2">
-  <li v-for="(item, index) in items">
+  <li v-for="(index, item) in items">
     {{ parentMessage }} - {{ index }} - {{ item.message }}
   </li>
 </ul>


### PR DESCRIPTION
Docs currently show that index is second param, but it should be the first param, at least in vue 1.