### PR TITLE
add larger example of full async component

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -994,7 +994,38 @@ Vue.component('async-example', function (resolve, reject) {
 })
 ```
 
-The factory function receives a `resolve` callback, which should be called when you have retrieved your component definition from the server. You can also call `reject(reason)` to indicate the load has failed. The `setTimeout` here is simply for demonstration; How to retrieve the component is entirely up to you. One recommended approach is to use async components together with [Webpack's code-splitting feature](http://webpack.github.io/docs/code-splitting.html):
+The factory function receives a `resolve` callback, which should be called when you have retrieved your component definition from the server. You can also call `reject(reason)` to indicate the load has failed. The `setTimeout` here is simply for demonstration; How to retrieve the component is entirely up to you.
+
+Using this convention, you can move the logic of your application into the object that is being resolved. A full example of an async component might look like the following:
+
+```html
+<async-example message="Done!"></async-example>
+```
+
+```js
+Vue.component('async-example', function(resolve, reject) {
+  // our template is a remote HTML partial
+  fetch('/async.html')
+    .then(function(res) {
+      return res.text();
+    }).then(function(template) {
+      resolve({
+        props: ['message'],
+        data: function() {
+          return {
+            time: Date.now()
+          };
+        },
+        template: template,
+        created: function() {
+          console.log('component is ready.')
+        }
+      });
+    }).catch(reject);
+})
+```
+
+One recommended approach is to use async components together with [Webpack's code-splitting feature](http://webpack.github.io/docs/code-splitting.html):
 
 ``` js
 Vue.component('async-webpack-example', function (resolve) {


### PR DESCRIPTION
I was pretty confused about async components and how they worked with `props` and `data`. I didn’t realize that you just moved your whole application logic into the object being resolved.

I feel this additional paragraph makes that much clearer. It also showcases an approach to loading a remote template and then rendering the results.

I attached a screenshot below to show the visible changes:

![screen shot 2016-11-22 at 5 08 05 pm](https://cloud.githubusercontent.com/assets/1425304/20548199/45bb47e8-b0d6-11e6-8d2c-edd577fd05f3.png)
