### PR TITLE
Add tip about order in event modifiers

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -194,6 +194,8 @@ To address this problem, Vue provides **event modifiers** for `v-on`. Recall tha
 <div v-on:click.self="doThat">...</div>
 ```
 
+<p class="tip">Order matters when using modifiers because the relevant code is generated in the same order. Therefore using `@click.prevent.self` will prevent **all clicks** while `@click.self.prevent` will only prevent clicks on the element itself.</p>
+
 > New in 2.1.4
 
 ``` html


### PR DESCRIPTION
The tip says it all. I think the notice may be too short but I wanted to raise the point that order matters because the code generated is different