### PR TITLE
Documented how to use v-cloak together with slots

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1957,6 +1957,8 @@ type: api
   ```
 
   The `<div>` will not be visible until the compilation is done.
+  
+  **Note:** When using `v-cloak` with [Slots](https://vuejs.org/v2/api/#slot-1), be sure to use `v-cloak` inside the file you are including the component from, the slot will be overwritten.
 
 ### v-once
 


### PR DESCRIPTION
One needs to use v-cloak in the file that defines the slot contents. This has not been documented before.