### PR TITLE
`team.md` : add Bruno Lesieur as a partner community members

### DIFF
--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -206,7 +206,8 @@ order: 31
     'Bangalore, India': [12.971599, 77.594563],
     'Kingston, Jamaica': [18.017874, -76.809904],
     'Tehran, Iran': [35.689197, 51.388974],
-    'Shanghai, China': [31.230390, 121.473702]
+    'Shanghai, China': [31.230390, 121.473702],
+    'Annecy, France': [45.899247, 6.129384]
   }
   var languageNameFor = {
     en: 'English',
@@ -615,7 +616,7 @@ order: 31
     },
     {
       name: 'Bruno Lesieur',
-      title: 'French Community Manager',
+      title: 'French Community Directeur',
       city: 'Annecy, France',
       languages: ['fr', 'en'],
       github: 'Haeresis',
@@ -626,7 +627,7 @@ order: 31
         orgUrl: 'https://www.orchard-id.com/'
       },
       reposPersonal: [
-        'Haeresis/node-atlas-hello-vue', 'NodeAtlas/node-atlas'
+        'vuejs-fr/vuejs.org', 'Haeresis/node-atlas-hello-vue'
       ],
       links: [
         'https://node-atlas.js.org/', 'https://blog.lesieur.name/'

--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -612,6 +612,25 @@ order: 31
       reposPersonal: [
         'elemefe/element', 'elemefe/mint-ui'
       ]
+    },
+    {
+      name: 'Bruno Lesieur',
+      title: 'French Community Manager',
+      city: 'Annecy, France',
+      languages: ['fr', 'en'],
+      github: 'Haeresis',
+      twitter: 'MachinisteWeb',
+      work: {
+        role: 'Cofounder',
+        org: 'Orchard ID',
+        orgUrl: 'https://www.orchard-id.com/'
+      },
+      reposPersonal: [
+        'Haeresis/node-atlas-hello-vue', 'NodeAtlas/node-atlas'
+      ],
+      links: [
+        'https://node-atlas.js.org/', 'https://blog.lesieur.name/'
+      ]
     }
   ]
 


### PR DESCRIPTION
Hi everybody!

The member page is a great idea and I just finish to translate it! It's important to know who participate on Vue project (and want to say his/her proudness). And that allows to see french interlocutor to discover Vue and to be redirected on documentations, Forum, Chat, etc... if there is some french people in the data list :)

I want to be added as a member for the « Partner Community » section to allows anybody to ask me help about Vue.

What I already done for Vue ecosystem?

- I create Vuejs-FR and I translate with french reviewer/translator team on GitHub all documentations from Vue and its ecosystem (Vue Router, Vuex, Vue Server Renderer, Vue Loader...) to allows french people to discover Vue : https://github.com/vuejs-fr/vuejs.org/
- I watch and participate on the Vue Forum French category I asked to create recently : https://forum.vuejs.org/c/french
- I created and I provide a french gitter Chat to all people want help in french : https://gitter.im/vuejs-fr/vue
- I develop a progressive server-side JavaScript framework called [NodeAtlas](https://node-atlas.js.org/english/) that allow you to create very simple website or huge webapp, depend of which feature you activate and use. One of possibility is to use Vue as SSR template engine with NodeAtlas and I provide a [Hello Vue Template](https://github.com/Haeresis/node-atlas-hello-vue) in standealone. This template is also used as boostrap template into NodeAtlas CLI. By the way, if some people want help to write a decent english version, it will be appreciate. It's ok for French part ;)

I will continue to update and translate documentation in french and track all modification from upstream repository.

Thx a lot for all Vue communauty to help me improve my french -> to -> english level, work in progress ;)