### PR TITLE
Typo: "let's cheat" should be "let's chat"

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -132,7 +132,7 @@ Vue.component('my-component', {
 })
 ```
 
-Then Vue will halt and emit warnings in the console, telling you that `data` must be a function for component instances. It's good to understand why the rules exist though, so let's cheat.
+Then Vue will halt and emit warnings in the console, telling you that `data` must be a function for component instances. It's good to understand why the rules exist though, so let's chat.
 
 ``` html
 <div id="example-2">


### PR DESCRIPTION
I believe the intention was for the phrase to be `let's chat` instead of `let's cheat`.  Full sentence comparison below.

```
BEFORE:
It’s good to understand why the rules exist though, so let’s cheat.

AFTER:
It’s good to understand why the rules exist though, so let’s chat.
```