### PR TITLE
Fix default delimiters

### DIFF
--- a/src/api/index.md
+++ b/src/api/index.md
@@ -829,7 +829,7 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
 - **Type:** `Array<string>`
 
-- **default:** `["{{", "}}"]`
+- **default:** `{% raw %}["{{", "}}"]{% endraw %}`
 
 - **Details:**
 


### PR DESCRIPTION
Fix parsed default delimiters in api doc
>default:  `[", "]`