### PR TITLE
minor typo fix for uniformity

### DIFF
--- a/src/api/index.md
+++ b/src/api/index.md
@@ -44,7 +44,7 @@ type: api
 
   The merge strategy receives the value of that option defined on the parent and child instances as the first and second arguments, respectively. The context Vue instance is passed as the third argument.
 
-- **See also**: [Custom Option Merging Strategies](/guide/mixins.html#Custom-Option-Merge-Strategies)
+- **See also:** [Custom Option Merging Strategies](/guide/mixins.html#Custom-Option-Merge-Strategies)
 
 ### devtools
 


### PR DESCRIPTION
In API reference file all the terms are formatted as **Term:**, but there was a single typo with a misplaced colon, which was fixed. It's minor, but nevertheless important for the reason of use of automated term extraction tools during translation.