### PR TITLE
Renamed TitleCase term to PascalCase throughout Components documentation

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -1131,7 +1131,7 @@ Note that when used as a route component in `vue-router`, these properties will 
 
 ### Component Naming Conventions
 
-When registering components (or props), you can use kebab-case, camelCase, or TitleCase.
+When registering components (or props), you can use kebab-case, camelCase, or PascalCase.
 
 ``` js
 // in a component definition
@@ -1140,8 +1140,8 @@ components: {
   'kebab-cased-component': { /* ... */ },
   // register using camelCase
   'camelCasedComponent': { /* ... */ },
-  // register using TitleCase
-  'TitleCasedComponent': { /* ... */ }
+  // register using PascalCase
+  'PascalCasedComponent': { /* ... */ }
 }
 ```
 
@@ -1158,13 +1158,13 @@ When using _string_ templates however, we're not bound by HTML's case-insensitiv
 
 - kebab-case
 - camelCase or kebab-case if the component has been defined using camelCase
-- kebab-case, camelCase or TitleCase if the component has been defined using TitleCase
+- kebab-case, camelCase or PascalCase if the component has been defined using PascalCase
 
 ``` js
 components: {
   'kebab-cased-component': { /* ... */ },
   camelCasedComponent: { /* ... */ },
-  TitleCasedComponent: { /* ... */ }
+  PascalCasedComponent: { /* ... */ }
 }
 ```
 
@@ -1174,12 +1174,12 @@ components: {
 <camel-cased-component></camel-cased-component>
 <camelCasedComponent></camelCasedComponent>
 
-<title-cased-component></title-cased-component>
-<titleCasedComponent></titleCasedComponent>
-<TitleCasedComponent></TitleCasedComponent>
+<pascal-cased-component></pascal-cased-component>
+<pascalCasedComponent></pascalCasedComponent>
+<PascalCasedComponent></PascalCasedComponent>
 ```
 
-This means that the TitleCase is the most universal _declaration convention_ and kebab-case is the most universal _usage convention_.
+This means that the PascalCase is the most universal _declaration convention_ and kebab-case is the most universal _usage convention_.
 
 If your component isn't passed content via `slot` elements, you can even make it self-closing with a `/` after the name:
 


### PR DESCRIPTION
"Camel case is distinct from title case, which is traditionally used for book titles and headlines, as the latter retains the spaces between the words." https://en.wikipedia.org/wiki/Camel_case