### PR TITLE
Made hero buttons more suitable in different languages

### DIFF
--- a/themes/vue/source/css/index.styl
+++ b/themes/vue/source/css/index.styl
@@ -57,6 +57,8 @@ body
         font-size 1.05em
         font-weight 600
         letter-spacing .1em
+        min-width 8em
+        text-align center
         &:first-child
             margin-right 1em
     .social-buttons


### PR DESCRIPTION
In some languages (e.g. Chinese) the text in hero buttons is too short. So they are too small to "be heroes".
So I set a `min-width` for them. Hope to make them more suitable.

Thanks.

before:  
![2017-07-10 11 58 57](https://user-images.githubusercontent.com/206848/28002378-39d464e6-6567-11e7-8cbb-38db068f190b.png)

after:  
![2017-07-10 11 59 09](https://user-images.githubusercontent.com/206848/28002380-3a0fd260-6567-11e7-8c94-670256df1cdc.png)
