### PR TITLE
Toggle sidebar by swipe

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -91,7 +91,7 @@
   }
 
   /**
-   * Mobile burger menu button for toggling sidebar
+   * Mobile burger menu button and gesture for toggling sidebar
    */
 
   function initMobileMenu () {
@@ -106,6 +106,27 @@
     document.body.addEventListener('click', function (e) {
       if (e.target !== menuButton && !sidebar.contains(e.target)) {
         sidebar.classList.remove('open')
+      }
+    })
+
+    // Toggle sidebar on swipe
+    var start = {}, end = {}
+
+    document.body.addEventListener('touchstart', function (e) {
+      start.x = e.changedTouches[0].clientX
+      start.y = e.changedTouches[0].clientY
+    })
+
+    document.body.addEventListener('touchend', function (e) {
+      end.y = e.changedTouches[0].clientY
+      end.x = e.changedTouches[0].clientX
+
+      var xDiff = end.x - start.x
+      var yDiff = end.y - start.y
+
+      if (Math.abs(xDiff) > Math.abs(yDiff)) {
+        if (xDiff > 0) sidebar.classList.add('open')
+        else sidebar.classList.remove('open')
       }
     })
   }


### PR DESCRIPTION
Open mobile menu on swipe from left to right and close on swipe from right to left.
Used [touch events](http://caniuse.com/#feat=touch).
Tested on:
- Chrome for Windows 10 (56.0.2924.87)
- Chrome for Android (55.0.2883.91)
![demo](https://cloud.githubusercontent.com/assets/13474134/23081683/f6e456a2-f566-11e6-82fa-6f103271e18d.gif)
