### PR TITLE
Need to wrap propsData in propsData object

### DIFF
--- a/src/v2/guide/unit-testing.md
+++ b/src/v2/guide/unit-testing.md
@@ -94,7 +94,7 @@ import MyComponent from './MyComponent.vue'
 // helper function that mounts and returns the rendered text
 function getRenderedText (Component, propsData) {
   const Ctor = Vue.extend(Component)
-  const vm = new Ctor({ propsData }).$mount()
+  const vm = new Ctor({ propsData: propsData }).$mount()
   return vm.$el.textContent
 }
 


### PR DESCRIPTION
When comparing to vue/test/unit/features/options/propsData.spec.js it appears the propsData object needs to be wrapped in { propsData: thepayload }