### PR TITLE
Open mobile menu only if slide come from left-border side of screen

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -126,7 +126,7 @@
       var yDiff = end.y - start.y
 
       if (Math.abs(xDiff) > Math.abs(yDiff)) {
-        if (xDiff > 0) sidebar.classList.add('open')
+        if (xDiff > 0 && start.x <= 80) sidebar.classList.add('open')
         else sidebar.classList.remove('open')
       }
     })


### PR DESCRIPTION
When we use the vuejs.org website from mobile, the menu is opened too many time because a lot of action from user is basicaly to slide left-to-right for read example code.

But each time an example code is slided to be red, the menu appears from left side.

Just allows it to be shown if the gesture start from left side conduct to a better UX.

For example, we have this type of message:

— *user from chat*
> Hello,
> juste pour prévenir, à chaque fois que je slide sur mon telephone de gauche à droite j'ai le menu de gauche. 
> Le menu responsive quoi, c'est vraiment affreux surtout pour lire le code. 
> En tout cas ce framework à l'air très sympa, il est nativement inclus avec Laravel maintenant en plus :)

that can be translated by

> Hello,
> just to warn, each time I slide on my phone from left to right I have the left menu.
> The responsive menu, it's really awful in particular to read code.
> Anyway, this framework look good, and he is natively include with Laravel now in addition :)