### PR TITLE
Move reactivity & render function docs into "Advanced / Internals" section

### DIFF
--- a/src/v2/guide/comparison.md
+++ b/src/v2/guide/comparison.md
@@ -1,7 +1,7 @@
 ---
 title: Comparison with Other Frameworks
 type: guide
-order: 701
+order: 801
 ---
 
 This is definitely the most difficult page in the guide to write, but we do feel it's important. Odds are, you've had problems you tried to solve and you've used another library to solve them. You're here because you want to know if Vue can solve your specific problems better. That's what we hope to answer for you.

--- a/src/v2/guide/deployment.md
+++ b/src/v2/guide/deployment.md
@@ -1,7 +1,7 @@
 ---
 title: Production Deployment
 type: guide
-order: 401
+order: 501
 ---
 
 ## Turn on Production Mode

--- a/src/v2/guide/join.md
+++ b/src/v2/guide/join.md
@@ -1,7 +1,7 @@
 ---
 title: Join the Vue.js Community!
 type: guide
-order: 702
+order: 802
 ---
 
 Vue's community is growing incredibly fast and if you're reading this, there's a good chance you're ready to join it. So... welcome!

--- a/src/v2/guide/migration-vue-router.md
+++ b/src/v2/guide/migration-vue-router.md
@@ -1,7 +1,7 @@
 ---
 title: Migration from Vue Router 0.7.x
 type: guide
-order: 602
+order: 702
 ---
 
 > Only Vue Router 2 is compatible with Vue 2, so if you're updating Vue, you'll have to update Vue Router as well. That's why we've included details on the migration path here in the main docs. For a complete guide on using the new Vue Router, see the [Vue Router docs](http://router.vuejs.org/en/).

--- a/src/v2/guide/migration-vuex.md
+++ b/src/v2/guide/migration-vuex.md
@@ -1,7 +1,7 @@
 ---
 title: Migration from Vuex 0.6.x to 1.0
 type: guide
-order: 603
+order: 703
 ---
 
 > Vuex 2.0 is released, but this guide only covers the migration to 1.0? Is that a typo? Also, it looks like Vuex 1.0 and 2.0 were released simultaneously. What's going on? Which one should I use and what's compatible with Vue 2.0?

--- a/src/v2/guide/migration.md
+++ b/src/v2/guide/migration.md
@@ -1,7 +1,7 @@
 ---
 title: Migration from Vue 1.x
 type: guide
-order: 601
+order: 701
 ---
 
 ## FAQ

--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -1,18 +1,8 @@
 ---
 title: Reactivity in Depth
 type: guide
-order: -1
+order: 401
 ---
-
-!!!!!!!!!!!!!!!!!!!!!!!!!!
-!! NOTE FOR TRANSLATORS !!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!! Don't bother translating changes to this page yet, !!
-!! as it's not visible on the frontend and will     !!
-!! eventually be adapted into a page - or perhaps   !!
-!! a completely separate guide - for potential      !!
-!! contributors to Vue.                             !!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 One of Vue's most distinct features is the unobtrusive reactivity system. Models are just plain JavaScript objects. When you modify them, the view updates. It makes state management very simple and intuitive, but it's also important to understand how it works to avoid some common gotchas. In this section, we are going to dig into some of the lower-level details of Vue's reactivity system.
 

--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -1,7 +1,7 @@
 ---
 title: Render Functions & JSX
 type: guide
-order: 303
+order: 402
 ---
 
 ## Basics

--- a/src/v2/guide/routing.md
+++ b/src/v2/guide/routing.md
@@ -1,7 +1,7 @@
 ---
 title: Routing
 type: guide
-order: 501
+order: 601
 ---
 
 ## Official Router

--- a/src/v2/guide/single-file-components.md
+++ b/src/v2/guide/single-file-components.md
@@ -1,7 +1,7 @@
 ---
 title: Single File Components
 type: guide
-order: 402
+order: 502
 ---
 
 ## Introduction

--- a/src/v2/guide/ssr.md
+++ b/src/v2/guide/ssr.md
@@ -1,7 +1,7 @@
 ---
 title: Server-Side Rendering
 type: guide
-order: 503
+order: 603
 ---
 
 ## The Complete SSR Guide

--- a/src/v2/guide/state-management.md
+++ b/src/v2/guide/state-management.md
@@ -1,7 +1,7 @@
 ---
 title: State Management
 type: guide
-order: 502
+order: 602
 ---
 
 ## Official Flux-Like Implementation

--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -1,7 +1,7 @@
 ---
 title: Meet the Team
 type: guide
-order: 703
+order: 803
 ---
 
 {% raw %}

--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -1,7 +1,7 @@
 ---
 title: TypeScript Support
 type: guide
-order: 404
+order: 504
 ---
 
 ## Important 2.2.0+ Change Notice for TS + webpack 2 users

--- a/src/v2/guide/unit-testing.md
+++ b/src/v2/guide/unit-testing.md
@@ -1,7 +1,7 @@
 ---
 title: Unit Testing
 type: guide
-order: 403
+order: 503
 ---
 
 ## Setup and Tooling

--- a/themes/vue/layout/partials/toc.ejs
+++ b/themes/vue/layout/partials/toc.ejs
@@ -11,6 +11,9 @@
             <% if (fileName === 'mixins') { %>
                 <li><h3>Reusability & Composition</h3></li>
             <% } %>
+            <% if (fileName === 'reactivity') { %>
+                <li><h3>Advanced / Internals</h3></li>
+            <% } %>
             <% if (fileName === 'deployment') { %>
                 <li><h3>Tooling</h3></li>
             <% } %>


### PR DESCRIPTION
Per this [suggestion](https://github.com/vuejs/vuejs.org/pull/1086#issuecomment-326604000), added an "Advanced / Internals" section and moved the reactivity and render function docs to it.