### PR TITLE
Remove SystemJS mention from Riot comparison

### DIFF
--- a/src/guide/comparison.md
+++ b/src/guide/comparison.md
@@ -324,6 +324,6 @@ Riot 2.0 provides a similar component-based development model (which is called a
 
 - True conditional rendering. Riot renders all if branches and simply shows/hides them.
 - A far more powerful router. Riot’s routing API is extremely minimal.
-- More mature tooling support. Vue provides official support for [Webpack](https://github.com/vuejs/vue-loader), [Browserify](https://github.com/vuejs/vueify), and [SystemJS](https://github.com/vuejs/systemjs-plugin-vue), while Riot relies on community support for build system integration.
+- More mature tooling support. Vue provides official support for [Webpack](https://github.com/vuejs/vue-loader) and [Browserify](https://github.com/vuejs/vueify), while Riot relies on community support for build system integration.
 - [Transition effect system](transitions.html). Riot has none.
 - Better performance. [Despite advertising](https://github.com/vuejs/vuejs.org/issues/346) use of a virtual DOM, Riot in fact uses dirty checking and thus suffers from the same performance issues as Angular 1.


### PR DESCRIPTION
Because our [official SystemJS plugin](https://github.com/vuejs/systemjs-plugin-vue) in currently on hold (and most likely abandoned due to low demand anyway).