### PR TITLE
Rename instance method param to instanceOptions

### DIFF
--- a/src/v2/guide/plugins.md
+++ b/src/v2/guide/plugins.md
@@ -44,7 +44,7 @@ MyPlugin.install = function (Vue, options) {
   })
 
   // 4. add an instance method
-  Vue.prototype.$myMethod = function (options) {
+  Vue.prototype.$myMethod = function (instanceOptions) {
     // something logic ...
   }
 }

--- a/src/v2/guide/plugins.md
+++ b/src/v2/guide/plugins.md
@@ -44,7 +44,7 @@ MyPlugin.install = function (Vue, options) {
   })
 
   // 4. add an instance method
-  Vue.prototype.$myMethod = function (instanceOptions) {
+  Vue.prototype.$myMethod = function (methodOptions) {
     // something logic ...
   }
 }


### PR DESCRIPTION
It's unclear that the options parameter for the plugin has no relation to the options parameter for the instance method. Using the single name "options" is confusing.