### PR TITLE
update wrapper width to 120px

### DIFF
--- a/themes/vue/layout/partials/sidebar.ejs
+++ b/themes/vue/layout/partials/sidebar.ejs
@@ -4,7 +4,7 @@
     </ul>
     <div class="list">
         <div id="donate" style="margin-bottom: 20px">
-            <span class="wrapper" style="width: 110px">
+            <span class="wrapper" style="width: 120px">
               <img src="/images/patreon.png">
               <a href="/support-vuejs">Support Vue.js</a>
             </span>


### PR DESCRIPTION
I think the wrapper is a little crowded, and my chrome can not display it normally. So I change it from 110px to 120px.
![image](https://cloud.githubusercontent.com/assets/12167554/19546891/d85f7cc0-96c5-11e6-9b6a-2b0cbba4aec8.png)
