### PR TITLE
Complete the doc on custom events

### DIFF
--- a/src/guide/components.md
+++ b/src/guide/components.md
@@ -421,6 +421,11 @@ When a prop validation fails, Vue will produce a console warning (if using the d
 
 We have learned that the parent can pass data down to the child using props, but how do we communicate back to the parent when something happens? This is where custom events come in.
 
+<p class="tip">Note : the vue events are **not** native DOM events.</p>
+`vm.$emit` is **not** an alias to `document.dispatchEvent(new CustomEvent(eventName, { detail: detail }));`
+
+A custom event sent via `vm.$emit('myCustomEvent', value)` will not get caught by `domElement.addEventListener('myCustomEvent', callback)`.
+
 ### Using `v-on` with Custom Events
 
 Every Vue instance implements the [Events interface](/api/#Instance-Methods-Events), which means it can:

--- a/src/guide/events.md
+++ b/src/guide/events.md
@@ -4,6 +4,9 @@ type: guide
 order: 9
 ---
 
+<p class="tip">Note : the vue events are **not** native DOM events.</p>
+See more details in the [Custom events](/components.html#Custom-Events) chapter.
+
 ## Listening to Events
 
 We can use the `v-on` directive to listen to DOM events and run some JavaScript when they're triggered.


### PR DESCRIPTION
When reading the documentation about event handling, one can assume `vm.$emit` is an alias to the DOM `dispatchEvent` method, which is not if I read the source correctly.

Hence this can lead to misconception about how to use those event methods.

This is a very first try to explain this in the doc, but surely it needs to be rephrased by a native english speaker as well as be corrected if I'm wrong, so please correct me!