### PR TITLE
Add missing comma in code sample for reusable transition component

### DIFF
--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -1486,7 +1486,7 @@ Vue.component('my-special-transition', {
   render: function (createElement, context) {
     var data = {
       props: {
-        name: 'very-special-transition'
+        name: 'very-special-transition',
         mode: 'out-in'
       },
       on: {


### PR DESCRIPTION
In the sample code for a functional component in "Reusable Transitions", fix the missing comma that should separate the props `name` and `mode`.