### PR TITLE
Fix a typing error.

### DIFF
--- a/src/guide/migration.md
+++ b/src/guide/migration.md
@@ -1036,7 +1036,7 @@ For a very naive implementation, you could just do something like this:
 '$' + price.toFixed(2)
 ```
 
-In many cases though, you'll still run into strange behavior (e.g. `0.035.toFixed(2)` rounds up to `0.4`, but `0.045` rounds down to `0.4`). To work around these issues, you can use the [`accounting`](http://openexchangerates.github.io/accounting.js/) library to more reliably format currencies.
+In many cases though, you'll still run into strange behavior (e.g. `0.035.toFixed(2)` rounds up to `0.04`, but `0.045` rounds down to `0.04`). To work around these issues, you can use the [`accounting`](http://openexchangerates.github.io/accounting.js/) library to more reliably format currencies.
 
 {% raw %}
 <div class="upgrade-path">


### PR DESCRIPTION
The expression, 0.035.toFixed(2) & 0.045.toFixed(2), will return '0.04', rather than '0.4'.