### PR TITLE
Reduced #ad z-index to 1 in media query

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -185,7 +185,7 @@
   .content.with-sidebar
     margin-left: 290px
   #ad
-    z-index: 7
+    z-index: 1
     position: relative
     padding: 0
     bottom: 0


### PR DESCRIPTION
On my MBP 13in laptop in Firefox 55.0.3 and Safari 11.0, the carbon ad in the main content would overflow with the menu, blocking out the dropdowns.