### PR TITLE
Change `node` to `Node.js` to avoid misunderstood.

### DIFF
--- a/src/v2/guide/ssr.md
+++ b/src/v2/guide/ssr.md
@@ -32,7 +32,7 @@ If you're using Webpack, you can easily add prerendering with the [prerender-spa
 
 ## Hello World
 
-If you've gotten this far, you're ready to see SSR in action. It sounds complex, but a simple node script demoing the feature requires only 3 steps:
+If you've gotten this far, you're ready to see SSR in action. It sounds complex, but a simple Node.js script demoing the feature requires only 3 steps:
 
 ``` js
 // Step 1: Create a Vue instance
@@ -86,10 +86,10 @@ new Vue({
 })
 ```
 
-To adapt this for SSR, there are a few modifications we'll have to make, so that it will work both in the browser and within node:
+To adapt this for SSR, there are a few modifications we'll have to make, so that it will work both in the browser and within Node.js:
 
 - When in the browser, add an instance of our app to the global context (i.e. `window`), so that we can mount it.
-- When in node, export a factory function so that we can create a fresh instance of the app for every request.
+- When in Node.js, export a factory function so that we can create a fresh instance of the app for every request.
 
 Accomplishing this requires a little boilerplate:
 


### PR DESCRIPTION
I participate to French translation and sometime node refers to a node from DOM and sometime it refers to Node.js (If I correctly understood).

I think it's a good thing to use Node.js and not just `node` to talk about Node.js

1. It's avoid non engilsh reader with few english skills to better understand Guide.

2. It's possbile to be a Front-end Expert and go into advanced section and to be a beginner with server-side Node.js techno and I think it's a good point to call a spade a spade.

3. Because it's the true name of application.

I understand because unix command is `node` it's a perfect shortcut and into a forum dedicated to Node.js it's a good shorthand but in the context of Vue it's a good thing to not use it.