### PR TITLE
Change link to the broken example

### DIFF
--- a/src/v2/guide/transitioning-state.md
+++ b/src/v2/guide/transitioning-state.md
@@ -390,7 +390,7 @@ function generatePoints (stats) {
 </style>
 {% endraw %}
 
-See [this fiddle](https://jsfiddle.net/chrisvfritz/65gLu2b6/) for the complete code behind the above demo.
+See [this fiddle](https://jsfiddle.net/termosa/65gLu2b6/81/) for the complete code behind the above demo.
 
 ## Organizing Transitions into Components
 


### PR DESCRIPTION
Change link to JsFiddle that was directed to the broken example with the new link to the fixed example