### PR TITLE
Add computed property into `v-for` example.

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -197,7 +197,7 @@ Sometime, you deal with an array and you want use a computed property based on e
 ``` html
 <ul id="repeat-computed" class="demo">
   <li v-for="(timestamp, index) in timestamps">
-    {{ formatedHours[index] }}
+    {{ formattedHours[index] }}
   </li>
 </ul>
 ```
@@ -213,7 +213,7 @@ new Vue({
     ]
   },
   computed: {
-    formatedHours: function () {
+    formattedHours: function () {
       return this.timestamps.map(function (timestamp) {
           var now = new Date(timestamp)
           return now.getHours() + ':' + now.getMinutes() + ':' + now.getSeconds()
@@ -228,7 +228,7 @@ Result:
 {% raw %}
 <ul id="repeat-computed" class="demo">
   <li v-for="(timestamp, index) in timestamps">
-    {{ formatedHours[index] }}
+    {{ formattedHours[index] }}
   </li>
 </ul>
 <script>
@@ -242,7 +242,7 @@ new Vue({
     ]
   },
   computed: {
-    formatedHours: function () {
+    formattedHours: function () {
       return this.timestamps.map(function (timestamp) {
           var now = new Date(timestamp)
           return now.getHours() + ':' + now.getMinutes() + ':' + now.getSeconds()

--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -196,8 +196,8 @@ Sometime, you deal with an array and you want use a computed property based on e
 
 ``` html
 <ul id="repeat-computed" class="demo">
-  <li v-for="(timestamp, index) in timestamps">
-    {{ formattedHours[index] }}
+  <li v-for="timestamp in formattedHours">
+    {{ timestamp }}
   </li>
 </ul>
 ```
@@ -227,8 +227,8 @@ Result:
 
 {% raw %}
 <ul id="repeat-computed" class="demo">
-  <li v-for="(timestamp, index) in timestamps">
-    {{ formattedHours[index] }}
+  <li v-for="timestamp in formattedHours">
+    {{ timestamp }}
   </li>
 </ul>
 <script>

--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -190,6 +190,69 @@ And another for the index:
 
 <p class="tip">When iterating over an object, the order is based on the key enumeration order of `Object.keys()`, which is **not** guaranteed to be consistent across JavaScript engine implementations.</p>
 
+### Computed property with `v-for`
+
+Sometime, you deal with an array and you want use a computed property based on each value of this array. This could be accomplish like that:
+
+``` html
+<ul id="repeat-computed" class="demo">
+  <li v-for="(timestamp, index) in timestamps">
+    {{ formatHours[index] }}
+  </li>
+</ul>
+```
+
+``` js
+new Vue({
+  el: '#repeat-computed',
+  data: {
+    timestamps: [
+      1501492818892,
+      1501492847876,
+      1501493126650
+    ]
+  },
+  computed: {
+    formatHours: function () {
+      return this.timestamps.map(function (timestamp) {
+          var now = new Date(timestamp)
+          return now.getHours() + ':' + now.getMinutes() + ':' + now.getSeconds()
+      });
+    }
+  }
+})
+```
+
+Result:
+
+{% raw %}
+<ul id="repeat-computed" class="demo">
+  <li v-for="(timestamp, index) in timestamps">
+    {{ formatHours[index] }}
+  </li>
+</ul>
+<script>
+new Vue({
+  el: '#repeat-computed',
+  data: {
+    timestamps: [
+      1501492818892,
+      1501492847876,
+      1501493126650
+    ]
+  },
+  computed: {
+    formatHours: function () {
+      return this.timestamps.map(function (timestamp) {
+          var now = new Date(timestamp)
+          return now.getHours() + ':' + now.getMinutes() + ':' + now.getSeconds()
+      });
+    }
+  }
+})
+</script>
+{% endraw %}
+
 ### Range `v-for`
 
 `v-for` can also take an integer. In this case it will repeat the template that many times.

--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -197,7 +197,7 @@ Sometime, you deal with an array and you want use a computed property based on e
 ``` html
 <ul id="repeat-computed" class="demo">
   <li v-for="(timestamp, index) in timestamps">
-    {{ formatHours[index] }}
+    {{ formatedHours[index] }}
   </li>
 </ul>
 ```
@@ -213,7 +213,7 @@ new Vue({
     ]
   },
   computed: {
-    formatHours: function () {
+    formatedHours: function () {
       return this.timestamps.map(function (timestamp) {
           var now = new Date(timestamp)
           return now.getHours() + ':' + now.getMinutes() + ':' + now.getSeconds()
@@ -228,7 +228,7 @@ Result:
 {% raw %}
 <ul id="repeat-computed" class="demo">
   <li v-for="(timestamp, index) in timestamps">
-    {{ formatHours[index] }}
+    {{ formatedHours[index] }}
   </li>
 </ul>
 <script>
@@ -242,7 +242,7 @@ new Vue({
     ]
   },
   computed: {
-    formatHours: function () {
+    formatedHours: function () {
       return this.timestamps.map(function (timestamp) {
           var now = new Date(timestamp)
           return now.getHours() + ':' + now.getMinutes() + ':' + now.getSeconds()


### PR DESCRIPTION
This is a proposition, feel free to not accept that if you think it's not the correct place or if this kind of example is findable somewhere else.

I have not find this type of example and it's a basic case to avoid some code like this : 

```htm
<ul id="repeat-computed" class="demo">
  <li v-for="timestamp in timestamps">
    {{ (new Date(timestamp)).getHours() + ':' + (new Date(timestamp)).getMinutes() + ':' + (new Date(timestamp)).getSeconds()  }}
  </li>
</ul>
```

So if you can change my word for a correct english sentence, I think it's an interesting case to add into discover Guide.

What is your thought ?