### PR TITLE
Use "real" custom key codes for keyCodes sample

### DIFF
--- a/src/api/index.md
+++ b/src/api/index.md
@@ -86,10 +86,14 @@ type: api
 - **Usage:**
 
   ``` js
-  Vue.config.keyCodes = { esc: 27 }
+  Vue.config.keyCodes = {
+    v: 86,
+    f1: 112,
+    mediaPlayPause: 179
+  } 
   ```
 
-  Define custom key aliases for v-on.
+  Define custom key alias(es) for v-on.
 
 ## Global API
 


### PR DESCRIPTION
Current sample use `esc: 27` to demonstrate custom key code registration, which can be misleading, as `esc` has always been a built-in.