### PR TITLE
Fix bad displaying behavior for 1300px screen size.

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -179,7 +179,7 @@
   #header
     background-color: rgba(255,255,255,.4)
 
-@media screen and (max-width: 1300px)
+@media screen and (max-width: 1340px)
   .content.with-sidebar
     margin-left: 290px
   #ad


### PR DESCRIPTION
![1300px](https://user-images.githubusercontent.com/3882169/28115606-e6bed890-6705-11e7-9093-990c271d1553.png)

## Correct way

For a screen lower 1300px all is good.
For a screen upper 1040px (include) that's become to be exactly the same space between left border and text as lower 1300px.

## Problem

between 1300px and 1039px, the text seems to closer, and for my 1300px screen, that is displaying same as on my screen capture. Not realy serious, is the standard behavior of Surface Pro 4 with tool bar on left.

## Solution

The simplier way to fix that is just to set media query to 1340px in replacement of 1300px.

You can test the fixed behavior on https://fr.vuejs.org/v2/guide/.

## Alternative

You can also just set 1340 for `.content.with-sidebar` and not for `#ad`

------

## BTW (not in this PR)

Usually a `max-width` query is setted at -1px than `min-width` value. e.g. for `page.styl` that should be `(max-width: 1339px)`, `(max-width: 899px)` and `(max-width: 559px)` 

So a `min-width` include edge value and `max-width` exclude edge value (or reversed, but in your case you use edge value for two way and that can be lead to « 1px edge problem » depending of situation.

What do you think about that ?