### PR TITLE
Fix : content left space behavior on all content pages

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -17,7 +17,7 @@
   padding: 2.2em 0
   max-width: 600px
   margin: 0 auto
-  padding-left: 20px
+  padding-left: 30px
   &.api
     > a:first-of-type > h2
       margin-top: 0
@@ -210,6 +210,7 @@
   .highlight pre
     padding: 1.2em 1em
   .content
+    padding-left 0
     &.with-sidebar
       margin: auto
     h2, h3


### PR DESCRIPTION
## From 900px to 1340px

![desktop](https://user-images.githubusercontent.com/3882169/28156466-25e79a7c-67b3-11e7-9514-ddfebb895beb.jpg)

Content is really closest to menu bar, that lead the `#` symbol to be mask by menu bar. Also space to each side of menu scroll bar are not consistent.

So I propose to set 30px padding to fix this behavior.

--> [See fix on FR version](https://fr.vuejs.org/v2/guide/#Parallele-avec-les-Custom-Elements)

## From 0 to 899px

![mobile](https://user-images.githubusercontent.com/3882169/28156580-a65325e6-67b3-11e7-8c43-c3301c4defcc.jpg)

Content is really far from left border in comparison of right border. That's is because there is a left padding offset to left that not exist on right.

So I propose to set 0 padding to fix this behavior.

--> [See fix on FR version with a screen reduced](https://fr.vuejs.org/v2/guide/#Parallele-avec-les-Custom-Elements)

PS : do not hesitate to refresh cache if you don't see differencies with current EN version.

What's your thoughs ?