### PR TITLE
Make the statement less definitive

### DIFF
--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -118,7 +118,8 @@ new Vue({
 
 There are also other hooks which will be called at different stages of the instance's lifecycle, such as [`mounted`](../api/#mounted), [`updated`](../api/#updated), and [`destroyed`](../api/#destroyed). All lifecycle hooks are called with their `this` context pointing to the Vue instance invoking it.
 
-<p class="tip">Don't use [arrow functions](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions) on an options property or callback, such as `created: () => console.log(this.a)` or `vm.$watch('a', newValue => this.myMethod())`. Since arrow functions are bound to the parent context, `this` will not be the Vue instance as you'd expect and it's very likely that `this.a` or `this.myMethod` will be undefined.</p>
+<p class="tip">Don't use [arrow functions](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions) on an options property or callback, such as `created: () => console.log(this.a)` or `vm.$watch('a', newValue => this.myMethod())`. Since arrow functions are bound to the parent context, `this` will not be the Vue instance as you'd expect, often resulting in errors such as `Uncaught TypeError: Cannot read property of undefined` or `Uncaught TypeError: this.myMethod is not a function`.</p>
+
 
 ## Lifecycle Diagram
 

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -118,7 +118,7 @@ new Vue({
 
 There are also other hooks which will be called at different stages of the instance's lifecycle, such as [`mounted`](../api/#mounted), [`updated`](../api/#updated), and [`destroyed`](../api/#destroyed). All lifecycle hooks are called with their `this` context pointing to the Vue instance invoking it.
 
-<p class="tip">Don't use [arrow functions](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions) on an options property or callback, such as `created: () => console.log(this.a)` or `vm.$watch('a', newValue => this.myMethod())`. Since arrow functions are bound to the parent context, `this` will not be the Vue instance as you'd expect and `this.a` or `this.myMethod` will be undefined.</p>
+<p class="tip">Don't use [arrow functions](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Functions/Arrow_functions) on an options property or callback, such as `created: () => console.log(this.a)` or `vm.$watch('a', newValue => this.myMethod())`. Since arrow functions are bound to the parent context, `this` will not be the Vue instance as you'd expect and it's very likely that `this.a` or `this.myMethod` will be undefined.</p>
 
 ## Lifecycle Diagram
 


### PR DESCRIPTION
The current statement reads: 

> Since arrow functions are bound to the parent context, `this` will not be the Vue instance as you'd expect and `this.a` or `this.myMethod` will be undefined.

which is true in most, but not all, of the cases. If the parent context by any chance has `a` or `myMethod`, `this.a` and `this.myMethod` won't be undefined: https://jsfiddle.net/phanan/Lwh1sye2/1/

This PR aims to make the statement less definitive. 