### PR TITLE
Edit multiline text style to trim the white space

### DIFF
--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -38,7 +38,7 @@ new Vue({
 
 ``` html
 <span>Multiline message is:</span>
-<p style="white-space: pre">{{ message }}</p>
+<p style="white-space: pre-line">{{ message }}</p>
 <br>
 <textarea v-model="message" placeholder="add multiple lines"></textarea>
 ```


### PR DESCRIPTION
If we change it form `pre` to `pre-line` we get a nicer trimmed text on each line without the need of modifiers.

Definition on both can be found in [the spec](https://www.w3.org/TR/css-text-3/#white-space-property) as follows:

```
‘pre’
This value prevents user agents from collapsing sequences of white space. Segment breaks such as line feeds and carriage returns are preserved as forced line breaks. Lines only break at forced line breaks; content that does not fit within the block container overflows it.

‘pre-line’
Like ‘normal’, this value collapses consecutive spaces and allows wrapping, but preserves segment breaks in the source as forced line breaks.
```

Both have the same browser support.