### PR TITLE
Update components.md

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -1312,7 +1312,7 @@ In our case, let's make that point the `tree-folder` component. We know the chil
 
 ``` js
 beforeCreate: function () {
-  this.$options.components.TreeFolderContents = require('./tree-folder-contents.vue').default
+  this.$options.components.TreeFolderContents = require('./tree-folder-contents.vue')
 }
 ```
 


### PR DESCRIPTION
To fix circular reference in webpack, change `require('./tree-folder-contents.vue').default` to `require('./tree-folder-contents.vue')`
my env:
```
nodejs: 6.9.1
vuejs: 2.3.4
webpack: 2.7.1
```