### PR TITLE
Revert "`cache` option for computed properties."

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -447,7 +447,7 @@ type: api
 
   <p class="tip">Note that __you should not use an arrow function to define a computed property__ (e.g. `aDouble: () => this.a * 2`). The reason is arrow functions bind the parent context, so `this` will not be the Vue instance as you expect and `this.a` will be undefined.</p>
 
-  Computed properties are cached, and only re-computed on reactive dependency changes.
+  Computed properties are cached, and only re-computed on reactive dependency changes. Note that if a certain dependency is out of the instance's scope (i.e. not reactive), the computed property will __not__ be updated.
 
 - **Example:**
 

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -439,7 +439,7 @@ type: api
 
 ### computed
 
-- **Type:** `{ [key: string]: Function | { get: Function, set: Function, cache: Boolean } }`
+- **Type:** `{ [key: string]: Function | { get: Function, set: Function } }`
 
 - **Details:**
 
@@ -447,9 +447,7 @@ type: api
 
   <p class="tip">Note that __you should not use an arrow function to define a computed property__ (e.g. `aDouble: () => this.a * 2`). The reason is arrow functions bind the parent context, so `this` will not be the Vue instance as you expect and `this.a` will be undefined.</p>
 
-  Computed properties are cached, and only re-computed on reactive dependency changes. Note that if a certain dependency is out of the instance's scope (i.e. not reactive), the computed property will not be updated. In this situation, caching can be turned off by setting `cache: false`. However, since the dependency is still not reactive, modifying it will not trigger a DOM update. 
-  
-  In most situations, `cache: false` will not be an ideal solution. Whenever possible, it's much better to pull external data into the reactivity system. For example, if a computed property depends on the size of the window, you can store this information in `data`, then use the `resize` event to keep the value up-to-date. Now it's reactive!
+  Computed properties are cached, and only re-computed on reactive dependency changes.
 
 - **Example:**
 


### PR DESCRIPTION
@frankdiox 
From #722
>I think the cache options works in Vue 2 but I could not find any information in the docs.
Is it just a documentation issue or was omitted on purpose for some reason? Thanks.

We merged at #722, but I'll revert it due to not support `cache: false` for Vue 2 or later.
We can realize same as `cache: false` with methods.
For this reasons, `cache: false` explanation intentionally was removed it from Vue 2 docs.

/cc @yyx990803 @chrisvfritz 
Please comment if you have something unsatisfactory.