### PR TITLE
Adjust example for circular component

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -1288,7 +1288,7 @@ In our case, I'll make that point the `tree-folder` component. We know the child
 
 ``` js
 beforeCreate: function () {
-  this.$options.components.TreeFolderContents = require('./tree-folder-contents.vue')
+  this.$options.components.TreeFolderContents = require('./tree-folder-contents.vue').default
 }
 ```
 


### PR DESCRIPTION
Since vue-loader 13.*, we have to use `require('./component.vue').default` instead of `require('./component.vue')`