### PR TITLE
Give example of envify in a gulp pipeline

### DIFF
--- a/src/v2/guide/deployment.md
+++ b/src/v2/guide/deployment.md
@@ -45,7 +45,23 @@ module.exports = {
   ``` bash
   NODE_ENV=production browserify -g envify -e main.js | uglifyjs -c -m > build.js
   ```
+- Or use [envify](https://github.com/hughsk/envify) in your gulp build pipeline:
 
+  ``` js
+  // use the envify custom module to specify environment variables
+  var envify = require('envify/custom');
+  ...
+  browserify(browserifyOptions)
+    .transform(vueify),
+    .transform(
+      {
+        global: true, // required in order to process node_modules files (including the vue module)
+      }, 
+      envify({NODE_ENV: 'production'})
+    )
+    .bundle()
+    ... // rest of gulp stream processing
+  ```
 #### Rollup
 
 Use [rollup-plugin-replace](https://github.com/rollup/rollup-plugin-replace):

--- a/src/v2/guide/deployment.md
+++ b/src/v2/guide/deployment.md
@@ -45,23 +45,23 @@ module.exports = {
   ``` bash
   NODE_ENV=production browserify -g envify -e main.js | uglifyjs -c -m > build.js
   ```
-- Or use [envify](https://github.com/hughsk/envify) in your gulp build pipeline:
+
+- Or, using [envify](https://github.com/hughsk/envify) with Gulp:
 
   ``` js
-  // use the envify custom module to specify environment variables
-  var envify = require('envify/custom');
-  ...
+  // Use the envify custom module to specify environment variables
+  var envify = require('envify/custom')
+
   browserify(browserifyOptions)
     .transform(vueify),
     .transform(
-      {
-        global: true, // required in order to process node_modules files (including the vue module)
-      }, 
-      envify({NODE_ENV: 'production'})
+      // Required in order to process node_modules files
+      { global: true },
+      envify({ NODE_ENV: 'production' })
     )
     .bundle()
-    ... // rest of gulp stream processing
   ```
+
 #### Rollup
 
 Use [rollup-plugin-replace](https://github.com/rollup/rollup-plugin-replace):


### PR DESCRIPTION
As the vue development warnings are in a node_modules file it is easy to miss the configuration option `global: true` when using envify in a gulp/browserify pipeline