### PR TITLE
[Website]: New item `Vue Server Renderer` in main menu

### DIFF
--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -17,6 +17,7 @@
     <li><ul>
       <li><a href="https://router.vuejs.org/" class="nav-link" target="_blank">Vue Router</a></li>
       <li><a href="https://vuex.vuejs.org/" class="nav-link" target="_blank">Vuex</a></li>
+      <li><a href="https://ssr.vuejs.org/" class="nav-link" target="_blank">Vue Server Renderer</a></li>
     </ul></li>
     <li><h4>Resource Lists</h4></li>
     <li><ul>


### PR DESCRIPTION
Because we have a great full documentation, and because we have now a Scalling Up section that speaks about :

— Routing (Vue Router),
— State Management (Vuex), and
— Server-Side Rendering (Vue Server Renderer)

I think it should be a good thing to propose it directly from main Ecosystem menu.

What are your throughs about this @chrisvfritz?