### PR TITLE
_common.styl: unify #donate a font-family

### DIFF
--- a/themes/vue/source/css/_common.styl
+++ b/themes/vue/source/css/_common.styl
@@ -198,7 +198,9 @@ a.button
         width 14px
         height 14px
     a
-        font 700 11px/14px 'Helvetica Neue', Helvetica, Arial, sans-serif
+        font-family $body-font
+        font-size 11px/14px
+        font-weight 700
         color #333333
         text-shadow 0 1px 0 #fff
     &:hover

--- a/themes/vue/source/css/_common.styl
+++ b/themes/vue/source/css/_common.styl
@@ -194,13 +194,12 @@ a.button
     border: 1px solid #d4d4d4
     img
         display: inline-block
-        vertical-align: middle
+        vertical-align: bottom
         width 14px
         height 14px
     a
-        font-family $body-font
-        font-size 11px/14px
-        font-weight 700
+        font 700 14px/14px $body-font
+        margin-left: 2px
         color #333333
         text-shadow 0 1px 0 #fff
     &:hover


### PR DESCRIPTION
Unify font-family setting of `#donate a` with `$body-font`.
Previously the font-family of `#donate a` is hard-coded and does not consist with `$body-font` and this PR solves this discrepancy.

Edit: typo