### PR TITLE
Riot comparison - VueJS interacts better with inline JS

### DIFF
--- a/src/v2/guide/comparison.md
+++ b/src/v2/guide/comparison.md
@@ -224,5 +224,6 @@ Riot 2.0 provides a similar component-based development model (which is called a
 
 - [Transition effect system](transitions.html). Riot has none.
 - A far more powerful router. Riot’s routing API is extremely minimal.
+- Riot doesn't allow direct access to components/tags from inline JS without using complex mixins. Vue has straight-forward approach.
 - Better performance. Riot [traverses a DOM tree](http://riotjs.com/compare/#virtual-dom-vs-expressions-binding) rather than using a virtual DOM, so suffers from the same performance issues as AngularJS.
 - More mature tooling support. Vue provides official support for [webpack](https://github.com/vuejs/vue-loader) and [Browserify](https://github.com/vuejs/vueify), while Riot relies on community support for build system integration.


### PR DESCRIPTION
- Riot doesn't allow direct access to components/tags from inline JS without using complex mixins. Vue has straight-forward approach.