### PR TITLE
Sidebar not fully displayed in pages with short content in Safari 11.0

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -173,6 +173,7 @@
   font-size: .9em
 
 #main.fix-sidebar
+  position: static
   .sidebar
     position: fixed
 


### PR DESCRIPTION
For example as the screenshot of https://vuejs.org/v2/guide/ssr.html in my display.

![2017-10-01 6 14 28](https://user-images.githubusercontent.com/206848/31053665-260edd38-a6d5-11e7-8eca-075cd4689021.png)

The bottom area of the page is blank. After this commit it works fine in my Safari and Chrome but I guess it needs more test.

Thanks.