### PR TITLE
Fix Lodash not loading from unpkg

### DIFF
--- a/src/v2/guide/computed.md
+++ b/src/v2/guide/computed.md
@@ -203,7 +203,7 @@ For example:
 <!-- is able to remain small by not reinventing them. This also   -->
 <!-- gives you the freedom to just use what you're familiar with. -->
 <script src="https://unpkg.com/axios@0.12.0/dist/axios.min.js"></script>
-<script src="https://unpkg.com/lodash@4.13.1/lodash.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.13.1/lodash.min.js"></script>
 <script>
 var watchExampleVM = new Vue({
   el: '#watch-example',
@@ -262,7 +262,7 @@ Result:
   <p>{{ answer }}</p>
 </div>
 <script src="https://unpkg.com/axios@0.12.0/dist/axios.min.js"></script>
-<script src="https://unpkg.com/lodash@4.13.1/lodash.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.13.1/lodash.min.js"></script>
 <script>
 var watchExampleVM = new Vue({
   el: '#watch-example',


### PR DESCRIPTION
For some reason, unpkg is not loading lodash.min.js, which is breaking the question example for watchers on the computed properties page. I've checked the .min links for axios and vue on unpkg, and it looks like it is just an issue with lodash. For example https://unpkg.com/lodash@4.13.1/lodash.min.js will return an error saying

> Cannot find file "/lodash.min.js" in package lodash@4.13.1

Going to https://unpkg.com/lodash@4.17.4/lodash.min.js results in the same error but with the 4.17.4 tag.

I have checked the directories on unpkg and they are listed as being there. Someone may want to get in contact with unpkg to let them know this, as for now I've suggested to use cdnjs for the lodash@4.13.1 min.js file which fixes the error the computed properties page was getting (_ is not defined).