### PR TITLE
Update class-and-style.md

### DIFF
--- a/src/v2/guide/class-and-style.md
+++ b/src/v2/guide/class-and-style.md
@@ -100,7 +100,7 @@ Which will render:
 If you would like to also toggle a class in the list conditionally, you can do it with a ternary expression:
 
 ``` html
-<div v-bind:class="[isActive ? activeClass : '', errorClass]">
+<div v-bind:class="[isActive ? 'activeClass' : '', errorClass]">
 ```
 
 This will always apply `errorClass`, but will only apply `activeClass` when `isActive` is `true`.


### PR DESCRIPTION
if you do not have the single quote around the class when using the tenary operate then vuejs complains the it can not find that class. I ran in to the is problem yesterday.