### PR TITLE
fix the return value of filter test

### DIFF
--- a/src/guide/migration.md
+++ b/src/guide/migration.md
@@ -908,7 +908,7 @@ Use JavaScript's built-in [`.filter` method](https://developer.mozilla.org/en-US
 computed: {
   filteredUsers: function () {
     return this.users.filter(function (user) {
-      return user.name.indexOf(this.searchQuery) >= 0
+      return user.name.indexOf(this.searchQuery) !== -1
     })
   }
 }

--- a/src/guide/migration.md
+++ b/src/guide/migration.md
@@ -908,7 +908,7 @@ Use JavaScript's built-in [`.filter` method](https://developer.mozilla.org/en-US
 computed: {
   filteredUsers: function () {
     return this.users.filter(function (user) {
-      return user.name.indexOf(this.searchQuery)
+      return user.name.indexOf(this.searchQuery) >= 0
     })
   }
 }


### PR DESCRIPTION
In javascript, string.indexOf() will return the position of searching term in string. For array.filter(), it needs a boolean value of the test. We must provide an expression in here, instead of use the result of string.indexOf() directly.