### PR TITLE
Change cast for coerce word

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1888,7 +1888,7 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
 - **Modifiers:**
   - [`.lazy`](../guide/forms.html#lazy) - listen to `change` events instead of `input`
-  - [`.number`](../guide/forms.html#number) - cast input string to numbers
+  - [`.number`](../guide/forms.html#number) - coerce input string to numbers
   - [`.trim`](../guide/forms.html#trim) - trim input
 
 - **Usage:**


### PR DESCRIPTION
They are lot of topics about « type » in JavaScript (strong type vs. weak type, static type vs. dynamic type) etc.

I thing is a good thing if we use correct word in our JS documentation. We do not use « casting » in JavaScript but « coercion ».

So I propose to use the « coerce » word in replacement of « cast » word but I don't know if is a correct english word.

— « In computer science, type conversion, type casting, and type coercion are different ways of changing an entity of one data type into another. » JavaScript use coercion, not casting : https://en.wikipedia.org/wiki/Type_conversion