### PR TITLE
create vm only when needed

### DIFF
--- a/src/v2/guide/computed.md
+++ b/src/v2/guide/computed.md
@@ -228,12 +228,12 @@ var watchExampleVM = new Vue({
     // _.throttle), visit: https://lodash.com/docs#debounce
     getAnswer: _.debounce(
       function () {
-        var vm = this
         if (this.question.indexOf('?') === -1) {
-          vm.answer = 'Questions usually contain a question mark. ;-)'
+          this.answer = 'Questions usually contain a question mark. ;-)'
           return
         }
-        vm.answer = 'Thinking...'
+        this.answer = 'Thinking...'
+        var vm = this
         axios.get('https://yesno.wtf/api')
           .then(function (response) {
             vm.answer = _.capitalize(response.data.answer)


### PR DESCRIPTION
I spent a little time figuring out why the line `var vm = this` was where it was and why the first two references to `vm.answer` couldn't be `this.answer`. they can be.

`vm` is only needed for the `axios.get()` callback.

This change tries to minimize any distractions in the tutorial.