### PR TITLE
Update Index.md (bad example repeated as good)

### DIFF
--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -1524,14 +1524,6 @@ By default, Vue updates the DOM as efficiently as possible. That means when swit
 </div>
 ```
 
-``` html
-<p v-if="error">
-  Error: {{ error }}
-</p>
-<div v-else>
-  {{ results }}
-</div>
-```
 {% raw %}</div>{% endraw %}
 
 


### PR DESCRIPTION
Drop the 
``` html
<p v-if="error">
  Error: {{ error }}
</p>
<div v-else>
  {{ results }}
</div>
```
In the **Good** example, the exact same example was given as in the **bad** example for the rule : 
**It's usually best to use `key` with `v-if` + `v-else`, if they are the same element type (e.g. both `<div>` elements).**

See here https://github.com/vuejs/vuejs.org/blob/master/src/v2/style-guide/index.md#good-24
