### PR TITLE
Makes a render() feature more obvious to the reader + typos

### DIFF
--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -167,7 +167,7 @@ One thing to note: similar to how `v-bind:class` and `v-bind:style` have special
   directives: [
     {
       name: 'my-custom-directive',
-      value: '2'
+      value: '2',
       expression: '1 + 1',
       arg: 'foo',
       modifiers: {
@@ -182,7 +182,7 @@ One thing to note: similar to how `v-bind:class` and `v-bind:style` have special
   },
   // The name of the slot, if this component is the
   // child of another component
-  slot: 'name-of-slot'
+  slot: 'name-of-slot',
   // Other special top-level properties
   key: 'myKey',
   ref: 'myRef'

--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -106,15 +106,16 @@ createElement(
   },
 
   // {String | Array}
-  // Children VNodes. Optional.
+  // Children VNodes, built using createElement(),
+  // or simply using strings to get 'text VNodes'. Optional.
   [
-    createElement('h1', 'hello world'),
+    'Some text comes first.',
+    createElement('h1', 'A headline'),
     createElement(MyComponent, {
       props: {
-        someProp: 'foo'
+        someProp: 'foobar'
       }
-    }),
-    'bar'
+    })
   ]
 )
 ```


### PR DESCRIPTION
... following an issue that I encountered.

https://github.com/vuejs/vue/issues/5870#issuecomment-308016696