### PR TITLE
Changed the `var` keyword to `const` in src/v2/guide/index.md

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -32,7 +32,7 @@ At the core of Vue.js is a system that enables us to declaratively render data t
 </div>
 ```
 ``` js
-var app = new Vue({
+const app = new Vue({
   el: '#app',
   data: {
     message: 'Hello Vue!'
@@ -44,7 +44,7 @@ var app = new Vue({
   {{ message }}
 </div>
 <script>
-var app = new Vue({
+const app = new Vue({
   el: '#app',
   data: {
     message: 'Hello Vue!'
@@ -66,7 +66,7 @@ In addition to text interpolation, we can also bind element attributes like this
 </div>
 ```
 ``` js
-var app2 = new Vue({
+const app2 = new Vue({
   el: '#app-2',
   data: {
     message: 'You loaded this page on ' + new Date()
@@ -80,7 +80,7 @@ var app2 = new Vue({
   </span>
 </div>
 <script>
-var app2 = new Vue({
+const app2 = new Vue({
   el: '#app-2',
   data: {
     message: 'You loaded this page on ' + new Date()
@@ -104,7 +104,7 @@ It's quite simple to toggle the presence of an element, too:
 ```
 
 ``` js
-var app3 = new Vue({
+const app3 = new Vue({
   el: '#app-3',
   data: {
     seen: true
@@ -117,7 +117,7 @@ var app3 = new Vue({
   <span v-if="seen">Now you see me</span>
 </div>
 <script>
-var app3 = new Vue({
+const app3 = new Vue({
   el: '#app-3',
   data: {
     seen: true
@@ -142,7 +142,7 @@ There are quite a few other directives, each with its own special functionality.
 </div>
 ```
 ``` js
-var app4 = new Vue({
+const app4 = new Vue({
   el: '#app-4',
   data: {
     todos: [
@@ -162,7 +162,7 @@ var app4 = new Vue({
   </ol>
 </div>
 <script>
-var app4 = new Vue({
+const app4 = new Vue({
   el: '#app-4',
   data: {
     todos: [
@@ -188,7 +188,7 @@ To let users interact with your app, we can use the `v-on` directive to attach e
 </div>
 ```
 ``` js
-var app5 = new Vue({
+const app5 = new Vue({
   el: '#app-5',
   data: {
     message: 'Hello Vue.js!'
@@ -206,7 +206,7 @@ var app5 = new Vue({
   <button v-on:click="reverseMessage">Reverse Message</button>
 </div>
 <script>
-var app5 = new Vue({
+const app5 = new Vue({
   el: '#app-5',
   data: {
     message: 'Hello Vue.js!'
@@ -231,7 +231,7 @@ Vue also provides the `v-model` directive that makes two-way binding between for
 </div>
 ```
 ``` js
-var app6 = new Vue({
+const app6 = new Vue({
   el: '#app-6',
   data: {
     message: 'Hello Vue!'
@@ -244,7 +244,7 @@ var app6 = new Vue({
   <input v-model="message">
 </div>
 <script>
-var app6 = new Vue({
+const app6 = new Vue({
   el: '#app-6',
   data: {
     message: 'Hello Vue!'
@@ -314,7 +314,7 @@ Vue.component('todo-item', {
   template: '<li>{{ todo.text }}</li>'
 })
 
-var app7 = new Vue({
+const app7 = new Vue({
   el: '#app-7',
   data: {
     groceryList: [
@@ -336,7 +336,7 @@ Vue.component('todo-item', {
   props: ['todo'],
   template: '<li>{{ todo.text }}</li>'
 })
-var app7 = new Vue({
+const app7 = new Vue({
   el: '#app-7',
   data: {
     groceryList: [


### PR DESCRIPTION
As most of the browsers are giving support to **ES6 synatax** and **ECMA** recommends to use `const` and  `let` instead of `var`. so I have updated  `src/v2/guide/index.md` a.k.a Getting started guide to use `const` and `let` instead of `var`