### PR TITLE
Correcting a syntax error in an example

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -139,9 +139,9 @@ new Vue({
   // ...
   filters: {
     capitalize: function (value) {
-      if (!value) return ''
-      value = value.toString()
-      return value.charAt(0).toUpperCase() + value.slice(1)
+      if (!value) return '';
+      value = value.toString();
+      return value.charAt(0).toUpperCase() + value.slice(1);
     }
   }
 })


### PR DESCRIPTION
Semicolons were missing at the end of the instruction