### PR TITLE
"Webpack" term capitalization + runtime-only build size extracted to a variable

### DIFF
--- a/src/api/index.md
+++ b/src/api/index.md
@@ -44,7 +44,7 @@ type: api
 
   The merge strategy receives the value of that option defined on the parent and child instances as the first and second arguments, respectively. The context Vue instance is passed as the third argument.
 
-- **See also**: [Custom Option Merging Strategies](/guide/mixins.html#Custom-Option-Merge-Strategies)
+- **See also:** [Custom Option Merging Strategies](/guide/mixins.html#Custom-Option-Merge-Strategies)
 
 ### devtools
 

--- a/src/api/index.md
+++ b/src/api/index.md
@@ -1508,7 +1508,7 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
 - **Does not expect expression**
 
-- **Usage**
+- **Usage:**
 
   Skip compilation for this element and all its children. You can use this for displaying raw mustache tags. Skipping large numbers of nodes with no directives on them can also speed up compilation.
 

--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -6,6 +6,7 @@ vue_version: 2.0.3
 dev_size: "188.88"
 min_size: "62.54"
 gz_size: "22.86"
+ro_gz_size: "16"
 ---
 
 ### Compatibility Note
@@ -49,9 +50,9 @@ There are two builds available, the standalone build and the runtime-only build.
 
 - The standalone build includes the compiler and supports the `template` option. **It also relies on the presence of browser APIs so you cannot use it for server-side rendering.**
 
-- The runtime-only build does not include the template compiler, and does not support the `template` option. You can only use the `render` option when using the runtime-only build, but it works with single-file components, because single-file components' templates are pre-compiled into `render` functions during the build step. The runtime-only build is roughly 30% lighter-weight than the standalone build, weighing only 16kb min+gzip.
+- The runtime-only build does not include the template compiler, and does not support the `template` option. You can only use the `render` option when using the runtime-only build, but it works with single-file components, because single-file components' templates are pre-compiled into `render` functions during the build step. The runtime-only build is roughly 30% lighter-weight than the standalone build, weighing only {{ro_gz_size}}kb min+gzip.
 
-By default, the NPM package exports the **runtime-only** build. To use the standalone build, add the following alias to your webpack config:
+By default, the NPM package exports the **runtime-only** build. To use the standalone build, add the following alias to your Webpack config:
 
 ``` js
 resolve: {


### PR DESCRIPTION
Subj. Also, I have no idea why eb3aef9 still shows up as if wasn't merged o_O
UPD: found another minor typo, also fixed (see 425055f)