### PR TITLE
removed v-bind.prop example since is wrong

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1785,6 +1785,9 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
   <!-- prop binding. "prop" must be declared in my-component. -->
   <my-component :prop="someThing"></my-component>
+  
+  <!-- pass down parent props in common with a child component -->
+  <child-component v-bind="$props"></child-component>
 
   <!-- XLink -->
   <svg><a :xlink:special="foo"></a></svg>

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1786,9 +1786,6 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
   <!-- prop binding. "prop" must be declared in my-component. -->
   <my-component :prop="someThing"></my-component>
 
-  <!-- pass down parent props in common with a child component -->
-  <child-component v-bind.prop="$props"></child-component>
-
   <!-- XLink -->
   <svg><a :xlink:special="foo"></a></svg>
   ```


### PR DESCRIPTION
v-bind.prop no longer works as explained in that example and shouldn't be used to filter props between parent and child components 