### PR TITLE
correct webpack 2 syntax

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -1016,7 +1016,7 @@ You can also return a `Promise` in the factory function, so with Webpack 2 + ES2
 ``` js
 Vue.component(
   'async-webpack-example',
-  () => System.import('./my-async-component')
+  () => import('./my-async-component')
 )
 ```
 


### PR DESCRIPTION
`System.import()` was dropped in favour of `import()`

See: 
* https://webpack.js.org/guides/migrating/#code-splitting-with-es2015
* webpack/webpack#3098 (PR: webpack/webpack#3413)