### PR TITLE
Add v-for :key to the the second component list example. Relates to #792

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -229,7 +229,8 @@ However, this won't automatically pass any data to the component, because compon
 <my-component
   v-for="(item, index) in items"
   v-bind:item="item"
-  v-bind:index="index">
+  v-bind:index="index"
+  v-bind:key="item.id">
 </my-component>
 ```
 


### PR DESCRIPTION
Makes the examples consistent, and less confusing since the v-for is now required. (Ref: https://github.com/vuejs/vuejs.org/pull/792)