### PR TITLE
Add a note about `this` type inference

### DIFF
--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -31,6 +31,8 @@ We also plan to provide an option to scaffold a ready-to-go Vue + TypeScript pro
 }
 ```
 
+Note that you have to include `strict: true` (or at least `noImplicitThis: true` which is a part of `strict` flag) to leverage type checking of `this` in component methods otherwise it is always treated as `any` type.
+
 See [TypeScript compiler options docs](https://www.typescriptlang.org/docs/handbook/compiler-options.html) for more details.
 
 ## Development Tooling


### PR DESCRIPTION
Although the recommended configuration has `strict: true`, I saw some people does not include it in their config and confused why `this` type is not inferred.

I guess the beginners of TypeScript may not understand what is `stricter inference for data properties on this`. So I added a more description about that.