### PR TITLE
Stop the scrollbar from showing up unnecessarily

### DIFF
--- a/themes/vue/source/css/_common.styl
+++ b/themes/vue/source/css/_common.styl
@@ -158,7 +158,7 @@ a.button
         display none
         box-sizing border-box
         max-height "calc(100vh - %s)" % $header-height
-        overflow-y scroll
+        overflow-y auto
         position absolute
         top 100%
         right -15px


### PR DESCRIPTION
Currently on the website, the dropdown nav links have overflow-y: scroll. This changes it to overflow-y: auto. Below is a screenshot of the current website. 

![image](https://cloud.githubusercontent.com/assets/1554424/26378075/ca494b2e-3fc7-11e7-89a9-ca832138bf61.png)
