### PR TITLE
style guide - missing no

### DIFF
--- a/src/v2/guide/style-guide.md
+++ b/src/v2/guide/style-guide.md
@@ -630,7 +630,7 @@ components/
 
 **Components with no content should be self-closing in single-file components, string templates, and JSX - but never in DOM templates.**
 
-Components that self-close communicate that they not only have no content, but are **meant** to have content. It's the difference between a blank page in a book and one labeled "This page intentionally left blank." Your code is also cleaner without the unnecessary closing tag.
+Components that self-close communicate that they not only have no content, but are **meant** to have no content. It's the difference between a blank page in a book and one labeled "This page intentionally left blank." Your code is also cleaner without the unnecessary closing tag.
 
 Unfortunately, HTML doesn't allow custom elements to be self-closing - only [official "void" elements](https://www.w3.org/TR/html/syntax.html#void-elements). That's why the strategy is only possible when Vue's template compiler can reach the template before the DOM, then serve the DOM spec-compliant HTML.
 


### PR DESCRIPTION
Missing No. Ya know, from Pokemon. Also the word "no" is missing in a sentence that should definitely have an extra "no".