### PR TITLE
Align Range v-for HTML sample with actual result

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -196,7 +196,7 @@ And another for the index:
 
 ``` html
 <div>
-  <span v-for="n in 10">{{ n }}</span>
+  <span v-for="n in 10">{{ n }} </span>
 </div>
 ```
 


### PR DESCRIPTION
In the [Range `v-for`](https://vuejs.org/v2/guide/list.html#Range-v-for) example, the result is printed with spaces. This is confusing because the sample HTML does not have additional spaces. In fact, when I saw this, I thought Vue was adding a space on its own, which I immediately verified because I thought that would be a very unintuitive and potentially problematic behavior.

Fortunately, Vue does behave as expected. The problem is merely that the HTML sample in the documentation is not the same as the markup of the actual Vue code in the example.

This PR corrects this by adding the space before the closing `</span>`.

Alternatively, the space could be removed in the example code instead, but personally, I think this way is better because it illustrates a specific behavior with spaces.