### PR TITLE
Change the alias according to the 2.1 release

### DIFF
--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -59,7 +59,7 @@ By default, the NPM package exports the **runtime-only** build. To use the stand
 ``` js
 resolve: {
   alias: {
-    'vue$': 'vue/dist/vue.js'
+    'vue$': 'vue/dist/vue.common.js'
   }
 }
 ```


### PR DESCRIPTION
If you've been using the standalone build by configuring the Webpack alias, it's recommended to make the following change to benefit from slightly better perf and smaller file size (only do this after upgrading to 2.1.0):