### PR TITLE
Performance improvements 🔥 🔥 🔥

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -64,10 +64,12 @@ Which will render:
   <my-component></my-component>
 </div>
 <script>
-Vue.component('my-component', {
-  template: '<div>A custom component!</div>'
+document.addEventListener('DOMContentLoaded', function() {
+  Vue.component('my-component', {
+    template: '<div>A custom component!</div>'
+  })
+  new Vue({ el: '#example' })
 })
-new Vue({ el: '#example' })
 </script>
 {% endraw %}
 
@@ -167,15 +169,17 @@ new Vue({
   <simple-counter></simple-counter>
 </div>
 <script>
-var data = { counter: 0 }
-Vue.component('simple-counter', {
-  template: '<button v-on:click="counter += 1">{{ counter }}</button>',
-  data: function () {
-    return data
-  }
-})
-new Vue({
-  el: '#example-2'
+document.addEventListener('DOMContentLoaded', function() {
+  var data = { counter: 0 }
+  Vue.component('simple-counter', {
+    template: '<button v-on:click="counter += 1">{{ counter }}</button>',
+    data: function () {
+      return data
+    }
+  })
+  new Vue({
+    el: '#example-2'
+  })
 })
 </script>
 {% endraw %}
@@ -199,16 +203,18 @@ Now all our counters each have their own internal state:
   <my-component></my-component>
 </div>
 <script>
-Vue.component('my-component', {
-  template: '<button v-on:click="counter += 1">{{ counter }}</button>',
-  data: function () {
-    return {
-      counter: 0
+document.addEventListener('DOMContentLoaded', function() {
+  Vue.component('my-component', {
+    template: '<button v-on:click="counter += 1">{{ counter }}</button>',
+    data: function () {
+      return {
+        counter: 0
+      }
     }
-  }
-})
-new Vue({
-  el: '#example-2-5'
+  })
+  new Vue({
+    el: '#example-2-5'
+  })
 })
 </script>
 {% endraw %}
@@ -254,14 +260,16 @@ Result:
   <child message="hello!"></child>
 </div>
 <script>
-new Vue({
-  el: '#prop-example-1',
-  components: {
-    child: {
-      props: ['message'],
-      template: '<span>{{ message }}</span>'
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#prop-example-1',
+    components: {
+      child: {
+        props: ['message'],
+        template: '<span>{{ message }}</span>'
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -312,17 +320,19 @@ Result:
   <child v-bind:my-message="parentMsg"></child>
 </div>
 <script>
-new Vue({
-  el: '#demo-2',
-  data: {
-    parentMsg: 'Message from parent'
-  },
-  components: {
-    child: {
-      props: ['myMessage'],
-      template: '<span>{{myMessage}}</span>'
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#demo-2',
+    data: {
+      parentMsg: 'Message from parent'
+    },
+    components: {
+      child: {
+        props: ['myMessage'],
+        template: '<span>{{myMessage}}</span>'
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -535,30 +545,32 @@ new Vue({
   <button-counter v-on:increment="incrementTotal"></button-counter>
 </div>
 <script>
-Vue.component('button-counter', {
-  template: '<button v-on:click="incrementCounter">{{ counter }}</button>',
-  data: function () {
-    return {
-      counter: 0
-    }
-  },
-  methods: {
-    incrementCounter: function () {
-      this.counter += 1
-      this.$emit('increment')
-    }
-  }
-})
-new Vue({
-  el: '#counter-event-example',
-  data: {
-    total: 0
-  },
-  methods: {
-    incrementTotal: function () {
-      this.total += 1
-    }
-  }
+document.addEventListener('DOMContentLoaded', function() {
+    Vue.component('button-counter', {
+      template: '<button v-on:click="incrementCounter">{{ counter }}</button>',
+      data: function () {
+        return {
+          counter: 0
+        }
+      },
+      methods: {
+        incrementCounter: function () {
+          this.counter += 1
+          this.$emit('increment')
+        }
+      }
+    })
+    new Vue({
+      el: '#counter-event-example',
+      data: {
+        total: 0
+      },
+      methods: {
+        incrementTotal: function () {
+          this.total += 1
+        }
+      }
+    })
 })
 </script>
 {% endraw %}
@@ -681,38 +693,40 @@ Vue.component('currency-input', {
   <currency-input v-model="price"></currency-input>
 </div>
 <script>
-Vue.component('currency-input', {
-  template: '\
-    <span>\
-      $\
-      <input\
-        ref="input"\
-        v-bind:value="value"\
-        v-on:input="updateValue($event.target.value)"\
-      >\
-    </span>\
-  ',
-  props: ['value'],
-  methods: {
-    updateValue: function (value) {
-      var formattedValue = value
-        .trim()
-        .slice(
-          0,
-          value.indexOf('.') === -1
-            ? value.length
-            : value.indexOf('.') + 3
-        )
-      if (formattedValue !== value) {
-        this.$refs.input.value = formattedValue
+document.addEventListener('DOMContentLoaded', function() {
+  Vue.component('currency-input', {
+    template: '\
+      <span>\
+        $\
+        <input\
+          ref="input"\
+          v-bind:value="value"\
+          v-on:input="updateValue($event.target.value)"\
+        >\
+      </span>\
+    ',
+    props: ['value'],
+    methods: {
+      updateValue: function (value) {
+        var formattedValue = value
+          .trim()
+          .slice(
+            0,
+            value.indexOf('.') === -1
+              ? value.length
+              : value.indexOf('.') + 3
+          )
+        if (formattedValue !== value) {
+          this.$refs.input.value = formattedValue
+        }
+        this.$emit('input', Number(formattedValue))
       }
-      this.$emit('input', Number(formattedValue))
     }
-  }
-})
-new Vue({
-  el: '#currency-input-example',
-  data: { price: '' }
+  })
+  new Vue({
+    el: '#currency-input-example',
+    data: { price: '' }
+  })
 })
 </script>
 {% endraw %}

--- a/src/v2/guide/computed.md
+++ b/src/v2/guide/computed.md
@@ -51,16 +51,18 @@ Result:
   <p>Computed reversed message: "{{ reversedMessage }}"</p>
 </div>
 <script>
-var vm = new Vue({
-  el: '#example',
-  data: {
-    message: 'Hello'
-  },
-  computed: {
-    reversedMessage: function () {
-      return this.message.split('').reverse().join('')
+document.addEventListener('DOMContentLoaded', function() {
+  var vm = new Vue({
+    el: '#example',
+    data: {
+      message: 'Hello'
+    },
+    computed: {
+      reversedMessage: function () {
+        return this.message.split('').reverse().join('')
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -202,51 +204,53 @@ For example:
 <!-- and collections of general-purpose utility methods, Vue core -->
 <!-- is able to remain small by not reinventing them. This also   -->
 <!-- gives you the freedom to just use what you're familiar with. -->
-<script src="https://unpkg.com/axios@0.12.0/dist/axios.min.js"></script>
-<script src="https://unpkg.com/lodash@4.13.1/lodash.min.js"></script>
+<script src="https://unpkg.com/axios@0.12.0/dist/axios.min.js" defer></script>
+<script src="https://unpkg.com/lodash@4.13.1/lodash.min.js" defer></script>
 <script>
-var watchExampleVM = new Vue({
-  el: '#watch-example',
-  data: {
-    question: '',
-    answer: 'I cannot give you an answer until you ask a question!'
-  },
-  watch: {
-    // whenever question changes, this function will run
-    question: function (newQuestion) {
-      this.answer = 'Waiting for you to stop typing...'
-      this.getAnswer()
+document.addEventListener('DOMContentLoaded', function() {
+  var watchExampleVM = new Vue({
+    el: '#watch-example',
+    data: {
+      question: '',
+      answer: 'I cannot give you an answer until you ask a question!'
+    },
+    watch: {
+      // whenever question changes, this function will run
+      question: function (newQuestion) {
+        this.answer = 'Waiting for you to stop typing...'
+        this.getAnswer()
+      }
+    },
+    methods: {
+      // _.debounce is a function provided by lodash to limit how
+      // often a particularly expensive operation can be run.
+      // In this case, we want to limit how often we access
+      // yesno.wtf/api, waiting until the user has completely
+      // finished typing before making the ajax request. To learn
+      // more about the _.debounce function (and its cousin
+      // _.throttle), visit: https://lodash.com/docs#debounce
+      getAnswer: _.debounce(
+        function () {
+          if (this.question.indexOf('?') === -1) {
+            this.answer = 'Questions usually contain a question mark. ;-)'
+            return
+          }
+          this.answer = 'Thinking...'
+          var vm = this
+          axios.get('https://yesno.wtf/api')
+            .then(function (response) {
+              vm.answer = _.capitalize(response.data.answer)
+            })
+            .catch(function (error) {
+              vm.answer = 'Error! Could not reach the API. ' + error
+            })
+        },
+        // This is the number of milliseconds we wait for the
+        // user to stop typing.
+        500
+      )
     }
-  },
-  methods: {
-    // _.debounce is a function provided by lodash to limit how
-    // often a particularly expensive operation can be run.
-    // In this case, we want to limit how often we access
-    // yesno.wtf/api, waiting until the user has completely
-    // finished typing before making the ajax request. To learn
-    // more about the _.debounce function (and its cousin
-    // _.throttle), visit: https://lodash.com/docs#debounce
-    getAnswer: _.debounce(
-      function () {
-        if (this.question.indexOf('?') === -1) {
-          this.answer = 'Questions usually contain a question mark. ;-)'
-          return
-        }
-        this.answer = 'Thinking...'
-        var vm = this
-        axios.get('https://yesno.wtf/api')
-          .then(function (response) {
-            vm.answer = _.capitalize(response.data.answer)
-          })
-          .catch(function (error) {
-            vm.answer = 'Error! Could not reach the API. ' + error
-          })
-      },
-      // This is the number of milliseconds we wait for the
-      // user to stop typing.
-      500
-    )
-  }
+  })
 })
 </script>
 ```
@@ -261,41 +265,43 @@ Result:
   </p>
   <p>{{ answer }}</p>
 </div>
-<script src="https://unpkg.com/axios@0.12.0/dist/axios.min.js"></script>
-<script src="https://unpkg.com/lodash@4.13.1/lodash.min.js"></script>
+<script src="https://unpkg.com/axios@0.12.0/dist/axios.min.js" defer></script>
+<script src="https://unpkg.com/lodash@4.13.1/lodash.min.js" defer></script>
 <script>
-var watchExampleVM = new Vue({
-  el: '#watch-example',
-  data: {
-    question: '',
-    answer: 'I cannot give you an answer until you ask a question!'
-  },
-  watch: {
-    question: function (newQuestion) {
-      this.answer = 'Waiting for you to stop typing...'
-      this.getAnswer()
+document.addEventListener('DOMContentLoaded', function() {
+  var watchExampleVM = new Vue({
+    el: '#watch-example',
+    data: {
+      question: '',
+      answer: 'I cannot give you an answer until you ask a question!'
+    },
+    watch: {
+      question: function (newQuestion) {
+        this.answer = 'Waiting for you to stop typing...'
+        this.getAnswer()
+      }
+    },
+    methods: {
+      getAnswer: _.debounce(
+        function () {
+          var vm = this
+          if (this.question.indexOf('?') === -1) {
+            vm.answer = 'Questions usually contain a question mark. ;-)'
+            return
+          }
+          vm.answer = 'Thinking...'
+          axios.get('https://yesno.wtf/api')
+            .then(function (response) {
+              vm.answer = _.capitalize(response.data.answer)
+            })
+            .catch(function (error) {
+              vm.answer = 'Error! Could not reach the API. ' + error
+            })
+        },
+        500
+      )
     }
-  },
-  methods: {
-    getAnswer: _.debounce(
-      function () {
-        var vm = this
-        if (this.question.indexOf('?') === -1) {
-          vm.answer = 'Questions usually contain a question mark. ;-)'
-          return
-        }
-        vm.answer = 'Thinking...'
-        axios.get('https://yesno.wtf/api')
-          .then(function (response) {
-            vm.answer = _.capitalize(response.data.answer)
-          })
-          .catch(function (error) {
-            vm.answer = 'Error! Could not reach the API. ' + error
-          })
-      },
-      500
-    )
-  }
+  })
 })
 </script>
 {% endraw %}

--- a/src/v2/guide/conditional.md
+++ b/src/v2/guide/conditional.md
@@ -112,16 +112,18 @@ Check it out for yourself by entering some text in the input, then pressing the 
   <button @click="toggleLoginType">Toggle login type</button>
 </div>
 <script>
-new Vue({
-  el: '#no-key-example',
-  data: {
-    loginType: 'username'
-  },
-  methods: {
-    toggleLoginType: function () {
-      return this.loginType = this.loginType === 'username' ? 'email' : 'username'
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#no-key-example',
+    data: {
+      loginType: 'username'
+    },
+    methods: {
+      toggleLoginType: function () {
+        return this.loginType = this.loginType === 'username' ? 'email' : 'username'
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -156,16 +158,18 @@ Now those inputs will be rendered from scratch each time you toggle. See for you
   <button @click="toggleLoginType">Toggle login type</button>
 </div>
 <script>
-new Vue({
-  el: '#key-example',
-  data: {
-    loginType: 'username'
-  },
-  methods: {
-    toggleLoginType: function () {
-      return this.loginType = this.loginType === 'username' ? 'email' : 'username'
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#key-example',
+    data: {
+      loginType: 'username'
+    },
+    methods: {
+      toggleLoginType: function () {
+        return this.loginType = this.loginType === 'username' ? 'email' : 'username'
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}

--- a/src/v2/guide/custom-directive.md
+++ b/src/v2/guide/custom-directive.md
@@ -13,13 +13,15 @@ In addition to the default set of directives shipped in core (`v-model` and `v-s
   <input v-focus>
 </div>
 <script>
-Vue.directive('focus', {
-  inserted: function (el) {
-    el.focus()
-  }
-})
-new Vue({
-  el: '#simplest-directive-example'
+document.addEventListener('DOMContentLoaded', function() {
+  Vue.directive('focus', {
+    inserted: function (el) {
+      el.focus()
+    }
+  })
+  new Vue({
+    el: '#simplest-directive-example'
+  })
 })
 </script>
 {% endraw %}
@@ -117,23 +119,25 @@ new Vue({
 {% raw %}
 <div id="hook-arguments-example" v-demo:foo.a.b="message" class="demo"></div>
 <script>
-Vue.directive('demo', {
-  bind: function (el, binding, vnode) {
-    var s = JSON.stringify
-    el.innerHTML =
-      'name: '       + s(binding.name) + '<br>' +
-      'value: '      + s(binding.value) + '<br>' +
-      'expression: ' + s(binding.expression) + '<br>' +
-      'argument: '   + s(binding.arg) + '<br>' +
-      'modifiers: '  + s(binding.modifiers) + '<br>' +
-      'vnode keys: ' + Object.keys(vnode).join(', ')
-  }
-})
-new Vue({
-  el: '#hook-arguments-example',
-  data: {
-    message: 'hello!'
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  Vue.directive('demo', {
+    bind: function (el, binding, vnode) {
+      var s = JSON.stringify
+      el.innerHTML =
+        'name: '       + s(binding.name) + '<br>' +
+        'value: '      + s(binding.value) + '<br>' +
+        'expression: ' + s(binding.expression) + '<br>' +
+        'argument: '   + s(binding.arg) + '<br>' +
+        'modifiers: '  + s(binding.modifiers) + '<br>' +
+        'vnode keys: ' + Object.keys(vnode).join(', ')
+    }
+  })
+  new Vue({
+    el: '#hook-arguments-example',
+    data: {
+      message: 'hello!'
+    }
+  })
 })
 </script>
 {% endraw %}

--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -33,11 +33,13 @@ Result:
   <p>The button above has been clicked {{ counter }} times.</p>
 </div>
 <script>
-var example1 = new Vue({
-  el: '#example-1',
-  data: {
-    counter: 0
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  var example1 = new Vue({
+    el: '#example-1',
+    data: {
+      counter: 0
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -85,19 +87,21 @@ Result:
   <button v-on:click="greet">Greet</button>
 </div>
 <script>
-var example2 = new Vue({
-  el: '#example-2',
-  data: {
-    name: 'Vue.js'
-  },
-  methods: {
-    greet: function (event) {
-      alert('Hello ' + this.name + '!')
-      if (event) {
-        alert(event.target.tagName)
+document.addEventListener('DOMContentLoaded', function() {
+  var example2 = new Vue({
+    el: '#example-2',
+    data: {
+      name: 'Vue.js'
+    },
+    methods: {
+      greet: function (event) {
+        alert('Hello ' + this.name + '!')
+        if (event) {
+          alert(event.target.tagName)
+        }
       }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -130,13 +134,15 @@ Result:
   <button v-on:click="say('what')">Say what</button>
 </div>
 <script>
-new Vue({
-  el: '#example-3',
-  methods: {
-    say: function (message) {
-      alert(message)
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-3',
+    methods: {
+      say: function (message) {
+        alert(message)
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -25,11 +25,13 @@ You can use the `v-model` directive to create two-way data bindings on form inpu
   <p>Message is: {{ message }}</p>
 </div>
 <script>
-new Vue({
-  el: '#example-1',
-  data: {
-    message: ''
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-1',
+    data: {
+      message: ''
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -51,11 +53,13 @@ new Vue({
   <textarea v-model="message" placeholder="add multiple lines"></textarea>
 </div>
 <script>
-new Vue({
-  el: '#example-textarea',
-  data: {
-    message: ''
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-textarea',
+    data: {
+      message: ''
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -79,11 +83,13 @@ Single checkbox, boolean value:
   <label for="checkbox">{{ checked }}</label>
 </div>
 <script>
-new Vue({
-  el: '#example-2',
-  data: {
-    checked: false
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-2',
+    data: {
+      checked: false
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -122,11 +128,13 @@ new Vue({
   <span>Checked names: {{ checkedNames }}</span>
 </div>
 <script>
-new Vue({
-  el: '#example-3',
-  data: {
-    checkedNames: []
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-3',
+    data: {
+      checkedNames: []
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -154,11 +162,13 @@ new Vue({
   <span>Picked: {{ picked }}</span>
 </div>
 <script>
-new Vue({
-  el: '#example-4',
-  data: {
-    picked: ''
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-4',
+    data: {
+      picked: ''
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -195,11 +205,13 @@ new Vue({
   <span>Selected: {{ selected }}</span>
 </div>
 <script>
-new Vue({
-  el: '#example-5',
-  data: {
-    selected: ''
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-5',
+    data: {
+      selected: ''
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -228,11 +240,13 @@ Multiple select (bound to Array):
   <span>Selected: {{ selected }}</span>
 </div>
 <script>
-new Vue({
-  el: '#example-6',
-  data: {
-    selected: []
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-6',
+    data: {
+      selected: []
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -270,16 +284,18 @@ new Vue({
   <span>Selected: {{ selected }}</span>
 </div>
 <script>
-new Vue({
-  el: '#example-7',
-  data: {
-    selected: 'A',
-    options: [
-      { text: 'One', value: 'A' },
-      { text: 'Two', value: 'B' },
-      { text: 'Three', value: 'C' }
-    ]
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-7',
+    data: {
+      selected: 'A',
+      options: [
+        { text: 'One', value: 'A' },
+        { text: 'Two', value: 'B' },
+        { text: 'Three', value: 'C' }
+      ]
+    }
+  })
 })
 </script>
 {% endraw %}

--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -44,11 +44,13 @@ var app = new Vue({
   {{ message }}
 </div>
 <script>
-var app = new Vue({
-  el: '#app',
-  data: {
-    message: 'Hello Vue!'
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  var app = new Vue({
+    el: '#app',
+    data: {
+      message: 'Hello Vue!'
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -80,11 +82,13 @@ var app2 = new Vue({
   </span>
 </div>
 <script>
-var app2 = new Vue({
-  el: '#app-2',
-  data: {
-    message: 'You loaded this page on ' + new Date()
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  var app2 = new Vue({
+    el: '#app-2',
+    data: {
+      message: 'You loaded this page on ' + new Date()
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -117,11 +121,13 @@ var app3 = new Vue({
   <span v-if="seen">Now you see me</span>
 </div>
 <script>
-var app3 = new Vue({
-  el: '#app-3',
-  data: {
-    seen: true
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  var app3 = new Vue({
+    el: '#app-3',
+    data: {
+      seen: true
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -162,15 +168,17 @@ var app4 = new Vue({
   </ol>
 </div>
 <script>
-var app4 = new Vue({
-  el: '#app-4',
-  data: {
-    todos: [
-      { text: 'Learn JavaScript' },
-      { text: 'Learn Vue' },
-      { text: 'Build something awesome' }
-    ]
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  var app4 = new Vue({
+    el: '#app-4',
+    data: {
+      todos: [
+        { text: 'Learn JavaScript' },
+        { text: 'Learn Vue' },
+        { text: 'Build something awesome' }
+      ]
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -206,16 +214,18 @@ var app5 = new Vue({
   <button v-on:click="reverseMessage">Reverse Message</button>
 </div>
 <script>
-var app5 = new Vue({
-  el: '#app-5',
-  data: {
-    message: 'Hello Vue.js!'
-  },
-  methods: {
-    reverseMessage: function () {
-      this.message = this.message.split('').reverse().join('')
+document.addEventListener('DOMContentLoaded', function() {
+  var app5 = new Vue({
+    el: '#app-5',
+    data: {
+      message: 'Hello Vue.js!'
+    },
+    methods: {
+      reverseMessage: function () {
+        this.message = this.message.split('').reverse().join('')
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -244,11 +254,13 @@ var app6 = new Vue({
   <input v-model="message">
 </div>
 <script>
-var app6 = new Vue({
-  el: '#app-6',
-  data: {
-    message: 'Hello Vue!'
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  var app6 = new Vue({
+    el: '#app-6',
+    data: {
+      message: 'Hello Vue!'
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -332,19 +344,21 @@ var app7 = new Vue({
   </ol>
 </div>
 <script>
-Vue.component('todo-item', {
-  props: ['todo'],
-  template: '<li>{{ todo.text }}</li>'
-})
-var app7 = new Vue({
-  el: '#app-7',
-  data: {
-    groceryList: [
-      { id: 0, text: 'Vegetables' },
-      { id: 1, text: 'Cheese' },
-      { id: 2, text: 'Whatever else humans are supposed to eat' }
-    ]
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  Vue.component('todo-item', {
+    props: ['todo'],
+    template: '<li>{{ todo.text }}</li>'
+  })
+  var app7 = new Vue({
+    el: '#app-7',
+    data: {
+      groceryList: [
+        { id: 0, text: 'Vegetables' },
+        { id: 1, text: 'Cheese' },
+        { id: 2, text: 'Whatever else humans are supposed to eat' }
+      ]
+    }
+  })
 })
 </script>
 {% endraw %}

--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -39,19 +39,21 @@ Result:
   </li>
 </ul>
 <script>
-var example1 = new Vue({
-  el: '#example-1',
-  data: {
-    items: [
-      { message: 'Foo' },
-      { message: 'Bar' }
-    ]
-  },
-  watch: {
-    items: function () {
-      smoothScroll.animateScroll(document.querySelector('#example-1'))
+document.addEventListener('DOMContentLoaded', function() {
+  var example1 = new Vue({
+    el: '#example-1',
+    data: {
+      items: [
+        { message: 'Foo' },
+        { message: 'Bar' }
+      ]
+    },
+    watch: {
+      items: function () {
+        smoothScroll.animateScroll(document.querySelector('#example-1'))
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -88,20 +90,22 @@ Result:
   </li>
 </ul>
 <script>
-var example2 = new Vue({
-  el: '#example-2',
-  data: {
-    parentMessage: 'Parent',
-    items: [
-      { message: 'Foo' },
-      { message: 'Bar' }
-    ]
-  },
-  watch: {
-    items: function () {
-      smoothScroll.animateScroll(document.querySelector('#example-2'))
+document.addEventListener('DOMContentLoaded', function() {
+  var example2 = new Vue({
+    el: '#example-2',
+    data: {
+      parentMessage: 'Parent',
+      items: [
+        { message: 'Foo' },
+        { message: 'Bar' }
+      ]
+    },
+    watch: {
+      items: function () {
+       smoothScroll.animateScroll(document.querySelector('#example-2'))
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -159,15 +163,17 @@ Result:
   </li>
 </ul>
 <script>
-new Vue({
-  el: '#repeat-object',
-  data: {
-    object: {
-      firstName: 'John',
-      lastName: 'Doe',
-      age: 30
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#repeat-object',
+    data: {
+      object: {
+        firstName: 'John',
+        lastName: 'Doe',
+        age: 30
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -207,7 +213,9 @@ Result:
   <span v-for="n in 10">{{ n }} </span>
 </div>
 <script>
-new Vue({ el: '#range' })
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({ el: '#range' })
+})
 </script>
 {% endraw %}
 
@@ -318,45 +326,47 @@ new Vue({
   </ul>
 </div>
 <script>
-Vue.component('todo-item', {
-  template: '\
-    <li>\
-      {{ title }}\
-      <button v-on:click="$emit(\'remove\')">X</button>\
-    </li>\
-  ',
-  props: ['title']
-})
-
-new Vue({
-  el: '#todo-list-example',
-  data: {
-    newTodoText: '',
-    todos: [
-      {
-        id: 1,
-        title: 'Do the dishes',
+document.addEventListener('DOMContentLoaded', function() {
+    Vue.component('todo-item', {
+      template: '\
+        <li>\
+          {{ title }}\
+          <button v-on:click="$emit(\'remove\')">X</button>\
+        </li>\
+      ',
+      props: ['title']
+    })
+    
+    new Vue({
+      el: '#todo-list-example',
+      data: {
+        newTodoText: '',
+        todos: [
+          {
+            id: 1,
+            title: 'Do the dishes',
+          },
+          {
+            id: 2,
+            title: 'Take out the trash',
+          },
+          {
+            id: 3,
+            title: 'Mow the lawn'
+          }
+        ],
+        nextTodoId: 4
       },
-      {
-        id: 2,
-        title: 'Take out the trash',
-      },
-      {
-        id: 3,
-        title: 'Mow the lawn'
+      methods: {
+        addNewTodo: function () {
+          this.todos.push({
+            id: this.nextTodoId++,
+            title: this.newTodoText
+          })
+          this.newTodoText = ''
+        }
       }
-    ],
-    nextTodoId: 4
-  },
-  methods: {
-    addNewTodo: function () {
-      this.todos.push({
-        id: this.nextTodoId++,
-        title: this.newTodoText
-      })
-      this.newTodoText = ''
-    }
-  }
+    })
 })
 </script>
 {% endraw %}

--- a/src/v2/guide/migration.md
+++ b/src/v2/guide/migration.md
@@ -418,45 +418,47 @@ Debouncing is used to limit how often we execute Ajax requests and other expensi
 These limitations become apparent when designing a search indicator, like this one for example:
 
 {% raw %}
-<script src="https://cdn.jsdelivr.net/lodash/4.13.1/lodash.js"></script>
+<script src="https://cdn.jsdelivr.net/lodash/4.13.1/lodash.js" defer></script>
 <div id="debounce-search-demo" class="demo">
   <input v-model="searchQuery" placeholder="Type something">
   <strong>{{ searchIndicator }}</strong>
 </div>
 <script>
-new Vue({
-  el: '#debounce-search-demo',
-  data: {
-    searchQuery: '',
-    searchQueryIsDirty: false,
-    isCalculating: false
-  },
-  computed: {
-    searchIndicator: function () {
-      if (this.isCalculating) {
-        return '⟳ Fetching new results'
-      } else if (this.searchQueryIsDirty) {
-        return '... Typing'
-      } else {
-        return '✓ Done'
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#debounce-search-demo',
+    data: {
+      searchQuery: '',
+      searchQueryIsDirty: false,
+      isCalculating: false
+    },
+    computed: {
+      searchIndicator: function () {
+        if (this.isCalculating) {
+          return '⟳ Fetching new results'
+        } else if (this.searchQueryIsDirty) {
+          return '... Typing'
+        } else {
+          return '✓ Done'
+        }
       }
+    },
+    watch: {
+      searchQuery: function () {
+        this.searchQueryIsDirty = true
+        this.expensiveOperation()
+      }
+    },
+    methods: {
+      expensiveOperation: _.debounce(function () {
+        this.isCalculating = true
+        setTimeout(function () {
+          this.isCalculating = false
+          this.searchQueryIsDirty = false
+        }.bind(this), 1000)
+      }, 500)
     }
-  },
-  watch: {
-    searchQuery: function () {
-      this.searchQueryIsDirty = true
-      this.expensiveOperation()
-    }
-  },
-  methods: {
-    expensiveOperation: _.debounce(function () {
-      this.isCalculating = true
-      setTimeout(function () {
-        this.isCalculating = false
-        this.searchQueryIsDirty = false
-      }.bind(this), 1000)
-    }, 500)
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -470,7 +472,7 @@ utility library, we know the specific debounce implementation we
 use will be best-in-class - and we can use it ANYWHERE. Not just
 in our template.
 -->
-<script src="https://cdn.jsdelivr.net/lodash/4.13.1/lodash.js"></script>
+<script src="https://cdn.jsdelivr.net/lodash/4.13.1/lodash.js" defer></script>
 <div id="debounce-search-demo">
   <input v-model="searchQuery" placeholder="Type something">
   <strong>{{ searchIndicator }}</strong>

--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -561,48 +561,50 @@ You may be interested to know that Vue's templates actually compile to render fu
   </div>
 </div>
 <script>
-new Vue({
-  el: '#vue-compile-demo',
-  data: {
-    templateText: '\
-<div>\n\
-  <header>\n\
-    <h1>I\'m a template!</h1>\n\
-  </header>\n\
-  <p v-if="message">\n\
-    {{ message }}\n\
-  </p>\n\
-  <p v-else>\n\
-    No message.\n\
-  </p>\n\
-</div>\
-    ',
-  },
-  computed: {
-    result: function () {
-      if (!this.templateText) {
-        return 'Enter a valid template above'
-      }
-      try {
-        var result = Vue.compile(this.templateText.replace(/\s{2,}/g, ''))
-        return {
-          render: this.formatFunction(result.render),
-          staticRenderFns: result.staticRenderFns.map(this.formatFunction)
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#vue-compile-demo',
+    data: {
+      templateText: '\
+  <div>\n\
+    <header>\n\
+      <h1>I\'m a template!</h1>\n\
+    </header>\n\
+    <p v-if="message">\n\
+      {{ message }}\n\
+    </p>\n\
+    <p v-else>\n\
+      No message.\n\
+    </p>\n\
+  </div>\
+      ',
+    },
+    computed: {
+      result: function () {
+        if (!this.templateText) {
+          return 'Enter a valid template above'
         }
-      } catch (error) {
-        return error.message
+        try {
+          var result = Vue.compile(this.templateText.replace(/\s{2,}/g, ''))
+          return {
+            render: this.formatFunction(result.render),
+            staticRenderFns: result.staticRenderFns.map(this.formatFunction)
+          }
+        } catch (error) {
+          return error.message
+        }
+      }
+    },
+    methods: {
+      formatFunction: function (fn) {
+        return fn.toString().replace(/(\{\n)(\S)/, '$1  $2')
       }
     }
-  },
-  methods: {
-    formatFunction: function (fn) {
-      return fn.toString().replace(/(\{\n)(\S)/, '$1  $2')
-    }
+  })
+  console.error = function (error) {
+    throw new Error(error)
   }
 })
-console.error = function (error) {
-  throw new Error(error)
-}
 </script>
 <style>
 #vue-compile-demo {

--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -189,7 +189,7 @@ order: 31
 </div>
 
 <script>
-(function () {
+document.addEventListener('DOMContentLoaded', function() {
   var cityCoordsFor = {
     'Annecy, France': [45.899247, 6.129384],
     'Alicante, Spain' : [38.346543, -0.483838],
@@ -1060,6 +1060,6 @@ order: 31
   function roundDistance (num) {
     return Number(Math.ceil(num).toPrecision(2))
   }
-})()
+})
 </script>
 {% endraw %}

--- a/src/v2/guide/transitioning-state.md
+++ b/src/v2/guide/transitioning-state.md
@@ -57,38 +57,40 @@ new Vue({
 ```
 
 {% raw %}
-<script src="https://unpkg.com/tween.js@16.3.4"></script>
+<script src="https://unpkg.com/tween.js@16.3.4" defer></script>
 <div id="animated-number-demo" class="demo">
   <input v-model.number="number" type="number" step="20">
   <p>{{ animatedNumber }}</p>
 </div>
 <script>
-new Vue({
-  el: '#animated-number-demo',
-  data: {
-    number: 0,
-    animatedNumber: 0
-  },
-  watch: {
-    number: function(newValue, oldValue) {
-      var vm = this
-      function animate () {
-        if (TWEEN.update()) {
-          requestAnimationFrame(animate)
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#animated-number-demo',
+    data: {
+      number: 0,
+      animatedNumber: 0
+    },
+    watch: {
+      number: function(newValue, oldValue) {
+        var vm = this
+        function animate () {
+          if (TWEEN.update()) {
+            requestAnimationFrame(animate)
+          }
         }
+
+        new TWEEN.Tween({ tweeningNumber: oldValue })
+          .easing(TWEEN.Easing.Quadratic.Out)
+          .to({ tweeningNumber: newValue }, 500)
+          .onUpdate(function () {
+            vm.animatedNumber = this.tweeningNumber.toFixed(0)
+          })
+          .start()
+
+        animate()
       }
-
-      new TWEEN.Tween({ tweeningNumber: oldValue })
-        .easing(TWEEN.Easing.Quadratic.Out)
-        .to({ tweeningNumber: newValue }, 500)
-        .onUpdate(function () {
-          vm.animatedNumber = this.tweeningNumber.toFixed(0)
-        })
-        .start()
-
-      animate()
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -193,53 +195,55 @@ new Vue({
   <p>{{ tweenedCSSColor }}</p>
 </div>
 <script>
-var Color = net.brehaut.Color
-new Vue({
-  el: '#example-7',
-  data: {
-    colorQuery: '',
-    color: {
-      red: 0,
-      green: 0,
-      blue: 0,
-      alpha: 1
+document.addEventListener('DOMContentLoaded', function() {
+  var Color = net.brehaut.Color
+  new Vue({
+    el: '#example-7',
+    data: {
+      colorQuery: '',
+      color: {
+        red: 0,
+        green: 0,
+        blue: 0,
+        alpha: 1
+      },
+      tweenedColor: {}
     },
-    tweenedColor: {}
-  },
-  created: function () {
-    this.tweenedColor = Object.assign({}, this.color)
-  },
-  watch: {
-    color: function () {
-      function animate () {
-        if (TWEEN.update()) {
-          requestAnimationFrame(animate)
+    created: function () {
+      this.tweenedColor = Object.assign({}, this.color)
+    },
+    watch: {
+      color: function () {
+        function animate () {
+          if (TWEEN.update()) {
+            requestAnimationFrame(animate)
+          }
         }
+
+        new TWEEN.Tween(this.tweenedColor)
+          .to(this.color, 750)
+          .start()
+
+        animate()
       }
-
-      new TWEEN.Tween(this.tweenedColor)
-        .to(this.color, 750)
-        .start()
-
-      animate()
+    },
+    computed: {
+      tweenedCSSColor: function () {
+        return new Color({
+          red: this.tweenedColor.red,
+          green: this.tweenedColor.green,
+          blue: this.tweenedColor.blue,
+          alpha: this.tweenedColor.alpha
+        }).toCSS()
+      }
+    },
+    methods: {
+      updateColor: function () {
+        this.color = new Color(this.colorQuery).toRGB()
+        this.colorQuery = ''
+      }
     }
-  },
-  computed: {
-    tweenedCSSColor: function () {
-      return new Color({
-        red: this.tweenedColor.red,
-        green: this.tweenedColor.green,
-        blue: this.tweenedColor.blue,
-        alpha: this.tweenedColor.alpha
-      }).toCSS()
-    }
-  },
-  methods: {
-    updateColor: function () {
-      this.color = new Color(this.colorQuery).toRGB()
-      this.colorQuery = ''
-    }
-  }
+  })
 })
 </script>
 <style>
@@ -288,88 +292,90 @@ Just as with Vue's transition components, the data backing state transitions can
   >
 </div>
 <script>
-new Vue({
-  el: '#svg-polygon-demo',
-  data: function () {
-    var defaultSides = 10
-    var stats = Array.apply(null, { length: defaultSides })
-      .map(function () { return 100 })
-    return {
-      stats: stats,
-      points: generatePoints(stats),
-      sides: defaultSides,
-      minRadius: 50,
-      interval: null,
-      updateInterval: 500
-    }
-  },
-  watch: {
-    sides: function (newSides, oldSides) {
-      var sidesDifference = newSides - oldSides
-      if (sidesDifference > 0) {
-        for (var i = 1; i <= sidesDifference; i++) {
-          this.stats.push(this.newRandomValue())
-        }
-      } else {
-        var absoluteSidesDifference = Math.abs(sidesDifference)
-        for (var i = 1; i <= absoluteSidesDifference; i++) {
-          this.stats.shift()
-        }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#svg-polygon-demo',
+    data: function () {
+      var defaultSides = 10
+      var stats = Array.apply(null, { length: defaultSides })
+        .map(function () { return 100 })
+      return {
+        stats: stats,
+        points: generatePoints(stats),
+        sides: defaultSides,
+        minRadius: 50,
+        interval: null,
+        updateInterval: 500
       }
     },
-    stats: function (newStats) {
-      TweenLite.to(
-        this.$data,
-        this.updateInterval / 1000,
-        { points: generatePoints(newStats) }
-      )
+    watch: {
+      sides: function (newSides, oldSides) {
+        var sidesDifference = newSides - oldSides
+        if (sidesDifference > 0) {
+          for (var i = 1; i <= sidesDifference; i++) {
+            this.stats.push(this.newRandomValue())
+          }
+        } else {
+          var absoluteSidesDifference = Math.abs(sidesDifference)
+          for (var i = 1; i <= absoluteSidesDifference; i++) {
+            this.stats.shift()
+          }
+        }
+      },
+      stats: function (newStats) {
+        TweenLite.to(
+          this.$data,
+          this.updateInterval / 1000,
+          { points: generatePoints(newStats) }
+        )
+      },
+      updateInterval: function () {
+        this.resetInterval()
+      }
     },
-    updateInterval: function () {
+    mounted: function () {
       this.resetInterval()
-    }
-  },
-  mounted: function () {
-    this.resetInterval()
-  },
-  methods: {
-    randomizeStats: function () {
-      var vm = this
-      this.stats = this.stats.map(function () {
-        return vm.newRandomValue()
-      })
     },
-    newRandomValue: function () {
-      return Math.ceil(this.minRadius + Math.random() * (100 - this.minRadius))
-    },
-    resetInterval: function () {
-      var vm = this
-      clearInterval(this.interval)
-      this.randomizeStats()
-      this.interval = setInterval(function () {
-        vm.randomizeStats()
-      }, this.updateInterval)
+    methods: {
+      randomizeStats: function () {
+        var vm = this
+        this.stats = this.stats.map(function () {
+          return vm.newRandomValue()
+        })
+      },
+      newRandomValue: function () {
+        return Math.ceil(this.minRadius + Math.random() * (100 - this.minRadius))
+      },
+      resetInterval: function () {
+        var vm = this
+        clearInterval(this.interval)
+        this.randomizeStats()
+        this.interval = setInterval(function () {
+          vm.randomizeStats()
+        }, this.updateInterval)
+      }
     }
+  })
+
+  function valueToPoint (value, index, total) {
+    var x     = 0
+    var y     = -value * 0.9
+    var angle = Math.PI * 2 / total * index
+    var cos   = Math.cos(angle)
+    var sin   = Math.sin(angle)
+    var tx    = x * cos - y * sin + 100
+    var ty    = x * sin + y * cos + 100
+    return { x: tx, y: ty }
+  }
+
+  function generatePoints (stats) {
+    var total = stats.length
+    return stats.map(function (stat, index) {
+      var point = valueToPoint(stat, index, total)
+      return point.x + ',' + point.y
+    }).join(' ')
   }
 })
-
-function valueToPoint (value, index, total) {
-  var x     = 0
-  var y     = -value * 0.9
-  var angle = Math.PI * 2 / total * index
-  var cos   = Math.cos(angle)
-  var sin   = Math.sin(angle)
-  var tx    = x * cos - y * sin + 100
-  var ty    = x * sin + y * cos + 100
-  return { x: tx, y: ty }
-}
-
-function generatePoints (stats) {
-  var total = stats.length
-  return stats.map(function (stat, index) {
-    var point = valueToPoint(stat, index, total)
-    return point.x + ',' + point.y
-  }).join(' ')
-}
 </script>
 <style>
 .demo-svg { display: block; }
@@ -483,58 +489,60 @@ new Vue({
   </p>
 </div>
 <script>
-Vue.component('animated-integer', {
-  template: '<span>{{ tweeningValue }}</span>',
-  props: {
-    value: {
-      type: Number,
-      required: true
-    }
-  },
-  data: function () {
-    return {
-      tweeningValue: 0
-    }
-  },
-  watch: {
-    value: function (newValue, oldValue) {
-      this.tween(oldValue, newValue)
-    }
-  },
-  mounted: function () {
-    this.tween(0, this.value)
-  },
-  methods: {
-    tween: function (startValue, endValue) {
-      var vm = this
-      function animate () {
-        if (TWEEN.update()) {
-          requestAnimationFrame(animate)
-        }
+document.addEventListener('DOMContentLoaded', function() {
+  Vue.component('animated-integer', {
+    template: '<span>{{ tweeningValue }}</span>',
+    props: {
+      value: {
+        type: Number,
+        required: true
       }
+    },
+    data: function () {
+      return {
+        tweeningValue: 0
+      }
+    },
+    watch: {
+      value: function (newValue, oldValue) {
+        this.tween(oldValue, newValue)
+      }
+    },
+    mounted: function () {
+      this.tween(0, this.value)
+    },
+    methods: {
+      tween: function (startValue, endValue) {
+        var vm = this
+        function animate () {
+          if (TWEEN.update()) {
+            requestAnimationFrame(animate)
+          }
+        }
 
-      new TWEEN.Tween({ tweeningValue: startValue })
-        .to({ tweeningValue: endValue }, 500)
-        .onUpdate(function () {
-          vm.tweeningValue = this.tweeningValue.toFixed(0)
-        })
-        .start()
+        new TWEEN.Tween({ tweeningValue: startValue })
+          .to({ tweeningValue: endValue }, 500)
+          .onUpdate(function () {
+            vm.tweeningValue = this.tweeningValue.toFixed(0)
+          })
+          .start()
 
-      animate()
+        animate()
+      }
     }
-  }
-})
-new Vue({
-  el: '#example-8',
-  data: {
-    firstNumber: 20,
-    secondNumber: 40
-  },
-  computed: {
-    result: function () {
-      return this.firstNumber + this.secondNumber
+  })
+  new Vue({
+    el: '#example-8',
+    data: {
+      firstNumber: 20,
+      secondNumber: 40
+    },
+    computed: {
+      result: function () {
+        return this.firstNumber + this.secondNumber
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}

--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -65,11 +65,13 @@ new Vue({
   </transition>
 </div>
 <script>
-new Vue({
-  el: '#demo',
-  data: {
-    show: true
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#demo',
+    data: {
+      show: true
+    }
+  })
 })
 </script>
 <style>
@@ -162,11 +164,13 @@ new Vue({
   </transition>
 </div>
 <script>
-new Vue({
-  el: '#example-1',
-  data: {
-    show: true
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-1',
+    data: {
+      show: true
+    }
+  })
 })
 </script>
 <style>
@@ -274,11 +278,13 @@ new Vue({
   }
 </style>
 <script>
-new Vue({
-  el: '#example-2',
-  data: {
-    show: true
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-2',
+    data: {
+      show: true
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -339,11 +345,13 @@ new Vue({
   </transition>
 </div>
 <script>
-new Vue({
-  el: '#example-3',
-  data: {
-    show: true
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-3',
+    data: {
+      show: true
+    }
+  })
 })
 </script>
 {% endraw %}
@@ -513,33 +521,35 @@ new Vue({
     </p>
   </transition>
 </div>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.2.3/velocity.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.2.3/velocity.min.js" defer></script>
 <script>
-new Vue({
-  el: '#example-4',
-  data: {
-    show: false
-  },
-  methods: {
-    beforeEnter: function (el) {
-      el.style.opacity = 0
-      el.style.transformOrigin = 'left'
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-4',
+    data: {
+      show: false
     },
-    enter: function (el, done) {
-      Velocity(el, { opacity: 1, fontSize: '1.4em' }, { duration: 300 })
-      Velocity(el, { fontSize: '1em' }, { complete: done })
-    },
-    leave: function (el, done) {
-      Velocity(el, { translateX: '15px', rotateZ: '50deg' }, { duration: 600 })
-      Velocity(el, { rotateZ: '100deg' }, { loop: 2 })
-      Velocity(el, {
-        rotateZ: '45deg',
-        translateY: '30px',
-        translateX: '30px',
-        opacity: 0
-      }, { complete: done })
+    methods: {
+      beforeEnter: function (el) {
+        el.style.opacity = 0
+        el.style.transformOrigin = 'left'
+      },
+      enter: function (el, done) {
+        Velocity(el, { opacity: 1, fontSize: '1.4em' }, { duration: 300 })
+        Velocity(el, { fontSize: '1em' }, { complete: done })
+      },
+      leave: function (el, done) {
+        Velocity(el, { translateX: '15px', rotateZ: '50deg' }, { duration: 600 })
+        Velocity(el, { rotateZ: '100deg' }, { loop: 2 })
+        Velocity(el, {
+          rotateZ: '45deg',
+          translateY: '30px',
+          translateX: '30px',
+          opacity: 0
+        }, { complete: done })
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -676,11 +686,13 @@ There's still one problem though. Try clicking the button below:
   </transition>
 </div>
 <script>
-new Vue({
-  el: '#no-mode-demo',
-  data: {
-    on: false
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#no-mode-demo',
+    data: {
+      on: false
+    }
+  })
 })
 </script>
 <style>
@@ -711,11 +723,13 @@ Sometimes this works great, like when transitioning items are absolutely positio
   </div>
 </div>
 <script>
-new Vue({
-  el: '#no-mode-absolute-demo',
-  data: {
-    on: false
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#no-mode-absolute-demo',
+    data: {
+      on: false
+    }
+  })
 })
 </script>
 <style>
@@ -751,11 +765,13 @@ And then maybe also translated so that they look like slide transitions:
   </div>
 </div>
 <script>
-new Vue({
-  el: '#no-mode-translate-demo',
-  data: {
-    on: false
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#no-mode-translate-demo',
+    data: {
+      on: false
+    }
+  })
 })
 </script>
 <style>
@@ -807,11 +823,13 @@ Now let's update the transition for our on/off buttons with `out-in`:
   </transition>
 </div>
 <script>
-new Vue({
-  el: '#with-mode-demo',
-  data: {
-    on: false
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#with-mode-demo',
+    data: {
+      on: false
+    }
+  })
 })
 </script>
 <style>
@@ -842,11 +860,13 @@ The `in-out` mode isn't used as often, but can sometimes be useful for a slightl
   </div>
 </div>
 <script>
-new Vue({
-  el: '#in-out-translate-demo',
-  data: {
-    on: false
-  }
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#in-out-translate-demo',
+    data: {
+      on: false
+    }
+  })
 })
 </script>
 <style>
@@ -928,19 +948,21 @@ new Vue({
 }
 </style>
 <script>
-new Vue({
-  el: '#transition-components-demo',
-  data: {
-    view: 'v-a'
-  },
-  components: {
-    'v-a': {
-      template: '<div>Component A</div>'
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#transition-components-demo',
+    data: {
+      view: 'v-a'
     },
-    'v-b': {
-      template: '<div>Component B</div>'
+    components: {
+      'v-a': {
+        template: '<div>Component A</div>'
+      },
+      'v-b': {
+        template: '<div>Component B</div>'
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -1019,23 +1041,25 @@ new Vue({
   </transition-group>
 </div>
 <script>
-new Vue({
-  el: '#list-demo',
-  data: {
-    items: [1,2,3,4,5,6,7,8,9],
-    nextNum: 10
-  },
-  methods: {
-    randomIndex: function () {
-      return Math.floor(Math.random() * this.items.length)
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#list-demo',
+    data: {
+      items: [1,2,3,4,5,6,7,8,9],
+      nextNum: 10
     },
-    add: function () {
-      this.items.splice(this.randomIndex(), 0, this.nextNum++)
-    },
-    remove: function () {
-      this.items.splice(this.randomIndex(), 1)
-    },
-  }
+    methods: {
+      randomIndex: function () {
+        return Math.floor(Math.random() * this.items.length)
+      },
+      add: function () {
+        this.items.splice(this.randomIndex(), 0, this.nextNum++)
+      },
+      remove: function () {
+        this.items.splice(this.randomIndex(), 1)
+      },
+    }
+  })
 })
 </script>
 <style>
@@ -1095,7 +1119,7 @@ new Vue({
 ```
 
 {% raw %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.14.1/lodash.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.14.1/lodash.min.js" defer></script>
 <div id="flip-list-demo" class="demo">
   <button v-on:click="shuffle">Shuffle</button>
   <transition-group name="flip-list" tag="ul">
@@ -1105,16 +1129,18 @@ new Vue({
   </transition-group>
 </div>
 <script>
-new Vue({
-  el: '#flip-list-demo',
-  data: {
-    items: [1,2,3,4,5,6,7,8,9]
-  },
-  methods: {
-    shuffle: function () {
-      this.items = _.shuffle(this.items)
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#flip-list-demo',
+    data: {
+      items: [1,2,3,4,5,6,7,8,9]
+    },
+    methods: {
+      shuffle: function () {
+        this.items = _.shuffle(this.items)
+      }
     }
-  }
+  })
 })
 </script>
 <style>
@@ -1188,7 +1214,7 @@ new Vue({
 ```
 
 {% raw %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.14.1/lodash.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.14.1/lodash.min.js" defer></script>
 <div id="list-complete-demo" class="demo">
   <button v-on:click="shuffle">Shuffle</button>
   <button v-on:click="add">Add</button>
@@ -1200,26 +1226,28 @@ new Vue({
   </transition-group>
 </div>
 <script>
-new Vue({
-  el: '#list-complete-demo',
-  data: {
-    items: [1,2,3,4,5,6,7,8,9],
-    nextNum: 10
-  },
-  methods: {
-    randomIndex: function () {
-      return Math.floor(Math.random() * this.items.length)
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#list-complete-demo',
+    data: {
+      items: [1,2,3,4,5,6,7,8,9],
+      nextNum: 10
     },
-    add: function () {
-      this.items.splice(this.randomIndex(), 0, this.nextNum++)
-    },
-    remove: function () {
-      this.items.splice(this.randomIndex(), 1)
-    },
-    shuffle: function () {
-      this.items = _.shuffle(this.items)
+    methods: {
+      randomIndex: function () {
+        return Math.floor(Math.random() * this.items.length)
+      },
+      add: function () {
+        this.items.splice(this.randomIndex(), 0, this.nextNum++)
+      },
+      remove: function () {
+        this.items.splice(this.randomIndex(), 1)
+      },
+      shuffle: function () {
+        this.items = _.shuffle(this.items)
+      }
     }
-  }
+  })
 })
 </script>
 <style>
@@ -1256,22 +1284,24 @@ These FLIP animations are also not limited to a single axis. Items in a multidim
   </transition-group>
 </div>
 <script>
-new Vue({
-  el: '#sudoku-demo',
-  data: {
-    cells: Array.apply(null, { length: 81 })
-      .map(function (_, index) {
-        return {
-          id: index,
-          number: index % 9 + 1
-        }
-      })
-  },
-  methods: {
-    shuffle: function () {
-      this.cells = _.shuffle(this.cells)
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#sudoku-demo',
+    data: {
+      cells: Array.apply(null, { length: 81 })
+        .map(function (_, index) {
+          return {
+            id: index,
+            number: index % 9 + 1
+          }
+        })
+    },
+    methods: {
+      shuffle: function () {
+        this.cells = _.shuffle(this.cells)
+      }
     }
-  }
+  })
 })
 </script>
 <style>
@@ -1380,7 +1410,7 @@ new Vue({
 ```
 
 {% raw %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.2.3/velocity.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.2.3/velocity.min.js" defer></script>
 <div id="example-5" class="demo">
   <input v-model="query">
   <transition-group
@@ -1399,52 +1429,54 @@ new Vue({
   </transition-group>
 </div>
 <script>
-new Vue({
-  el: '#example-5',
-  data: {
-    query: '',
-    list: [
-      { msg: 'Bruce Lee' },
-      { msg: 'Jackie Chan' },
-      { msg: 'Chuck Norris' },
-      { msg: 'Jet Li' },
-      { msg: 'Kung Fury' }
-    ]
-  },
-  computed: {
-    computedList: function () {
-      var vm = this
-      return this.list.filter(function (item) {
-        return item.msg.toLowerCase().indexOf(vm.query.toLowerCase()) !== -1
-      })
-    }
-  },
-  methods: {
-    beforeEnter: function (el) {
-      el.style.opacity = 0
-      el.style.height = 0
+document.addEventListener('DOMContentLoaded', function() {
+  new Vue({
+    el: '#example-5',
+    data: {
+      query: '',
+      list: [
+        { msg: 'Bruce Lee' },
+        { msg: 'Jackie Chan' },
+        { msg: 'Chuck Norris' },
+        { msg: 'Jet Li' },
+        { msg: 'Kung Fury' }
+      ]
     },
-    enter: function (el, done) {
-      var delay = el.dataset.index * 150
-      setTimeout(function () {
-        Velocity(
-          el,
-          { opacity: 1, height: '1.6em' },
-          { complete: done }
-        )
-      }, delay)
+    computed: {
+      computedList: function () {
+        var vm = this
+        return this.list.filter(function (item) {
+          return item.msg.toLowerCase().indexOf(vm.query.toLowerCase()) !== -1
+        })
+      }
     },
-    leave: function (el, done) {
-      var delay = el.dataset.index * 150
-      setTimeout(function () {
-        Velocity(
-          el,
-          { opacity: 0, height: 0 },
-          { complete: done }
-        )
-      }, delay)
+    methods: {
+      beforeEnter: function (el) {
+        el.style.opacity = 0
+        el.style.height = 0
+      },
+      enter: function (el, done) {
+        var delay = el.dataset.index * 150
+        setTimeout(function () {
+          Velocity(
+            el,
+            { opacity: 1, height: '1.6em' },
+            { complete: done }
+          )
+        }, delay)
+      },
+      leave: function (el, done) {
+        var delay = el.dataset.index * 150
+        setTimeout(function () {
+          Velocity(
+            el,
+            { opacity: 0, height: 0 },
+            { complete: done }
+          )
+        }, delay)
+      }
     }
-  }
+  })
 })
 </script>
 {% endraw %}
@@ -1590,7 +1622,7 @@ new Vue({
 ```
 
 {% raw %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.2.3/velocity.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/velocity/1.2.3/velocity.min.js" defer></script>
 <div id="dynamic-fade-demo" class="demo">
   Fade In: <input type="range" v-model="fadeInDuration" min="0" v-bind:max="maxFadeDuration">
   Fade Out: <input type="range" v-model="fadeOutDuration" min="0" v-bind:max="maxFadeDuration">
@@ -1612,49 +1644,51 @@ new Vue({
   >Stop it!</button>
 </div>
 <script>
-new Vue({
-  el: '#dynamic-fade-demo',
-  data: {
-    show: true,
-    fadeInDuration: 1000,
-    fadeOutDuration: 1000,
-    maxFadeDuration: 1500,
-    stop: true
-  },
-  mounted: function () {
-    this.show = false
-  },
-  methods: {
-    beforeEnter: function (el) {
-      el.style.opacity = 0
-    },
-    enter: function (el, done) {
-      var vm = this
-      Velocity(el,
-        { opacity: 1 },
-        {
-          duration: this.fadeInDuration,
-          complete: function () {
-            done()
-            if (!vm.stop) vm.show = false
-          }
+document.addEventListener('DOMContentLoaded', function() {
+    new Vue({
+      el: '#dynamic-fade-demo',
+      data: {
+        show: true,
+        fadeInDuration: 1000,
+        fadeOutDuration: 1000,
+        maxFadeDuration: 1500,
+        stop: true
+      },
+      mounted: function () {
+        this.show = false
+      },
+      methods: {
+        beforeEnter: function (el) {
+          el.style.opacity = 0
+        },
+        enter: function (el, done) {
+          var vm = this
+          Velocity(el,
+            { opacity: 1 },
+            {
+              duration: this.fadeInDuration,
+              complete: function () {
+                done()
+                if (!vm.stop) vm.show = false
+              }
+            }
+          )
+        },
+        leave: function (el, done) {
+          var vm = this
+          Velocity(el,
+            { opacity: 0 },
+            {
+              duration: this.fadeOutDuration,
+              complete: function () {
+                done()
+                vm.show = true
+              }
+            }
+          )
         }
-      )
-    },
-    leave: function (el, done) {
-      var vm = this
-      Velocity(el,
-        { opacity: 0 },
-        {
-          duration: this.fadeOutDuration,
-          complete: function () {
-            done()
-            vm.show = true
-          }
-        }
-      )
-    }
-  }
+      }
+    })
 })
 </script>
 {% endraw %}

--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -56,7 +56,7 @@
         <%- css(isIndex ? 'css/index' : 'css/page') %>
 
         <!-- this needs to be loaded before guide's inline scripts -->
-        <script src="<%- url_for("/js/vue.js") %>"></script>
+        <script src="<%- url_for("/js/vue.js") %>" defer></script>
         <script>window.PAGE_TYPE = "<%- page.type %>"</script>
 
         <!-- ga -->

--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -84,45 +84,45 @@
                     <%- body %>
                 <% } %>
             </div>
-            <script src="<%- url_for("/js/smooth-scroll.min.js") %>"></script>
+            <script src="<%- url_for("/js/smooth-scroll.min.js") %>" defer></script>
         <% } else { %>
             <%- body %>
         <% } %>
 
         <!-- main custom script for sidebars, version selects etc. -->
-        <script src="<%- url_for("/js/css.escape.js") %>"></script>
-        <script src="<%- url_for("/js/common.js") %>"></script>
+        <script src="<%- url_for("/js/css.escape.js") %>" defer></script>
+        <script src="<%- url_for("/js/common.js") %>" defer></script>
 
         <!-- search -->
         <link href="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" rel='stylesheet' type='text/css'>
         <%- css('css/search') %>
-        <script src="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
-        <script>
-        [
-          '#search-query-nav',
-          '#search-query-sidebar',
-          '#search-query-menu'
-        ].forEach(function (selector) {
-          if (!document.querySelector(selector)) return
-          // search index defaults to v2
-          var match = window.location.pathname.match(/^\/(v\d+)/)
-          var version = match ? match[1] : 'v2'
-          docsearch({
-            appId: 'BH4D9OD16A',
-            apiKey: '85cc3221c9f23bfbaa4e3913dd7625ea',
-            indexName: 'vuejs',
-            inputSelector: selector,
-            algoliaOptions: { facetFilters: ["version:" + version] }
-          })
-        })
-        </script>
-
+        <script src="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js" defer></script>
         <!-- fastclick -->
-        <script src="//cdnjs.cloudflare.com/ajax/libs/fastclick/1.0.6/fastclick.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/fastclick/1.0.6/fastclick.min.js" defer></script>
         <script>
-        document.addEventListener('DOMContentLoaded', function() {
-          FastClick.attach(document.body)
-        }, false)
+            document.addEventListener('DOMContentLoaded', function() {
+                var docsearchInit = function() {
+                    [
+                    '#search-query-nav',
+                    '#search-query-sidebar',
+                    '#search-query-menu'
+                    ].forEach(function (selector) {
+                        if (!document.querySelector(selector)) return;
+                        // search index defaults to v2
+                        var match = window.location.pathname.match(/^\/(v\d+)/);
+                        var version = match ? match[1] : 'v2';
+                        docsearch({
+                            appId: 'BH4D9OD16A',
+                            apiKey: '85cc3221c9f23bfbaa4e3913dd7625ea',
+                            indexName: 'vuejs',
+                            inputSelector: selector,
+                            algoliaOptions: { facetFilters: ["version:" + version] }
+                        });
+                    });
+                };
+                docsearchInit();
+                FastClick.attach(document.body);
+            }, false);
         </script>
     </body>
 </html>

--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -47,9 +47,6 @@
         <meta name="msapplication-config" content="browserconfig.xml">
         <link rel="manifest" href="/manifest.json">
 
-        <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600|Roboto Mono' rel='stylesheet' type='text/css'>
-        <link href='//fonts.googleapis.com/css?family=Dosis:500&text=Vue.js' rel='stylesheet' type='text/css'>
-
         <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
 
         <!-- main page styles -->
@@ -92,6 +89,10 @@
         <!-- main custom script for sidebars, version selects etc. -->
         <script src="<%- url_for("/js/css.escape.js") %>" defer></script>
         <script src="<%- url_for("/js/common.js") %>" defer></script>
+        
+        <!-- fonts -->
+        <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600|Roboto Mono' rel='stylesheet' type='text/css'>
+        <link href='//fonts.googleapis.com/css?family=Dosis:500&text=Vue.js' rel='stylesheet' type='text/css'>
 
         <!-- search -->
         <link href="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" rel='stylesheet' type='text/css'>

--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -45,7 +45,34 @@
         <meta name="theme-color" content="#4fc08d">
 
         <meta name="msapplication-config" content="browserconfig.xml">
+        <script>
+            /* Font Face Observer v2.0.13 - © Bram Stein. License: BSD-3-Clause */(function(){'use strict';var f,g=[];function l(a){g.push(a);1==g.length&&f()}function m(){for(;g.length;)g[0](),g.shift()}f=function(){setTimeout(m)};function n(a){this.a=p;this.b=void 0;this.f=[];var b=this;try{a(function(a){q(b,a)},function(a){r(b,a)})}catch(c){r(b,c)}}var p=2;function t(a){return new n(function(b,c){c(a)})}function u(a){return new n(function(b){b(a)})}function q(a,b){if(a.a==p){if(b==a)throw new TypeError;var c=!1;try{var d=b&&b.then;if(null!=b&&"object"==typeof b&&"function"==typeof d){d.call(b,function(b){c||q(a,b);c=!0},function(b){c||r(a,b);c=!0});return}}catch(e){c||r(a,e);return}a.a=0;a.b=b;v(a)}}
+            function r(a,b){if(a.a==p){if(b==a)throw new TypeError;a.a=1;a.b=b;v(a)}}function v(a){l(function(){if(a.a!=p)for(;a.f.length;){var b=a.f.shift(),c=b[0],d=b[1],e=b[2],b=b[3];try{0==a.a?"function"==typeof c?e(c.call(void 0,a.b)):e(a.b):1==a.a&&("function"==typeof d?e(d.call(void 0,a.b)):b(a.b))}catch(h){b(h)}}})}n.prototype.g=function(a){return this.c(void 0,a)};n.prototype.c=function(a,b){var c=this;return new n(function(d,e){c.f.push([a,b,d,e]);v(c)})};
+            function w(a){return new n(function(b,c){function d(c){return function(d){h[c]=d;e+=1;e==a.length&&b(h)}}var e=0,h=[];0==a.length&&b(h);for(var k=0;k<a.length;k+=1)u(a[k]).c(d(k),c)})}function x(a){return new n(function(b,c){for(var d=0;d<a.length;d+=1)u(a[d]).c(b,c)})};window.Promise||(window.Promise=n,window.Promise.resolve=u,window.Promise.reject=t,window.Promise.race=x,window.Promise.all=w,window.Promise.prototype.then=n.prototype.c,window.Promise.prototype["catch"]=n.prototype.g);}());
+
+            (function(){function l(a,b){document.addEventListener?a.addEventListener("scroll",b,!1):a.attachEvent("scroll",b)}function m(a){document.body?a():document.addEventListener?document.addEventListener("DOMContentLoaded",function c(){document.removeEventListener("DOMContentLoaded",c);a()}):document.attachEvent("onreadystatechange",function k(){if("interactive"==document.readyState||"complete"==document.readyState)document.detachEvent("onreadystatechange",k),a()})};function r(a){this.a=document.createElement("div");this.a.setAttribute("aria-hidden","true");this.a.appendChild(document.createTextNode(a));this.b=document.createElement("span");this.c=document.createElement("span");this.h=document.createElement("span");this.f=document.createElement("span");this.g=-1;this.b.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";this.c.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";
+            this.f.style.cssText="max-width:none;display:inline-block;position:absolute;height:100%;width:100%;overflow:scroll;font-size:16px;";this.h.style.cssText="display:inline-block;width:200%;height:200%;font-size:16px;max-width:none;";this.b.appendChild(this.h);this.c.appendChild(this.f);this.a.appendChild(this.b);this.a.appendChild(this.c)}
+            function t(a,b){a.a.style.cssText="max-width:none;min-width:20px;min-height:20px;display:inline-block;overflow:hidden;position:absolute;width:auto;margin:0;padding:0;top:-999px;white-space:nowrap;font-synthesis:none;font:"+b+";"}function y(a){var b=a.a.offsetWidth,c=b+100;a.f.style.width=c+"px";a.c.scrollLeft=c;a.b.scrollLeft=a.b.scrollWidth+100;return a.g!==b?(a.g=b,!0):!1}function z(a,b){function c(){var a=k;y(a)&&a.a.parentNode&&b(a.g)}var k=a;l(a.b,c);l(a.c,c);y(a)};function A(a,b){var c=b||{};this.family=a;this.style=c.style||"normal";this.weight=c.weight||"normal";this.stretch=c.stretch||"normal"}var B=null,C=null,E=null,F=null;function G(){if(null===C)if(J()&&/Apple/.test(window.navigator.vendor)){var a=/AppleWebKit\/([0-9]+)(?:\.([0-9]+))(?:\.([0-9]+))/.exec(window.navigator.userAgent);C=!!a&&603>parseInt(a[1],10)}else C=!1;return C}function J(){null===F&&(F=!!document.fonts);return F}
+            function K(){if(null===E){var a=document.createElement("div");try{a.style.font="condensed 100px sans-serif"}catch(b){}E=""!==a.style.font}return E}function L(a,b){return[a.style,a.weight,K()?a.stretch:"","100px",b].join(" ")}
+            A.prototype.load=function(a,b){var c=this,k=a||"BESbswy",q=0,D=b||3E3,H=(new Date).getTime();return new Promise(function(a,b){if(J()&&!G()){var M=new Promise(function(a,b){function e(){(new Date).getTime()-H>=D?b():document.fonts.load(L(c,'"'+c.family+'"'),k).then(function(c){1<=c.length?a():setTimeout(e,25)},function(){b()})}e()}),N=new Promise(function(a,c){q=setTimeout(c,D)});Promise.race([N,M]).then(function(){clearTimeout(q);a(c)},function(){b(c)})}else m(function(){function u(){var b;if(b=-1!=
+            f&&-1!=g||-1!=f&&-1!=h||-1!=g&&-1!=h)(b=f!=g&&f!=h&&g!=h)||(null===B&&(b=/AppleWebKit\/([0-9]+)(?:\.([0-9]+))/.exec(window.navigator.userAgent),B=!!b&&(536>parseInt(b[1],10)||536===parseInt(b[1],10)&&11>=parseInt(b[2],10))),b=B&&(f==v&&g==v&&h==v||f==w&&g==w&&h==w||f==x&&g==x&&h==x)),b=!b;b&&(d.parentNode&&d.parentNode.removeChild(d),clearTimeout(q),a(c))}function I(){if((new Date).getTime()-H>=D)d.parentNode&&d.parentNode.removeChild(d),b(c);else{var a=document.hidden;if(!0===a||void 0===a)f=e.a.offsetWidth,
+            g=n.a.offsetWidth,h=p.a.offsetWidth,u();q=setTimeout(I,50)}}var e=new r(k),n=new r(k),p=new r(k),f=-1,g=-1,h=-1,v=-1,w=-1,x=-1,d=document.createElement("div");d.dir="ltr";t(e,L(c,"sans-serif"));t(n,L(c,"serif"));t(p,L(c,"monospace"));d.appendChild(e.a);d.appendChild(n.a);d.appendChild(p.a);document.body.appendChild(d);v=e.a.offsetWidth;w=n.a.offsetWidth;x=p.a.offsetWidth;I();z(e,function(a){f=a;u()});t(e,L(c,'"'+c.family+'",sans-serif'));z(n,function(a){g=a;u()});t(n,L(c,'"'+c.family+'",serif'));
+            z(p,function(a){h=a;u()});t(p,L(c,'"'+c.family+'",monospace'))})})};"object"===typeof module?module.exports=A:(window.FontFaceObserver=A,window.FontFaceObserver.prototype.load=A.prototype.load);}());
+        </script>
+        <script>
+            var loadFont = function(fontName, webFontLoadedClassName) {
+                var font = new FontFaceObserver(fontName);
+                return font.load().then(function () {
+                    document.documentElement.classList.add(webFontLoadedClassName);
+                });
+            };
+            loadFont('Source Sans Pro', 'wf-body-active');
+            loadFont('Dosis', 'wf-logo-active');
+            loadFont('Roboto Mono', 'wf-code-active');
+        </script>
         <link rel="manifest" href="/manifest.json">
+        <link href="https://fonts.googleapis.com/css?family=Roboto+Mono|Source+Sans+Pro:300,400,600" rel="stylesheet">
+        <link href='//fonts.googleapis.com/css?family=Dosis:500&text=Vue.js' rel='stylesheet' type='text/css'>
 
         <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" type="text/css">
 
@@ -89,10 +116,6 @@
         <!-- main custom script for sidebars, version selects etc. -->
         <script src="<%- url_for("/js/css.escape.js") %>" defer></script>
         <script src="<%- url_for("/js/common.js") %>" defer></script>
-        
-        <!-- fonts -->
-        <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600|Roboto Mono' rel='stylesheet' type='text/css'>
-        <link href='//fonts.googleapis.com/css?family=Dosis:500&text=Vue.js' rel='stylesheet' type='text/css'>
 
         <!-- search -->
         <link href="//cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" rel='stylesheet' type='text/css'>

--- a/themes/vue/source/css/_common.styl
+++ b/themes/vue/source/css/_common.styl
@@ -2,7 +2,6 @@
 @import "_syntax"
 
 body
-  font-family: $body-font
   font-size: $body-font-size
   -webkit-font-smoothing: antialiased
   -moz-osx-font-smoothing: grayscale
@@ -11,6 +10,10 @@ body
   margin: 0
   &.docs
     padding-top: $header-height
+
+.wf-active
+  body
+    font-family: $body-font
 
 @media screen and (max-width: 900px)
   body.docs
@@ -28,11 +31,14 @@ h1, h2, h3, h4, strong
   color: $dark
 
 code, pre
-  font-family: $code-font
   font-size: $code-font-size
   background-color: $codebg
   -webkit-font-smoothing: initial
   -moz-osx-font-smoothing: initial
+
+.wf-active
+  code
+    font-family: $code-font
 
 code
   color: #e96900

--- a/themes/vue/source/css/_header.styl
+++ b/themes/vue/source/css/_header.styl
@@ -48,9 +48,12 @@ body.docs
   height: 16px
   font-size: 9px
   font-weight: bold
-  font-family: $code-font
   padding: 1px 4px 0 6px
   border-radius: 4px
+
+.wf-active
+  .new-label
+    font-family: $code-font
 
 .search-query
   height: 30px
@@ -74,13 +77,16 @@ body.docs
   font-size: 1.5em
   line-height: $header-height
   color: $dark
-  font-family: $logo-font
   font-weight: 500
   img
     vertical-align: middle
     margin-right: 6px
     width: $header-height
     height: $header-height
+
+.wf-logo-active
+  #logo
+    font-family: $logo-font
 
 #mobile-bar
   position: fixed

--- a/themes/vue/source/css/index.styl
+++ b/themes/vue/source/css/index.styl
@@ -47,7 +47,6 @@ body
     margin: 0
     font-size: 3.2em
   h2
-    font-family: $logo-font
     font-weight: 500
     font-size: 2.4em
     margin: 0 0 10px
@@ -68,6 +67,11 @@ body
       display: inline-block
       vertical-align: middle
       margin-right: 15px
+
+.wf-active
+  #hero
+    h2
+      font-family: $logo-font
 
 #highlights
   background-color: #fff

--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -142,7 +142,6 @@
         text-align: center
         line-height: 20px
         font-weight: bold
-        font-family: $logo-font
         font-size: 14px
       code
         background-color: #efefef
@@ -159,6 +158,13 @@
         content: '\f00c'
         font-family: FontAwesome
         background-color: $green
+
+.wf-active
+  .content
+    p
+      &.tip, &.success
+        &:before
+          font-family: $logo-font
 
 .guide-links
   margin-top: 2em


### PR DESCRIPTION
Hi. I wanted to share some ideas about docs performance improvements.

**TL;DR:**

I have some history, so let's go.

Using [pwmetrics](https://github.com/paulirish/pwmetrics/) some measurements were done.

_P.S. It’s taking measurements using Nexus 5 devices emulation and 1.6 Mbps network throttling._

![vue-docs-before](https://user-images.githubusercontent.com/6231516/28858478-713deca0-7759-11e7-89bb-ddf811f0d20b.png)


So, looks like there some place for opportunity,
Below some inconsistent behavior of **FOIC** (flash of invisible content) and **FOUC** (flash of unstyled content) can be noticed.

**FOIC**

![vue-foic-before](https://user-images.githubusercontent.com/6231516/28858508-ad80b49a-7759-11e7-905c-8f83bd587a4a.gif)



**FOUC**

![vue-fouc-before](https://user-images.githubusercontent.com/6231516/28858521-ba5dd77e-7759-11e7-9e94-c53505236444.gif)


It will be nice to show fallback font as soon as possible and add **progressive enhancement** strategy to the site.


But, first of all, scripts which are blocking First Paint should be managed.

[Timeline trace](https://chromedevtools.github.io/timeline-viewer/?loadTimelineFromURL=drive://0B0c67TI7mLzERGUwRV9FNlhmVU0)

![image](https://user-images.githubusercontent.com/6231516/28858589-466428fe-775a-11e7-9183-2d791c07edf1.png)


--------------------------------------------------------

So, adding `defer` attribute to all these scripts (except vue.js, we will manage it later) brought us to

![vue-docs-defer](https://user-images.githubusercontent.com/6231516/28858615-924171c8-775a-11e7-9812-6172dcb23579.png)


**100ms** for **TTCI** and **TTFI** not so impressive but it’s something.
Commit - b996ecf

Continue….

--------------------------------------------------------------------------------------
Adding defer to `vue.js` saved us 
**FCP** -  `3,528 sec` -> `1,972 sec`
**FMP** - `4,627 sec` -> `3,419 sec`
**PSI** - `6,116 sec` -> `4,912 sec`
**TTFI** - `6,066 sec` -> `4,861 sec`
**TTCI** - `6,066 sec` -> `4,861 sec`

![vue-docs-vue js-defer](https://user-images.githubusercontent.com/6231516/28858632-ba69ae5e-775a-11e7-8043-edb165542127.png)


Good, but we can do more.
Commit - 97ea5db

_P.S. Adding defer requires to warp example codes into _domContentLoaded_ listener, but I think it can be easily done in scope of `hexo-renderer-marked` fork._ 

----------------------------------------------------------------

Looks like fonts loading is blocking **FMP**

[Timeline trace](https://chromedevtools.github.io/timeline-viewer/?loadTimelineFromURL=drive://0B0c67TI7mLzEYWxSeEYyTlVxYWM)

![image](https://user-images.githubusercontent.com/6231516/28858721-44d5a502-775b-11e7-8af9-21b697268bd1.png)



Since browsers repaint after loading resources founded in body 

![image](https://user-images.githubusercontent.com/6231516/28858754-79e777b6-775b-11e7-88b0-0d6d8b33c0a6.png)


we can cheat and move loading resources fonts there.
Commit - 7fba6b7

Results:

![vue-docs-fonts-in-body](https://user-images.githubusercontent.com/6231516/28858772-a2c2cfd2-775b-11e7-87f6-5174d20ad934.png)


Really really nice results on chart.

**FMP**, **FCP** under `2 sec` 
**TTCI**, **TTCI**, **PSI** under `5 sec`

How it looks in browser

**FOIC**


![vue-docs-fonts-in-body-foic](https://user-images.githubusercontent.com/6231516/28858780-b7f4700e-775b-11e7-8307-8139ac590902.gif)


**FOUC**

![vue-docs-fonts-in-body-fouc](https://user-images.githubusercontent.com/6231516/28858786-bdd49030-775b-11e7-9795-4b6be3b5b67d.gif)




Not nice behavior for browsers with **FOIC** strategy…

------------------------------------------

But, we have [fontfaceobserver](https://github.com/bramstein/fontfaceobserver) which detects fonts loading. Let's try it.

So, results are:
[Timeline trace](https://chromedevtools.github.io/timeline-viewer/?loadTimelineFromURL=drive://0B0c67TI7mLzEWVlFQjloeXRDeEE)

![vue-docs-fontfaceobserver](https://user-images.githubusercontent.com/6231516/28858800-e309ab10-775b-11e7-9c0b-de7157bde2c0.png)


**FMP**, **FCP** under `2 sec`, still the same
**TTCI**, **TTCI**, **PSI** under `5,2 sec` instead of `4,8 sec`

Hense, `400ms` looks like a good trade off for consistent behavior through all browsers.
Commit - 6b13c3

And, last gifs

**FOIC**

![vue-docs-foic-fontfaceobserver](https://user-images.githubusercontent.com/6231516/28858821-006ff6a0-775c-11e7-885f-e9acee9b2824.gif)


**FOUC**

![vue-docs-fouc-fontfaceobserver](https://user-images.githubusercontent.com/6231516/28858830-0f394632-775c-11e7-8f3e-38c419d40b16.gif)



Aaaaand to compare the before and after...

![image](https://user-images.githubusercontent.com/6231516/28858920-d028b0a8-775c-11e7-9c48-95913a6dfe89.png)


Thanks :)

_P.S. In case supporting only evergreen browsers `font-display` can manage FOIC._
