### PR TITLE
Update state-management.md to change demo debug message to be more clear

### DIFF
--- a/src/v2/guide/state-management.md
+++ b/src/v2/guide/state-management.md
@@ -44,7 +44,7 @@ var store = {
   },
   clearMessageAction () {
     this.debug && console.log('clearMessageAction triggered')
-    this.state.message = 'action B triggered'
+    this.state.message = 'clearMessageAction triggered'
   }
 }
 ```


### PR DESCRIPTION
A tiny edit for " store pattern" demo code to change debug message 'action B triggered' to be 'clearMessageAction triggered' as there actions called 'B' and could be confusing for the reader.