### PR TITLE
Replace toBe with to.equal for typeof tests

### DIFF
--- a/src/v2/guide/unit-testing.md
+++ b/src/v2/guide/unit-testing.md
@@ -43,13 +43,13 @@ import MyComponent from 'path/to/MyComponent.vue'
 describe('MyComponent', () => {
   // Inspect the raw component options
   it('has a created hook', () => {
-    expect(typeof MyComponent.created).toBe('function')
+    expect(typeof MyComponent.created).to.equal('function')
   })
 
   // Evaluate the results of functions in
   // the raw component options
   it('sets the correct default data', () => {
-    expect(typeof MyComponent.data).toBe('function')
+    expect(typeof MyComponent.data).to.equal('function')
     const defaultData = MyComponent.data()
     expect(defaultData.message).toBe('hello!')
   })


### PR DESCRIPTION
Having this undefined is not a function (evaluating 'expect(_MyComponent.default.data).toBe('function')')
when using toBe. No more error when using to.equal