### PR TITLE
Optimized the CSS in a transition example

### DIFF
--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -212,7 +212,7 @@ new Vue({
   animation: bounce-in .5s;
 }
 .bounce-leave-active {
-  animation: bounce-out .5s reverse;
+  animation: bounce-in .5s reverse;
 }
 @keyframes bounce-in {
   0% {
@@ -241,7 +241,7 @@ new Vue({
     animation: bounce-in .5s;
   }
   .bounce-leave-active {
-    -webkit-animation: bounce-out .5s;
+    -webkit-animation: bounce-in .5s reverse;
     animation: bounce-in .5s reverse;
   }
   @keyframes bounce-in {

--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -212,7 +212,7 @@ new Vue({
   animation: bounce-in .5s;
 }
 .bounce-leave-active {
-  animation: bounce-out .5s;
+  animation: bounce-out .5s reverse;
 }
 @keyframes bounce-in {
   0% {
@@ -223,17 +223,6 @@ new Vue({
   }
   100% {
     transform: scale(1);
-  }
-}
-@keyframes bounce-out {
-  0% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.5);
-  }
-  100% {
-    transform: scale(0);
   }
 }
 ```
@@ -253,7 +242,7 @@ new Vue({
   }
   .bounce-leave-active {
     -webkit-animation: bounce-out .5s;
-    animation: bounce-out .5s;
+    animation: bounce-in .5s reverse;
   }
   @keyframes bounce-in {
     0% {
@@ -269,20 +258,6 @@ new Vue({
       transform: scale(1);
     }
   }
-  @keyframes bounce-out {
-    0% {
-      -webkit-transform: scale(1);
-      transform: scale(1);
-    }
-    50% {
-      -webkit-transform: scale(1.5);
-      transform: scale(1.5);
-    }
-    100% {
-      -webkit-transform: scale(0);
-      transform: scale(0);
-    }
-  }
   @-webkit-keyframes bounce-in {
     0% {
       -webkit-transform: scale(0);
@@ -295,20 +270,6 @@ new Vue({
     100% {
       -webkit-transform: scale(1);
       transform: scale(1);
-    }
-  }
-  @-webkit-keyframes bounce-out {
-    0% {
-      -webkit-transform: scale(1);
-      transform: scale(1);
-    }
-    50% {
-      -webkit-transform: scale(1.5);
-      transform: scale(1.5);
-    }
-    100% {
-      -webkit-transform: scale(0);
-      transform: scale(0);
     }
   }
 </style>


### PR DESCRIPTION
Removed unnecessary CSS animation declaration and use. For this example, we can just re-use the first animation and reverse it.