### PR TITLE
[Translation] Official French Translation from Vue-FR

### DIFF
--- a/themes/vue/layout/partials/language_dropdown.ejs
+++ b/themes/vue/layout/partials/language_dropdown.ejs
@@ -6,5 +6,6 @@
     <li><a href="https://ru.vuejs.org/" class="nav-link" target="_blank">Русский</a></li>
     <li><a href="https://kr.vuejs.org/" class="nav-link" target="_blank">한국어</a></li>
     <li><a href="https://br.vuejs.org/" class="nav-link" target="_blank">Português</a></li>
+    <li><a href="https://fr.vuejs.org/" class="nav-link" target="_blank">Français</a></li>
   </ul>
 </li>


### PR DESCRIPTION
## French Link (in this PR)

We proud to say the all basis are french translated and the https://fr.vuejs.org/ is referenced.

All material for beginners is in french so you can add the link to french version. That means the beginners (who are probably the person which not know well the english and cannot use others MVVM) can use easilly Vue with this documentation.

Others pages from Advanced are already under translation and API is 66% translated. The most important page, Comparison, is also translated to allows professional to be interested by Vue. Saddly, a lot of french people prefer use product with french translation (book, movie, game, documentation, etc.).

So we have also create a french chat support for Vue: https://gitter.im/vuejs-fr/vue

and we have requested a Forum part: https://forum.vuejs.org/t/create-a-francais-category-for-french-discussions-helps/ without success (could you help us for this point?).

All pages still in english have the mention (En) and a message saying : 

> **Cette page est en cours de traduction française. Revenez une autre fois pour lire une traduction achevée ou [participez à la traduction française ici](https://github.com/vuejs-fr/vuejs.org).**

that means the translation is in progress and ask to help us for translation.

I think add french translation from now under the official website link can offers visibility to french translation to allows more people to discover Vue and translate it.



## Alphabetic Order (not in this PR)

We have re-order by alphabetic list the translation links because it's a french convention for list item to be order in this way. I'm not fully sure that is the same case for english but I suggest you re-order also your links in this way (so Russian link should be the last and the french list should appears above Portuguese) or the way you prefer (because currently I just added french link to the end).

Thx a lot for your great job !