### PR TITLE
Tip: UI libraries using hidden form fields #1194

### DIFF
--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -12,7 +12,7 @@ You can use the `v-model` directive to create two-way data bindings on form inpu
 
 <p class="tip" id="vmodel-ime-tip">For languages that require an [IME](https://en.wikipedia.org/wiki/Input_method) (Chinese, Japanese, Korean etc.), you'll notice that `v-model` doesn't get updated during IME composition. If you want to cater for these updates as well, use `input` event instead.</p>
 
-<p class="tip">Some common form UI libraries directly change the value of hidden input fields to store the current state. Since this does not raise an `onchanged` event on the element, `v-model` cannot automatically detect the changed value and update the model.</p>
+<p class="tip">Note that `v-model` listens for the `input` (default) or `change` (if you use the `lazy` modifier, more on this below) events on the element. These only fire when the *user* modifies the field. Vue cannot automatically update based on other code making changes to the element's value.</p>
 
 ### Text
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -12,6 +12,8 @@ You can use the `v-model` directive to create two-way data bindings on form inpu
 
 <p class="tip" id="vmodel-ime-tip">For languages that require an [IME](https://en.wikipedia.org/wiki/Input_method) (Chinese, Japanese, Korean etc.), you'll notice that `v-model` doesn't get updated during IME composition. If you want to cater for these updates as well, use `input` event instead.</p>
 
+<p class="tip">Some common form UI libraries directly change the value of hidden input fields to store the current state. Since this does not raise an `onchanged` event on the element, `v-model` cannot automatically detect the changed value and update the model.</p>
+
 ### Text
 
 ``` html


### PR DESCRIPTION
Added a tip based on personal experience using SemanticUI's dropdown field, which relies on a hidden input field to store the current state.