### PR TITLE
Change the background color of code element when used in a tip

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -111,6 +111,9 @@
             font-weight bold
             font-family $logo-font
             font-size 14px
+            
+        & code
+            background-color #efefef
 
         em
             color $medium

--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -112,7 +112,7 @@
             font-family $logo-font
             font-size 14px
             
-        & code
+        code
             background-color #efefef
 
         em


### PR DESCRIPTION
When using a `code` in a `tip`, both background are of the same color, which leads to weird looking padding.

This fixes this by changing the code background color slightly.
Before :
![Before](https://cloud.githubusercontent.com/assets/7248877/19702483/97404b5a-9a9b-11e6-9dc1-b911001996c7.png)

After :
![After](https://cloud.githubusercontent.com/assets/7248877/19702484/9740556e-9a9b-11e6-9626-9ab4833bd75b.png)

