### PR TITLE
adds tip to methods documentation about underscore and dollar prefixed namespace collisions with methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 public/
 .deploy*/
 src/_drafts
+.idea/

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -565,7 +565,7 @@ if (version === 2) {
   <p class="tip">
     Note that __you should not use an arrow function to define a method__ (e.g. `plus: () => this.a++`). The reason is arrow functions bind the parent context, so `this` will not be the Vue instance as you expect and `this.a` will be undefined.
 
-    Also note that __methods must not be prefixed with an `_`__, e.g. `_update`, as this conflicts with interval Vue methods.
+    Also note that __methods must not be prefixed with an `_` or `$`__, e.g. `_update` or `$update`, as this may conflict with interval Vue methods.
   </p>
 
 - **Example:**

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -562,7 +562,11 @@ if (version === 2) {
 
   Methods to be mixed into the Vue instance. You can access these methods directly on the VM instance, or use them in directive expressions. All methods will have their `this` context automatically bound to the Vue instance.
 
-  <p class="tip">Note that __you should not use an arrow function to define a method__ (e.g. `plus: () => this.a++`). The reason is arrow functions bind the parent context, so `this` will not be the Vue instance as you expect and `this.a` will be undefined.</p>
+  <p class="tip">
+    Note that __you should not use an arrow function to define a method__ (e.g. `plus: () => this.a++`). The reason is arrow functions bind the parent context, so `this` will not be the Vue instance as you expect and `this.a` will be undefined.
+
+    Also note that __methods must not be prefixed with an `_`__, e.g. `_update`, as this conflicts with interval Vue methods.
+  </p>
 
 - **Example:**
 


### PR DESCRIPTION
This PR is in reference to https://github.com/vuejs/vue/issues/6312.

Please note that this PR also add `.idea/` to gitignore.