### PR TITLE
fix: adjust padding for content section

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -17,7 +17,7 @@
   padding: 2.2em 0
   max-width: 600px
   margin: 0 auto
-  padding-left: 30px
+  padding-left: 50px
   &.api
     > a:first-of-type > h2
       margin-top: 0


### PR DESCRIPTION
adjust padding for the content section

**before**

![before](https://user-images.githubusercontent.com/20282546/30014016-96bfc73c-9167-11e7-835c-86373b73a876.png)

**after**

![after](https://user-images.githubusercontent.com/20282546/30014021-9bab1c92-9167-11e7-92d7-633a04e010c2.png)
