### PR TITLE
Unified all single quotes into double quotes in CSS.

### DIFF
--- a/themes/vue/source/css/_common.styl
+++ b/themes/vue/source/css/_common.styl
@@ -96,13 +96,13 @@ a.button
       height: 15px
       font-weight: 600
   &.html .code:before
-    content: 'HTML'
+    content: "HTML"
   &.js .code:before
-    content: 'JS'
+    content: "JS"
   &.bash .code:before
-    content: 'Shell'
+    content: "Shell"
   &.css .code:before
-    content: 'CSS'
+    content: "CSS"
 
 #main
   position: relative

--- a/themes/vue/source/css/_settings.styl
+++ b/themes/vue/source/css/_settings.styl
@@ -1,7 +1,7 @@
 // font faces
-$body-font = 'Source Sans Pro', 'Helvetica Neue', Arial, sans-serif
-$logo-font = 'Dosis', 'Source Sans Pro', 'Helvetica Neue', Arial, sans-serif
-$code-font = 'Roboto Mono', Monaco, courier, monospace
+$body-font = "Source Sans Pro", "Helvetica Neue", Arial, sans-serif
+$logo-font = "Dosis", "Source Sans Pro", "Helvetica Neue", Arial, sans-serif
+$code-font = "Roboto Mono", Monaco, courier, monospace
 
 // font sizes
 $body-font-size = 15px

--- a/themes/vue/source/css/_team.styl
+++ b/themes/vue/source/css/_team.styl
@@ -56,7 +56,7 @@
       // .distance
       //   position: relative
       //   &:before
-      //     content: '\f1eb'
+      //     content: "\f1eb"
       //     font-family: FontAwesome
       //     position: absolute
       //     top: 50%
@@ -68,7 +68,7 @@
         cursor: help
         color: steelblue
         &:after
-          content: '\f06a'
+          content: "\f06a"
           font-family: FontAwesome
           font-size: .75em
           vertical-align: super
@@ -87,7 +87,7 @@
         font-size: .84em
         font-weight: 600
         &::after
-          content: ''
+          content: ""
           margin-right: 7px
         i
           width: 14px
@@ -102,16 +102,16 @@
         font-weight: 600
         &::after
           display: block
-          content: ' '
+          content: " "
           margin-top: .6em
       li
         display: inline-block
         &::after
           display: inline-block
-          content: '·'
+          content: "·"
           margin: 0 8px
         &:last-child::after
-          content: ''
+          content: ""
       .social
         a
           display: inline-block

--- a/themes/vue/source/css/index.styl
+++ b/themes/vue/source/css/index.styl
@@ -1,6 +1,6 @@
 @import "_common"
 @import "_header"
-@import '_sidebar'
+@import "_sidebar"
 @import "_sponsor"
 
 $width = 900px

--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -51,7 +51,7 @@
     margin: 0 0 1em
   h2, h3
     &:before
-      content: ''
+      content: ""
       display: block
       margin-top: -1 * $heading-link-padding-top
       height: $heading-link-padding-top
@@ -151,12 +151,12 @@
     &.tip
       border-left-color: $red
       &:before
-        content: '!'
+        content: "!"
         background-color: $red
     &.success
       border-left-color: $green
       &:before
-        content: '\f00c'
+        content: "\f00c"
         font-family: FontAwesome
         background-color: $green
 
@@ -215,7 +215,7 @@
       margin: auto
     h2, h3
       &:before
-        content: ''
+        content: ""
         display: block
         margin-top: -1 * $mobile-heading-link-padding-top
         height: $mobile-heading-link-padding-top

--- a/themes/vue/source/css/search.styl
+++ b/themes/vue/source/css/search.styl
@@ -1,4 +1,4 @@
-@import '_settings'
+@import "_settings"
 
 $border = #ddd
 


### PR DESCRIPTION
I found `'` and `"` mixed in CSS files. And they are 50%-50% used in:

* `@import` rules
* `font-family` values
* `content` values
* attribute selectors

So I tried to unified them all into double quotes. Hope to be helpful.

Thanks.