### PR TITLE
Close one html link tag so that you can copy-paste the example.

### DIFF
--- a/src/guide/events.md
+++ b/src/guide/events.md
@@ -173,7 +173,7 @@ To address this problem, Vue provides **event modifiers** for `v-on`. Recall tha
 <form v-on:submit.prevent="onSubmit"></form>
 
 <!-- modifiers can be chained -->
-<a v-on:click.stop.prevent="doThat">
+<a v-on:click.stop.prevent="doThat"></a>
 
 <!-- just the modifier -->
 <form v-on:submit.prevent></form>


### PR DESCRIPTION
Close one html <a> tag so that you can copy-paste the example and prevent your IDE to complain about it.