### PR TITLE
Change standalone to full build

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -122,7 +122,7 @@ type: api
   ```html
   <input type="text" @keyup.media-play-pause="method">
   ```
-  
+
   Define custom key alias(es) for v-on.
 
 ### performance
@@ -351,7 +351,7 @@ type: api
 
 - **Usage:**
 
-  Compiles a template string into a render function. **Only available in the standalone build.**
+  Compiles a template string into a render function. **Only available in the full build.**
 
   ``` js
   var res = Vue.compile('<div><span>{{ msg }}</span></div>')
@@ -1013,7 +1013,7 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
 - **Details:**
 
-  Change the plain text interpolation delimiters. **This option is only available in the standalone build.**
+  Change the plain text interpolation delimiters. **This option is only available in the full build.**
 
 - **Example:**
 

--- a/src/v2/guide/deployment.md
+++ b/src/v2/guide/deployment.md
@@ -10,7 +10,7 @@ During development, Vue provides a lot of warnings to help you with common error
 
 ### Without Build Tools
 
-If you are using the standalone build, i.e. directly including Vue via a script tag without a build tool, make sure to use the minified version (`vue.min.js`) for production. Both versions can be found in the [Installation guide](installation.html#Direct-lt-script-gt-Include).
+If you are using the full build, i.e. directly including Vue via a script tag without a build tool, make sure to use the minified version (`vue.min.js`) for production. Both versions can be found in the [Installation guide](installation.html#Direct-lt-script-gt-Include).
 
 ### With Build Tools
 

--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -206,7 +206,7 @@ Also see [Production Deployment Tips](deployment.html).
 
 ### CSP environments
 
-Some environments, such as Google Chrome Apps, enforce Content Security Policy (CSP), which prohibits the use of `new Function()` for evaluating expressions. The standalone build depends on this feature to compile templates, so is unusable in these environments.
+Some environments, such as Google Chrome Apps, enforce Content Security Policy (CSP), which prohibits the use of `new Function()` for evaluating expressions. The full build depends on this feature to compile templates, so is unusable in these environments.
 
 On the other hand, the runtime-only build is fully CSP-compliant. When using the runtime-only build with [Webpack + vue-loader](https://github.com/vuejs-templates/webpack-simple) or [Browserify + vueify](https://github.com/vuejs-templates/browserify-simple), your templates will be precompiled into `render` functions which work perfectly in CSP environments.
 


### PR DESCRIPTION
Because now in [explanation of different builds](https://vuejs.org/v2/guide/installation.html#Explanation-of-Different-Builds) there are no more any standalone builds