### PR TITLE
Add horizontal scroll on table overflow, Fixes #785

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -103,6 +103,8 @@
         border-collapse collapse
         margin 1.2em auto
         padding 0
+        display block
+        overflow-x auto
         td, th
             line-height 1.5em
             padding .4em .8em


### PR DESCRIPTION
The table would go outside the screen on mobile and would not be scrollable. (Screenshot is available on the issue page #785)