### PR TITLE
Minor typo changes

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -327,7 +327,7 @@ new Vue({
 </script>
 {% endraw %}
 
-### Literal vs Dynamic
+### Literal vs. Dynamic
 
 A common mistake beginners tend to make is attempting to pass down a number using the literal syntax:
 

--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -288,7 +288,7 @@ new Vue({
 {% raw %}
 <div id="todo-list-example" class="demo">
   <input
-    v-model="newTodoText" v
+    v-model="newTodoText"
     v-on:keyup.enter="addNewTodo"
     placeholder="Add a todo"
   >
@@ -389,7 +389,7 @@ You can open the console and play with the previous examples' `items` array by c
 
 ### Replacing an Array
 
-Mutation methods, as the name suggests, mutate the original array they are called on. In comparison, there are also non-mutating methods, e.g. `filter()`, `concat()` and `slice()`, which do not mutate the original Array but **always return a new array**. When working with non-mutating methods, you can just replace the old array with the new one:
+Mutation methods, as the name suggests, mutate the original array they are called on. In comparison, there are also non-mutating methods, e.g. `filter()`, `concat()` and `slice()`, which do not mutate the original array but **always return a new array**. When working with non-mutating methods, you can just replace the old array with the new one:
 
 ``` js
 example1.items = example1.items.filter(function (item) {


### PR DESCRIPTION
- Extra v removed
- « Array » to  « array »
- « vs to vs. »