### PR TITLE
Fix caveat 2 solution in list rendering section

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -420,10 +420,10 @@ Vue.set(example1.items, indexOfItem, newValue)
 example1.items.splice(indexOfItem, 1, newValue)
 ```
 
-To deal with caveat 2, you can also use `splice`:
+To deal with caveat 2, you can also use `slice`:
 
 ``` js
-example1.items.splice(newLength)
+example1.items = example1.items.slice(0, newLength)
 ```
 
 ## Displaying Filtered/Sorted Results


### PR DESCRIPTION
Currently list rendering section includes a wrong solution for Caveat #2.
`vm.items.length = newLength` is not equal to `example1.items.splice(newLength)`.
