### PR TITLE
Portuguese language

### DIFF
--- a/themes/vue/layout/partials/language_dropdown.ejs
+++ b/themes/vue/layout/partials/language_dropdown.ejs
@@ -5,7 +5,7 @@
     <li><a href="https://jp.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">日本語</a></li>
     <li><a href="https://ru.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">Русский</a></li>
     <li><a href="https://kr.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">한국어</a></li>
-    <li><a href="https://br.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">Português</a></li>
+    <li><a href="https://br.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">Português (Brazil)</a></li>
     <li><a href="https://fr.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">Français</a></li>
   </ul>
 </li>


### PR DESCRIPTION
Better identification for the Brazillian language, since there are several major diferences between Portuguese (Portugal) from Portuguese (Brazil).