### PR TITLE
remove wrong statement about el: option. (fix #499)

### DIFF
--- a/src/guide/components.md
+++ b/src/guide/components.md
@@ -213,8 +213,6 @@ new Vue({
 </script>
 {% endraw %}
 
-The `el` option also requires a function value when used in a component instance, for exactly the same reason.
-
 ### Composing Components
 
 Components are meant to be used together, most commonly in parent-child relationships: component A may use component B in its own template. They inevitably need to communicate to one another: the parent may need to pass data down to the child, and the child may need to inform the parent of something that happened in the child. However, it is also very important to keep the parent and the child as decoupled as possible via a clearly-defined interface. This ensures each component's code can be written and reasoned about in relative isolation, thus making them more maintainable and potentially easier to reuse.


### PR DESCRIPTION
fixing #499 

Docs state [here](http://vuejs.org/guide/components.html#data-Must-Be-a-Function): 

> The `el` option also requires a function value when used in a component instance, for exactly the same reason.

As the el option can only be used during instance creation in 2.0, this seems to be no longer the case, right?

The 2.0 [API docs for the el: option](http://vuejs.org/api/#el) also say that it can only be `String | HTML Element`

