### PR TITLE
Add disclaimer that $on cannot be used to listen to events from children

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -448,6 +448,8 @@ Every Vue instance implements an [events interface](../api/#Instance-Methods-Eve
 
 In addition, a parent component can listen to the events emitted from a child component using `v-on` directly in the template where the child component is used.
 
+<p class="tip">You cannot use `$on` to listen to events emitted by children. You must use `v-on` directly in the template, as in the example below.</p>
+
 Here's an example:
 
 ``` html


### PR DESCRIPTION
I assumed parents could listen to child events using `$on` and that `v-on` was just convenient syntax. Adding a disclaimer may help others like me, especially those that come from an Angular or Vue 1.0 background.