### PR TITLE
Update plugins.md

### DIFF
--- a/src/v2/guide/plugins.md
+++ b/src/v2/guide/plugins.md
@@ -12,7 +12,7 @@ Plugins usually add global-level functionality to Vue. There is no strictly defi
 
 2. Add one or more global assets: directives/filters/transitions etc. e.g. [vue-touch](https://github.com/vuejs/vue-touch)
 
-3. Add some component options by global mixin. e.g. [vuex](https://github.com/vuejs/vuex)
+3. Add some component options by global mixin. e.g. [vuex](https://github.com/vuejs/vuex) 1.x
 
 4. Add some Vue instance methods by attaching them to Vue.prototype.
 

--- a/src/v2/guide/plugins.md
+++ b/src/v2/guide/plugins.md
@@ -12,7 +12,7 @@ Plugins usually add global-level functionality to Vue. There is no strictly defi
 
 2. Add one or more global assets: directives/filters/transitions etc. e.g. [vue-touch](https://github.com/vuejs/vue-touch)
 
-3. Add some component options by global mixin. e.g. [vuex](https://github.com/vuejs/vuex) 1.x
+3. Add some component options by global mixin. e.g. [vue-router](https://github.com/vuejs/vue-router)
 
 4. Add some Vue instance methods by attaching them to Vue.prototype.
 


### PR DESCRIPTION
https://github.com/vuejs/vuejs.org/blob/master/src/v2/guide/mixins.md#custom-option-merge-strategies
Here, say 'A more advanced example can be found on Vuex's 1.x merging strategy'
And, vuex 2.x not use `optionMergeStrategies`.
So, i think 'Add some component options by global mixin. e.g. vuex' in [plugin.html](https://vuejs.org/v2/guide/plugins.html), means vuex 1.x