### PR TITLE
_sidebar.styl add some air to sidebar

### DIFF
--- a/themes/vue/source/css/_sidebar.styl
+++ b/themes/vue/source/css/_sidebar.styl
@@ -18,8 +18,10 @@
     ul
         list-style-type none
         margin 0
-        line-height 1.8em
+        line-height 1.5em
         padding-left 1em
+    li
+        margin-bottom 0.5em
     .version-select
         vertical-align middle
         margin-left 5px


### PR DESCRIPTION
In russian translation the text of some chapters in sidebar longer than one-line.
And when there are many items its hard to understand where ending one chapter and start another.

This pull-request make line-height in sidebar a little smaller and add margin between sidebar items.

| Language | Before  | After |
| ------------- | ------------- | ------------- |
| Russian | ![2017-04-28-2](https://cloud.githubusercontent.com/assets/4497128/25521702/57b00ade-2c09-11e7-9021-3080dc2cca01.PNG)  | ![2017-04-28-1](https://cloud.githubusercontent.com/assets/4497128/25521701/57af100c-2c09-11e7-8404-9de0a92b5610.PNG)  |
| English | ![2017-04-28-3](https://cloud.githubusercontent.com/assets/4497128/25521703/57b10b6e-2c09-11e7-8cb2-7d737e6aadbc.PNG)  | ![2017-04-28-4](https://cloud.githubusercontent.com/assets/4497128/25521704/57b1bab4-2c09-11e7-9f73-d9614c45b127.PNG)  |


