### PR TITLE
docs: fix url typo to vue-class-component repo

### DIFF
--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -72,7 +72,7 @@ export default {
 
 ## Class-Style Vue Components
 
-If you prefer a class-based API when declaring components, you can use the officially maintained [vue-class-component](https://github.com/vuejs/vue-class-componen) decorator:
+If you prefer a class-based API when declaring components, you can use the officially maintained [vue-class-component](https://github.com/vuejs/vue-class-component) decorator:
 
 ``` ts
 import Vue from 'vue'


### PR DESCRIPTION
The URL was typed wrong and led to a GitHub 404 page.