### PR TITLE
Add hreflang for language URLs

### DIFF
--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -7,6 +7,14 @@
         <meta name="description" content="<%- theme.site_description %>">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 
+        <link rel="alternate" hreflang="x-default" href="https://vuejs.org/<%- page.path %>">
+        <link rel="alternate" hreflang="zh" href="https://cn.vuejs.org/<%- page.path %>">
+        <link rel="alternate" hreflang="ja" href="https://jp.vuejs.org/<%- page.path %>">
+        <link rel="alternate" hreflang="ru" href="https://ru.vuejs.org/<%- page.path %>">
+        <link rel="alternate" hreflang="ko" href="https://kr.vuejs.org/<%- page.path %>">
+        <link rel="alternate" hreflang="pt-BR" href="https://br.vuejs.org/<%- page.path %>">
+        <link rel="alternate" hreflang="fr" href="https://fr.vuejs.org/<%- page.path %>">
+
         <meta property="og:type" content="article">
         <meta property="og:title" content="<%- page.title ? page.title + ' — ' : '' %>Vue.js">
         <meta property="og:description" content="<%- theme.site_description %>">


### PR DESCRIPTION
Hello!

It seems Google crawls the different languages as different pages. I added few lines to fix this.
By the way, do you think ISO codes should be used for language subdomains as well (ex: **ja** instead of **jp**)?

![Goggle issue with different languages](https://user-images.githubusercontent.com/7230764/28274581-901b94aa-6b11-11e7-96ae-08b853036426.png)