### PR TITLE
Replace <p> tag with <span> in app3

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -99,7 +99,7 @@ It's easy to toggle the presence of an element, too:
 
 ``` html
 <div id="app-3">
-  <p v-if="seen">Now you see me</p>
+  <span v-if="seen">Now you see me</span>
 </div>
 ```
 


### PR DESCRIPTION
The code snippet uses `<p>`, but the actual demo uses `<span>`