### PR TITLE
Update Vetur type inference for SFCs

### DIFF
--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -56,19 +56,7 @@ const Component = {
 }
 ```
 
-Note that when using Vetur with SFCs, type inference will be automatically applied to the default export, so there's no need to wrap it in `Vue.extend`:
-
-``` html
-<template>
-  ...
-</template>
-
-<script lang="ts">
-export default {
-  // type inference enabled
-}
-</script>
-```
+Note that when using Vetur with SFCs, even though type inference will be automatically applied to the default export, `Vue.extend` will still need to wrap the exported object, otherwise Typescript will throw a compile error later.
 
 ## Class-Style Vue Components
 

--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -56,8 +56,6 @@ const Component = {
 }
 ```
 
-Note that when using Vetur with SFCs, even though type inference will be automatically applied to the default export, `Vue.extend` will still need to wrap the exported object, otherwise Typescript will throw a compile error later.
-
 ## Class-Style Vue Components
 
 If you prefer a class-based API when declaring components, you can use the officially maintained [vue-class-component](https://github.com/vuejs/vue-class-component) decorator:


### PR DESCRIPTION
The Typescript guide says that exporting `Vue.extend({...})` will no longer be necessary in Typescript-based SFCs due to Vetur having correct syntax highlighting and type inference. Despite the fact that Vetur deals with this correctly without wrapping, the Typescript compiler will produce an error when the default export isn't wrapped, presumably because it does not make the same assumptions as Vetur.

The official Typescript Vue starter guide references this as well, stating that `Vue.extend({...})` is still required even with Vetur.

This change is to remove that snippet in the Typescript guide so that users aren't confused that their Typescript compilers are erroring out despite Vetur working correctly.