### PR TITLE
Fix: Demystified markdown logic

### DIFF
--- a/src/v2/examples/index.md
+++ b/src/v2/examples/index.md
@@ -6,4 +6,4 @@ order: 0
 
 > Dead simple Markdown editor.
 
-<iframe width="100%" height="500" src="https://jsfiddle.net/chrisvfritz/rdjjpc7a/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+<iframe width="100%" height="500" src="https://jsfiddle.net/rdjjpc7a/6303/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>

--- a/src/v2/examples/index.md
+++ b/src/v2/examples/index.md
@@ -6,4 +6,4 @@ order: 0
 
 > Dead simple Markdown editor.
 
-<iframe width="100%" height="500" src="https://jsfiddle.net/rdjjpc7a/6303/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+<iframe width="100%" height="500" src="https://jsfiddle.net/chrisvfritz/0dzvcf4d/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>


### PR DESCRIPTION
I have changes jsfiddle link with a similar jsfiddle. 

The difference between two jsfiddle is in javascript code, `marked()` has a comment mentioning its source as external library. 

This is important because it is easy to overlook that `marked()` comes from an external library instead of Vue, especially for a beginner.
