### PR TITLE
Update components.md

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -190,6 +190,8 @@ data: function () {
 }
 ```
 
+**It should be noted that the opening curly brace of the fresh data object MUST be on the same line as the `return`.**
+
 Now all our counters each have their own internal state:
 
 {% raw %}


### PR DESCRIPTION
Added a reminder that when returning a fresh object from a function, you MUST place the opening curly brace on the same line as the "return". This is a really nasty gotcha if you get it wrong!