### PR TITLE
Bug in select2 wrapper component example (on options changed)

### DIFF
--- a/src/v2/examples/select2.md
+++ b/src/v2/examples/select2.md
@@ -6,4 +6,4 @@ order: 8
 
 > In this example we are integrating a 3rd party jQuery plugin (select2) by wrapping it inside a custom component.
 
-<iframe width="100%" height="500" src="https://jsfiddle.net/fruqrvdL/456/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+<iframe width="100%" height="500" src="https://jsfiddle.net/morcs/anvadawu/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>

--- a/src/v2/examples/select2.md
+++ b/src/v2/examples/select2.md
@@ -6,4 +6,4 @@ order: 8
 
 > In this example we are integrating a 3rd party jQuery plugin (select2) by wrapping it inside a custom component.
 
-<iframe width="100%" height="500" src="https://jsfiddle.net/morcs/anvadawu/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+<iframe width="100%" height="500" src="https://jsfiddle.net/chrisvfritz/d131Lebj/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>


### PR DESCRIPTION
I found when using this - if the options change after rendering, the new set gets appended to the existing set rather than replacing them. Adding the empty() call in the options watch solved this.

I'm not sure how to update the jsfiddle so I linked to my fork of it, happy to change as needed!