### PR TITLE
Update list.md

### DIFF
--- a/src/guide/list.md
+++ b/src/guide/list.md
@@ -60,7 +60,7 @@ Inside `v-for` blocks we have full access to parent scope properties. `v-for` al
 
 ``` html
 <ul id="example-2">
-  <li v-for="(item, index) in items">
+  <li v-for="(index, item) in items">
     {{ parentMessage }} - {{ index }} - {{ item.message }}
   </li>
 </ul>
@@ -83,7 +83,7 @@ Result:
 
 {% raw%}
 <ul id="example-2" class="demo">
-  <li v-for="(item, index) in items">
+  <li v-for="(index, item) in items">
     {{ parentMessage }} - {{ index }} - {{ item.message }}
   </li>
 </ul>


### PR DESCRIPTION
Replace `item` with `index` in `v-for(item, index)` because it outputs the following.

- Parent- [object Object] -

- Parent- [object Object] - 

Changing it to this form `v-for(index, item)` outputs the correct result.