### PR TITLE
Clarify only custom event listeners are removed with `vm.$off`

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1392,7 +1392,7 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
 - **Usage:**
 
-  Remove event listener(s).
+  Remove custom event listener(s).
 
   - If no arguments are provided, remove all event listeners;
 


### PR DESCRIPTION
Clarify only custom event listeners are removed with `vm.$off`

From discussion here https://github.com/vuejs/vue/issues/5829#issuecomment-306400930