### PR TITLE
Set the default color for the search input

### DIFF
--- a/themes/vue/source/css/_header.styl
+++ b/themes/vue/source/css/_header.styl
@@ -42,7 +42,7 @@ body.docs
     box-sizing border-box
     padding 0 15px 0 30px
     border 1px solid #e3e3e3
-    color $light
+    color $dark
     outline none
     border-radius 15px
     margin-right 10px

--- a/themes/vue/source/css/_header.styl
+++ b/themes/vue/source/css/_header.styl
@@ -42,6 +42,7 @@ body.docs
     box-sizing border-box
     padding 0 15px 0 30px
     border 1px solid #e3e3e3
+    color $light
     outline none
     border-radius 15px
     margin-right 10px


### PR DESCRIPTION
Since the search input text color is not set, if a user has changed its default color (ie. when using a dark theme), then the search input text can be unreadable.

Example of hard to read color combination:
![default_search_color_font](https://cloud.githubusercontent.com/assets/7248877/19493437/4ceacf56-9516-11e6-81cb-ff0daee2ed4a.png)

This PR just sets the color to a default one.