### PR TITLE
update Comparison/TypeScript/decorator

### DIFF
--- a/src/v2/guide/comparison.md
+++ b/src/v2/guide/comparison.md
@@ -267,7 +267,7 @@ We have a separate section for Angular 2 because it really is a completely new f
 
 While Angular 1 could be used for smaller applications, Angular 2 has shifted focus to best facilitate large enterprise applications. As part of this, it almost requires TypeScript, which can be very useful for developers that desire the type safety of languages such as Java and C#.
 
-Vue is also well-suited to [enterprise environments](https://github.com/vuejs/awesome-vue#enterprise-usage) and can even be used with TypeScript via our [official typings](https://github.com/vuejs/vue/tree/dev/types) and [user-contributed decorators](https://github.com/itsFrank/vue-typescript), though it's definitely optional in our case.
+Vue is also well-suited to [enterprise environments](https://github.com/vuejs/awesome-vue#enterprise-usage) and can even be used with TypeScript via our [official typings](https://github.com/vuejs/vue/tree/dev/types) and [official decorators](https://github.com/vuejs/vue-class-component), though it's definitely optional in our case.
 
 ### Size and Performance
 

--- a/src/v2/guide/comparison.md
+++ b/src/v2/guide/comparison.md
@@ -267,7 +267,7 @@ We have a separate section for Angular 2 because it really is a completely new f
 
 While Angular 1 could be used for smaller applications, Angular 2 has shifted focus to best facilitate large enterprise applications. As part of this, it almost requires TypeScript, which can be very useful for developers that desire the type safety of languages such as Java and C#.
 
-Vue is also well-suited to [enterprise environments](https://github.com/vuejs/awesome-vue#enterprise-usage) and can even be used with TypeScript via our [official typings](https://github.com/vuejs/vue/tree/dev/types) and [official decorators](https://github.com/vuejs/vue-class-component), though it's definitely optional in our case.
+Vue is also well-suited to [enterprise environments](https://github.com/vuejs/awesome-vue#enterprise-usage) and can even be used with TypeScript via our [official typings](https://github.com/vuejs/vue/tree/dev/types) and [official decorator](https://github.com/vuejs/vue-class-component), though it's definitely optional in our case.
 
 ### Size and Performance
 


### PR DESCRIPTION
Because
* we have official decorator
* `vue-typescript` is not for the current version of Vue.js