### PR TITLE
[GLOBAL CONFIG] performance property defaults to true rather other false

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -124,7 +124,7 @@ type: api
 
 - **Type:** `boolean`
 
-- **Default:** `false`
+- **Default:** `true`
 
 - **Usage**:
 


### PR DESCRIPTION
When I bootstrap a vue project without doing anything about `vue.config.performance`, I can see trace in the browser devtool timeline, only when I Explicitly set `vue.config.performance = false`,  this trace disappears. 

So I think it's default is `true`.