### PR TITLE
Widen the textarea and limit the resize to vertical only

### DIFF
--- a/themes/vue/source/css/_demo.styl
+++ b/themes/vue/source/css/_demo.styl
@@ -35,6 +35,9 @@
             margin-top 0
         &:last-child
             margin-bottom 0
+    textarea
+        width 100%
+        resize vertical
 
 
 


### PR DESCRIPTION
In the "Multiline text" example, the textarea element is very small by default, and the user can resize it past the container width (hence, the text area content can be hidden and an horizontal scrollbar can appear).

This commit fixes the size so that by default it uses 100% of the available width and only allow the user to resize the textarea vertically.