### PR TITLE
Add Additional Resources to ecosystem dropdown

### DIFF
--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -14,7 +14,7 @@
         <li><a href="https://vue-loader.vuejs.org" class="nav-link" target="_blank">Vue Loader</a></li>
       </ul>
     </li>
-    <li><h4>Core Plugins</h4></li>
+    <li><h4>Core Libraries</h4></li>
     <li><ul>
       <li><a href="https://router.vuejs.org/" class="nav-link" target="_blank">Vue Router</a></li>
       <li><a href="https://vuex.vuejs.org/" class="nav-link" target="_blank">Vuex</a></li>

--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -26,7 +26,13 @@
       <li><a href="https://curated.vuejs.org/" class="nav-link" target="_blank">Vue Curated</a></li>
       <li><a href="https://github.com/vuejs/awesome-vue" class="nav-link" target="_blank">Awesome Vue</a></li>
     </ul></li>
+    <li><h4>Additional Resources</h4></li>
+    <li>
+      <ul>
+        <li><a href="https://vue-loader.vuejs.org" class="nav-link" target="_blank">Vue Loader</a></li>
+        <li><a href="http://vuejs-templates.github.io/webpack/" class="nav-link" target="_blank">Webpack template</a></li>
+        <li><a href="https://github.com/vuejs/vue-cli" class="nav-link" target="_blank">Vue CLI</a></li>
+      </ul>
+    </li>
   </ul>
 </li>
-
-

--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -6,7 +6,20 @@
     <li><ul>
       <li><a href="https://forum.vuejs.org/" class="nav-link" target="_blank">Forum</a></li>
       <li><a href="https://chat.vuejs.org/" class="nav-link" target="_blank">Chat</a></li>
-      <li><a href="https://github.com/vuejs-templates" class="nav-link" target="_blank">Templates</a></li>
+    </ul></li>
+    <li><h4>Tooling</h4></li>
+    <li>
+      <ul>
+        <li><a href="https://github.com/vuejs/vue-devtools" class="nav-link" target="_blank">Devtools</a></li>
+        <li><a href="https://vuejs-templates.github.io/webpack" class="nav-link" target="_blank">Webpack Template</a></li>
+        <li><a href="https://vue-loader.vuejs.org" class="nav-link" target="_blank">Vue Loader</a></li>
+      </ul>
+    </li>
+    <li><h4>Core Plugins</h4></li>
+    <li><ul>
+      <li><a href="https://router.vuejs.org/" class="nav-link" target="_blank">Vue Router</a></li>
+      <li><a href="https://vuex.vuejs.org/" class="nav-link" target="_blank">Vuex</a></li>
+      <li><a href="https://ssr.vuejs.org/" class="nav-link" target="_blank">Vue Server Renderer</a></li>
     </ul></li>
     <li><h4>News</h4></li>
     <li><ul>
@@ -14,25 +27,11 @@
       <li><a href="https://medium.com/the-vue-point" class="nav-link" target="_blank">Blog</a></li>
       <li><a href="https://vuejobs.com/?ref=vuejs" class="nav-link" target="_blank">Jobs</a></li>
     </ul></li>
-    <li><h4>Core Plugins</h4></li>
-    <li><ul>
-      <li><a href="https://router.vuejs.org/" class="nav-link" target="_blank">Vue Router</a></li>
-      <li><a href="https://vuex.vuejs.org/" class="nav-link" target="_blank">Vuex</a></li>
-      <li><a href="https://ssr.vuejs.org/" class="nav-link" target="_blank">Vue Server Renderer</a></li>
-    </ul></li>
     <li><h4>Resource Lists</h4></li>
     <li><ul>
       <li><a href="https://github.com/vuejs" class="nav-link" target="_blank">Official Repos</a></li>
       <li><a href="https://curated.vuejs.org/" class="nav-link" target="_blank">Vue Curated</a></li>
       <li><a href="https://github.com/vuejs/awesome-vue" class="nav-link" target="_blank">Awesome Vue</a></li>
     </ul></li>
-    <li><h4>Additional Resources</h4></li>
-    <li>
-      <ul>
-        <li><a href="https://vue-loader.vuejs.org" class="nav-link" target="_blank">Vue Loader</a></li>
-        <li><a href="http://vuejs-templates.github.io/webpack/" class="nav-link" target="_blank">Webpack template</a></li>
-        <li><a href="https://github.com/vuejs/vue-cli" class="nav-link" target="_blank">Vue CLI</a></li>
-      </ul>
-    </li>
   </ul>
 </li>

--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -1,7 +1,6 @@
 <li class="nav-dropdown-container ecosystem">
   <a class="nav-link">Ecosystem</a><span class="arrow"></span>
   <ul class="nav-dropdown">
-    <li><a href="https://github.com/vuejs/roadmap" class="nav-link" target="_blank">Roadmap</a></li>
     <li><h4>Help</h4></li>
     <li><ul>
       <li><a href="https://forum.vuejs.org/" class="nav-link" target="_blank">Forum</a></li>
@@ -23,6 +22,7 @@
     </ul></li>
     <li><h4>News</h4></li>
     <li><ul>
+      <li><a href="https://github.com/vuejs/roadmap" class="nav-link" target="_blank">Roadmap</a></li>
       <li><a href="https://twitter.com/vuejs" class="nav-link" target="_blank">Twitter</a></li>
       <li><a href="https://medium.com/the-vue-point" class="nav-link" target="_blank">Blog</a></li>
       <li><a href="https://vuejobs.com/?ref=vuejs" class="nav-link" target="_blank">Jobs</a></li>


### PR DESCRIPTION
I visited _vuejs.org_ for the purpose of visiting vue-loader documentation and noticed it wasn't listed. I feel it is a crucial aspect of developing vue and would suggest adding it alongside the ecosystem dropdown.

These three links didn't seem to fit the pattern of the other headers so I created another header. However, if others feel they can be nested under an existing header or one named differently (eg. - 'Getting Started'), I would be happy to make that change. 

Thank you all for your great work around this project. I'm happy to help however I can.

Dave