### PR TITLE
remove false statement

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -399,8 +399,6 @@ To give Vue a hint so that it can track each node's identity, and thus reuse and
 
 It is recommended to provide a `key` with `v-for` whenever possible, unless the iterated DOM content is simple, or you are intentionally relying on the default behavior for performance gains.
 
-Since it's a generic mechanism for Vue to identify nodes, the `key` also has other uses that are not specifically tied to `v-for`, as we will see later in the guide.
-
 ## Array Change Detection
 
 ### Mutation Methods


### PR DESCRIPTION
We here wrongly informed users that we will know more about use cases for the `key` prop, but it is no longer existing.