### PR TITLE
Add v-bind example to components

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -327,17 +327,28 @@ new Vue({
 </script>
 {% endraw %}
 
-When you need to pass an entire object as a set of props (like the spread operator), you can use `v-bind` without specifying a key.
+If you want to pass all the properties in an object as props, you can use `v-bind` without an argument (`v-bind` instead of `v-bind:prop-name`. For example, given a `todo` object:
 
 ``` js
-Vue.component('person', {
-  props: ['name', 'age'],
-  template: '<span>{{ name }} ({{ age }})</span>'
-})
+todo: { 
+  text: 'Learn Vue', 
+  isComplete: false 
+}
 ```
 
+Then:
+
 ``` html
-<child v-bind="{ name: 'Bob', age: 25 }"></child>
+<todo-item v-bind="todo"></todo-item>
+```
+
+Will be equivalent to:
+
+``` html
+<todo-item 
+  v-bind:text="todo.text"
+  v-bind:is-complete="todo.isComplete"
+></todo-item>
 ```
 
 ### Literal vs. Dynamic

--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -327,6 +327,19 @@ new Vue({
 </script>
 {% endraw %}
 
+When you need to pass an entire object as a set of props (like the spread operator), you can use `v-bind` without specifying a key.
+
+``` js
+Vue.component('person', {
+  props: ['name', 'age'],
+  template: '<span>{{ name }} ({{ age }})</span>'
+})
+```
+
+``` html
+<child v-bind="{ name: 'Bob', age: 25 }"></child>
+```
+
 ### Literal vs. Dynamic
 
 A common mistake beginners tend to make is attempting to pass down a number using the literal syntax:


### PR DESCRIPTION
There's no example of using `v-bind` for multiple props in the guide, only in the API references. This PR adds a quick example in the Components section.