### PR TITLE
Fix: changing hash on load if contains non-ASCII chars

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -37,9 +37,9 @@
   function initLocationHashFuzzyMatching () {
     var hash;
     try {
-		  hash = escapeCharacters( decodeURIComponent( window.location.hash ) )
+      hash = escapeCharacters( decodeURIComponent( window.location.hash ) )
     } catch(e) {
-		  hash = escapeCharacters( window.location.hash )
+      hash = escapeCharacters( window.location.hash )
     }
     if (!hash) return
     var hashTarget = document.getElementById(hash)

--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -35,7 +35,12 @@
   }
 
   function initLocationHashFuzzyMatching () {
-    var hash = window.location.hash
+    var hash;
+    try {
+		  hash = escapeCharacters( decodeURIComponent( window.location.hash ) )
+    } catch(e) {
+		  hash = escapeCharacters( window.location.hash )
+    }
     if (!hash) return
     var hashTarget = document.getElementById(hash)
     if (!hashTarget) {

--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -37,9 +37,9 @@
   function initLocationHashFuzzyMatching () {
     var hash;
     try {
-      hash = escapeCharacters( decodeURIComponent( window.location.hash ) )
+      hash = escapeCharacters(decodeURIComponent(window.location.hash))
     } catch(e) {
-      hash = escapeCharacters( window.location.hash )
+      hash = escapeCharacters(window.location.hash)
     }
     if (!hash) return
     var hashTarget = document.getElementById(hash)


### PR DESCRIPTION
Situation: user open page with hash (to some part of docs), or click link in docs with hash (to another part).

If hash contains non-ASCII characters, for example:
`https://ru.vuejs.org/v2/guide/components.html#Пользовательские-события`

After page load hash will changed to another:
`https://ru.vuejs.org/v2/guide/components.html#camelCase-против-kebab-case`

This is because hash encoded:
`https://ru.vuejs.org/v2/guide/components.html#%D0%9F%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8C%D1%81%D0%BA%D0%B8%D0%B5-%D1%81%D0%BE%D0%B1%D1%8B%D1%82%D0%B8%D1%8F`

This fix add decoding to solve problem
P.S.: Using Firefox 50.1.0