### PR TITLE
Add French informations for French Translation Team (Vuejs-FR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Russian translation is maintained by Translation Gang.
 
 TODO: provide information here
 
+### French
+
+French translation is maintained by Vuejs-FR.
+
+* Translation Repo — [/vuejs-fr/vuejs.org](https://github.com/vuejs-fr/vuejs.org)
+
 ### Want to help with the translation?
 
 If you feel okay with translating sorta alone, just fork the repo, create a "work-in-progress" issue to inform others that you're doing the translation, and just go on.


### PR DESCRIPTION
All is explained here : 
- https://github.com/vuejs/vuejs.org/issues/703

The http://fr.vuejs.org/ is already avaiable for some pages.

**Maybe should be a good thing to order each Translation Language by Alphabetic Language Order ?**