### PR TITLE
[Website]: Let menu to be above add

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -185,7 +185,7 @@
   .content.with-sidebar
     margin-left: 290px
   #ad
-    z-index: 7
+    z-index: 1
     position: relative
     padding: 0
     bottom: 0


### PR DESCRIPTION
If you open menu you can see this problem:

![image](https://user-images.githubusercontent.com/3882169/31274236-64f70834-aa92-11e7-96e6-007415be10de.png)

To fix it, just set the z-index: 7 to 1. There is an explanation why add are so high in z-index order? Add should never to be more important than content, and worth, than navigation.

![image](https://user-images.githubusercontent.com/3882169/31274308-a9bee2a2-aa92-11e7-8496-a142d5d458fd.png)


