### PR TITLE
Fix v-model section

### DIFF
--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -299,6 +299,7 @@ render: function (createElement) {
     on: {
       input: function (event) {
         self.value = event.target.value
+        self.$emit('input', event.target.value)
       }
     }
   })


### PR DESCRIPTION
Hi,

v-model section requires extra line to make this code complete. Otherwise it causes a problem:
```
render: function (createElement) {
  var self = this
  return createElement('input', {
    domProps: {
      value: self.value
    },
    on: {
      input: function (event) {
        self.value = event.target.value
        // This line should be added
        self.$emit('input', event.target.value)
      }
    }
  })
}
```

Otherwise the value is updated in the one way. Please see example http://codepen.io/asolopovas/pen/OpWVxa?editors=1011