### PR TITLE
Fix an error in Component Example

### DIFF
--- a/src/guide/index.md
+++ b/src/guide/index.md
@@ -265,9 +265,8 @@ Now you can compose it in another component's template:
 <ul>
   <!--
   Create an instance of the todo-item component
-  for each todo in a todos array
   -->
-  <todo-item v-for="todo in todos"></todo-item>
+  <todo-item></todo-item>
 </ul>
 ```
 


### PR DESCRIPTION
The current example will produce an error as there is no "todos" `props` that introduced yet.