### PR TITLE
Fix typo in raw vs demo markup

### DIFF
--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -43,8 +43,9 @@ new Vue({
 
 {% raw %}
 <div id="example-textarea" class="demo">
-  <span>Message is:</span>
-  <p style="white-space: pre">{{ message }}</p><br>
+  <span>Multiline message is:</span>
+  <p style="white-space: pre">{{ message }}</p>
+  <br>
   <textarea v-model="message" placeholder="add multiple lines"></textarea>
 </div>
 <script>


### PR DESCRIPTION
In the "Multiline text" section, the demo and raw markup had a small text discrepancy.

Changed "Message is:" to "Multiline message is:" to make them match up. Also added a line break before a `<br>` tag to match the demo and raw markup.