### PR TITLE
Update typescript.md

### DIFF
--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -64,9 +64,10 @@ Note that when using Vetur with SFCs, type inference will be automatically appli
 </template>
 
 <script lang="ts">
-export default {
-  // type inference enabled
-}
+import Vue, {ComponentOptions} from 'vue'
+  export default {
+    // type inference enabled
+  } as ComponentOptions<Vue>
 </script>
 ```
 


### PR DESCRIPTION
The typesrcipt error cann't be checked by Vuter until you assert the  Object type to ComponentOptions<Vue>.