### PR TITLE
Use latest version on jsDelivr

### DIFF
--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -33,7 +33,7 @@ Simply download and include with a script tag. `Vue` will be registered as a glo
 
 Recommended: [unpkg](https://unpkg.com/vue/dist/vue.js), which will reflect the latest version as soon as it is published to npm. You can also browse the source of the npm package at [unpkg.com/vue/](https://unpkg.com/vue/).
 
-Also available on [jsDelivr](//cdn.jsdelivr.net/vue/{{vue_version}}/vue.js) or [cdnjs](//cdnjs.cloudflare.com/ajax/libs/vue/{{vue_version}}/vue.js), but these two services take some time to sync so the latest release may not be available yet.
+Also available on [jsDelivr](//cdn.jsdelivr.net/vue/latest/vue.js) or [cdnjs](//cdnjs.cloudflare.com/ajax/libs/vue/{{vue_version}}/vue.js), but these two services take some time to sync so the latest release may not be available yet.
 
 ## NPM
 


### PR DESCRIPTION
jsDelivr supports latest tag, it's not updated as instantly as unpkg but should do the trick.