### PR TITLE
Update transition docs

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1750,21 +1750,27 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
   - `mode` - string, Controls the timing sequence of leaving/entering transitions. Available modes are `"out-in"` and `"in-out"`; defaults to simultaneous.
   - `enter-class` - string
   - `leave-class` - string
+  - `appear-class` - string
+  - `enter-to-class` - string
+  - `leave-to-class` - string
+  - `appear-to-class` - string
   - `enter-active-class` - string
   - `leave-active-class` - string
-  - `appear-class` - string
   - `appear-active-class` - string
 
 - **Events:**
   - `before-enter`
-  - `enter`
-  - `after-enter`
   - `before-leave`
-  - `leave`
-  - `after-leave`
   - `before-appear`
+  - `enter`
+  - `leave`
   - `appear`
+  - `after-enter`
+  - `after-leave`
   - `after-appear`
+  - `enter-cancelled`
+  - `leave-cancelled` (`v-show` only)
+  - `appear-cancelled`
 
 - **Usage:**
 

--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -596,7 +596,7 @@ and custom JavaScript hooks:
   v-on:before-appear="customBeforeAppearHook"
   v-on:appear="customAppearHook"
   v-on:after-appear="customAfterAppearHook"
-  v-on:appear-cancelled="customAppeaCancelledHook"
+  v-on:appear-cancelled="customAppearCancelledHook"
 >
   <!-- ... -->
 </transition>

--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -581,6 +581,7 @@ By default, this will use the transitions specified for entering and leaving. If
 <transition
   appear
   appear-class="custom-appear-class"
+  appear-to-class="custom-appear-to-class" (>= 2.1.8 only)
   appear-active-class="custom-appear-active-class"
 >
   <!-- ... -->
@@ -595,6 +596,7 @@ and custom JavaScript hooks:
   v-on:before-appear="customBeforeAppearHook"
   v-on:appear="customAppearHook"
   v-on:after-appear="customAfterAppearHook"
+  v-on:appear-cancelled="customAppeaCancelledHook"
 >
   <!-- ... -->
 </transition>


### PR DESCRIPTION
`transition` had changed in 2.1.8, but it was not reflected in some docs.
I added it.