### PR TITLE
Add the correct display to <details> in IE and Edge

### DIFF
--- a/themes/vue/source/css/_style-guide.styl
+++ b/themes/vue/source/css/_style-guide.styl
@@ -35,6 +35,7 @@ $style-guide-priority-d-color = white
   details, .style-enforcement
     background-color #eee
   details
+    display block // Add the correct display in IE and Edge.
     position relative
     &:not([open]) summary
       &::after


### PR DESCRIPTION
The `<details>` and `<summary>` elements are [not supported in IE and Edge](https://caniuse.com/#search=details). Adding a polyfill may not be worth it but in order to apply CSS styles correctly to these elements, a correct `display` should be added. 

Adding the correct `display` to `<summary>` is [a little bit tricky](https://developer.mozilla.org/nl/docs/Web/HTML/Element/details#Example_with_styling). For now,  correcting the `display` of `<details>` solves the problem.

Screenshot: IE11 on Windows Phone 8.1.

![vuejsorg-wp-details](https://user-images.githubusercontent.com/13110140/31049223-fa31b7d6-a62e-11e7-90f7-e0203d98b69e.jpg)

[Screenshots of IE11 and Edge on Windows 10.](https://developer.microsoft.com/en-us/microsoft-edge/tools/screenshots/?url=http%3A%2F%2Fvuejs.org%2Fv2%2Fstyle-guide)
