### PR TITLE
add version to Vue.config.performance default value

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -124,7 +124,7 @@ type: api
 
 - **Type:** `boolean`
 
-- **Default:** `false`
+- **Default:** `false (from 2.2.3)`
 
 - **Usage**:
 


### PR DESCRIPTION
See the release note: https://github.com/vuejs/vue/releases/tag/v2.2.3
Related issue: https://github.com/vuejs/vue/issues/5174 #834 
