### PR TITLE
Use index as the key in todo list example

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -298,7 +298,7 @@ new Vue({
     <li
       is="todo-item"
       v-for="(todo, index) in todos"
-      v-bind:key="todo"
+      v-bind:key="index"
       v-bind:title="todo"
       v-on:remove="todos.splice(index, 1)"
     ></li>


### PR DESCRIPTION
If the todo content is used as the key, there will be issues if a user enters multiple todos with the same content. Using the index ensures that all keys are unique.