### PR TITLE
[API] add valid "number" type for "key"

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1975,7 +1975,7 @@ if (version === 2) {
 
 ### key
 
-- **Expects:** `string`
+- **Expects:** `number | string`
 
   The `key` special attribute is primarily used as a hint for Vue's virtual DOM algorithm to identify VNodes when diffing the new list of nodes against the old list. Without keys, Vue uses an algorithm that minimizes element movement and tries to patch/reuse elements of the same type in-place as much as possible. With keys, it will reorder elements based on the order change of keys, and elements with keys that are no longer present will always be removed/destroyed.
 


### PR DESCRIPTION
Not sure if I read this correctly, but it looks like key can work fine with numbers.

https://github.com/vuejs/vue/blob/5981529b497f5ef064b123aeb58eb9655172d6eb/src/core/instance/render-helpers/render-list.js#L12