### PR TITLE
Fix bug in store pattern example

### DIFF
--- a/src/v2/guide/state-management.md
+++ b/src/v2/guide/state-management.md
@@ -44,7 +44,7 @@ var store = {
   },
   clearMessageAction () {
     this.debug && console.log('clearMessageAction triggered')
-    this.state.message = 'clearMessageAction triggered'
+    this.state.message = ''
   }
 }
 ```


### PR DESCRIPTION
Seems like clearMessageAction should clear the message, not set it to the same thing as the log message.