### PR TITLE
Template declaration and render function priorities

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -609,9 +609,11 @@ if (version === 2) {
 
   <p class="tip">The provided element merely serves as a mounting point. Unlike in Vue 1.x, the mounted element will be replaced with Vue-generated DOM in all cases. It is therefore not recommended to mount the root instance to `<html>` or `<body>`.</p>
 
-  <p class="tip">If neither `render` function nor `template` option is present, the in-DOM HTML of the mounting DOM element will be extracted as the template. In this case, [Runtime + Compiler build of Vue](../guide/installation.html#Runtime-Compiler-vs-Runtime-only) should be used.</p>
+  <p class="tip">If neither `render` function nor `template` option is present, the in-DOM HTML of the mounting DOM element will be extracted as the template. In this case, Runtime + Compiler build of Vue should be used.</p>
 
-- **See also:** [Lifecycle Diagram](../guide/instance.html#Lifecycle-Diagram)
+- **See also:**
+  - [Lifecycle Diagram](../guide/instance.html#Lifecycle-Diagram)
+  - [Runtime + Compiler vs. Runtime-only](../guide/installation.html#Runtime-Compiler-vs-Runtime-only)
 
 ### template
 

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -641,7 +641,7 @@ if (version === 2) {
 
     If the component is a functional component, the render function also receives an extra argument `context`, which provides access to contextual data since functional components are instance-less.
     
-    <p class="tip">In the option object, the `render` function has priority over the render function compiled from `template` option or in-DOM HTML template of the mounting element which is specified by the `el` option.</p>
+    <p class="tip">The `render` function has priority over the render function compiled from `template` option or in-DOM HTML template of the mounting element which is specified by the `el` option.</p>
 
   - **See also:**
     - [Render Functions](../guide/render-function)

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -609,6 +609,8 @@ if (version === 2) {
 
   <p class="tip">The provided element merely serves as a mounting point. Unlike in Vue 1.x, the mounted element will be replaced with Vue-generated DOM in all cases. It is therefore not recommended to mount the root instance to `<html>` or `<body>`.</p>
 
+  <p class="tip">If neither `render` function nor `template` option is present, the in-DOM HTML of the mounting DOM element will be extracted as the template. In this case, standalone build with template compiler of Vue should be used.</p>
+
 - **See also:** [Lifecycle Diagram](../guide/instance.html#Lifecycle-Diagram)
 
 ### template
@@ -623,6 +625,8 @@ if (version === 2) {
 
   <p class="tip">From a security perspective, you should only use Vue templates that you can trust. Never use user-generated content as your template.</p>
 
+  <p class="tip">If render function is present in the Vue option, the template will be ignored.</p>
+
 - **See also:**
   - [Lifecycle Diagram](../guide/instance.html#Lifecycle-Diagram)
   - [Content Distribution](../guide/components.html#Content-Distribution-with-Slots)
@@ -636,6 +640,8 @@ if (version === 2) {
     An alternative to string templates allowing you to leverage the full programmatic power of JavaScript. The render function receives a `createElement` method as it's first argument used to create `VNode`s.
 
     If the component is a functional component, the render function also receives an extra argument `context`, which provides access to contextual data since functional components are instance-less.
+    
+    <p class="tip">In the option object, the `render` function has priority over the render function compiled from `template` option or in-DOM HTML template of the mounting element which is specified by the `el` option.</p>
 
   - **See also:**
     - [Render Functions](../guide/render-function)

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -609,7 +609,7 @@ if (version === 2) {
 
   <p class="tip">The provided element merely serves as a mounting point. Unlike in Vue 1.x, the mounted element will be replaced with Vue-generated DOM in all cases. It is therefore not recommended to mount the root instance to `<html>` or `<body>`.</p>
 
-  <p class="tip">If neither `render` function nor `template` option is present, the in-DOM HTML of the mounting DOM element will be extracted as the template. In this case, standalone build with template compiler of Vue should be used.</p>
+  <p class="tip">If neither `render` function nor `template` option is present, the in-DOM HTML of the mounting DOM element will be extracted as the template. In this case, [Runtime + Compiler build of Vue](../guide/installation.html#Runtime-Compiler-vs-Runtime-only) should be used.</p>
 
 - **See also:** [Lifecycle Diagram](../guide/instance.html#Lifecycle-Diagram)
 

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -4,11 +4,11 @@ type: guide
 order: 4
 ---
 
-Vue.js uses an HTML-based template syntax that allows you to declaratively bind the rendered DOM to the underlying Vue instance's data. All Vue.js templates are valid HTML that can be parsed by spec-compliant browsers and HTML parsers.
+Vue.js uses an HTML-based template syntax that allows you to declaratively bind the rendered DOM to the underlying Vue instance's data. When you instantiate a Vue instance, you may use [template option](../api/#template) to declare the template. If `template` option is not present in the option object, the `Vue` constructor will extract the in-DOM HTML of mounting element specified by [el option](../api/#el) instead. All Vue.js templates are valid HTML that can be parsed by spec-compliant browsers and HTML parsers.
 
 Under the hood, Vue compiles the templates into Virtual DOM render functions. Combined with the reactivity system, Vue is able to intelligently figure out the minimal amount of components to re-render and apply the minimal amount of DOM manipulations when the app state changes.
 
-If you are familiar with Virtual DOM concepts and prefer the raw power of JavaScript, you can also [directly write render functions](render-function.html) instead of templates, with optional JSX support.
+If you are familiar with Virtual DOM concepts and prefer the raw power of JavaScript, you can also [directly write render functions](render-function.html) instead of templates, with optional JSX support. In the option object, a handwritten render function has priority over the render function compiled from `template` option or the mounting element in-DOM HTML template.
 
 ## Interpolations
 

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -4,11 +4,11 @@ type: guide
 order: 4
 ---
 
-Vue.js uses an HTML-based template syntax that allows you to declaratively bind the rendered DOM to the underlying Vue instance's data. When you instantiate a Vue instance, you may use [template option](../api/#template) to declare the template. If `template` option is not present in the option object, the `Vue` constructor will extract the in-DOM HTML of mounting element specified by [el option](../api/#el) instead. All Vue.js templates are valid HTML that can be parsed by spec-compliant browsers and HTML parsers.
+Vue.js uses an HTML-based template syntax that allows you to declaratively bind the rendered DOM to the underlying Vue instance's data. All Vue.js templates are valid HTML that can be parsed by spec-compliant browsers and HTML parsers.
 
 Under the hood, Vue compiles the templates into Virtual DOM render functions. Combined with the reactivity system, Vue is able to intelligently figure out the minimal amount of components to re-render and apply the minimal amount of DOM manipulations when the app state changes.
 
-If you are familiar with Virtual DOM concepts and prefer the raw power of JavaScript, you can also [directly write render functions](render-function.html) instead of templates, with optional JSX support. In the option object, a handwritten render function has priority over the render function compiled from `template` option or the mounting element in-DOM HTML template.
+If you are familiar with Virtual DOM concepts and prefer the raw power of JavaScript, you can also [directly write render functions](render-function.html) instead of templates, with optional JSX support.
 
 ## Interpolations
 


### PR DESCRIPTION
The following problem is common for developers, and I think the information about `el` in-DOM HTML template and priorities is necessary for them to avoid the problem.

[Vue runtime build problem](https://translate.google.com/translate?sl=zh-CN&tl=en&js=y&prev=_t&hl=zh-CN&ie=UTF-8&u=https%3A%2F%2Fsegmentfault.com%2Fq%2F1010000008458139&edit-text=)