### PR TITLE
Fix broken transition example

### DIFF
--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -139,7 +139,7 @@ new Vue({
   transition: all .8s cubic-bezier(1.0, 0.5, 0.8, 1.0);
 }
 .slide-fade-enter, .slide-fade-leave-active {
-  padding-left: 10px;
+  transform: translateX(10px);
   opacity: 0;
 }
 ```
@@ -169,7 +169,7 @@ new Vue({
   transition: all .8s cubic-bezier(1.0, 0.5, 0.8, 1.0);
 }
 .slide-fade-enter, .slide-fade-leave-active {
-  padding-left: 10px;
+  transform: translateX(10px);
   opacity: 0;
 }
 </style>


### PR DESCRIPTION
Padding is set to `0 !important`, so this example didn't work. It's also
bad practice to transition padding unless you really have to: in this
case, a transform is more performant, so I changed it to that instead.