### PR TITLE
Recommend return type annotation

### DIFF
--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -139,3 +139,38 @@ var vm = new Vue({
   myOption: 'Hello'
 })
 ```
+
+## Annotating Return Type
+
+Vue's type definition is prone to [circular reference](https://github.com/Microsoft/TypeScript/issues/12846#issuecomment-270296195) of `this`.
+Annotating return type is highly recommended to avoid such error.
+
+```ts
+import Vue, { VNode } from 'vue'
+
+const Component = Vue.extend({
+  data() {
+    return {
+      msg: 'Hello'
+    }
+  },
+  methods: {
+    // need annotation due to `this` in return type
+    greet(): string {
+      return this.msg + ' world'
+    }
+  },
+  computed: {
+    // need annotation
+    greeting(): string {
+      return this.greet() + '!'
+    }
+  },
+  // `createElement` is inferred, but `render` needs return type
+  render(createElement): VNode {
+    return createElement('div', this.greeting)
+  }
+})
+```
+
+If you find type inference or member completion doesn't work, you can try annotating method return type.

--- a/src/v2/guide/typescript.md
+++ b/src/v2/guide/typescript.md
@@ -140,10 +140,10 @@ var vm = new Vue({
 })
 ```
 
-## Annotating Return Type
+## Annotating Return Types
 
-Vue's type definition is prone to [circular reference](https://github.com/Microsoft/TypeScript/issues/12846#issuecomment-270296195) of `this`.
-Annotating return type is highly recommended to avoid such error.
+Because of the circular nature of Vue's declaration files, TypeScript may have difficulties inferring the types of certain methods.
+For this reason, you may need to annotate the return type on methods like `render` and those in `computed`.
 
 ```ts
 import Vue, { VNode } from 'vue'
@@ -173,4 +173,5 @@ const Component = Vue.extend({
 })
 ```
 
-If you find type inference or member completion doesn't work, you can try annotating method return type.
+If you find type inference or member completion isn't working, annotating certain methods may help address these problems.
+Using the `--noImplicitAny` option will help find many of these unannotated methods.


### PR DESCRIPTION
Fix https://github.com/vuejs/vue/issues/6921

TS has type inference limitation, we need to recommend users annotate their return type.


`circular dependency` might be a hard term. So I added a link to @DanielRosenwasser 's comment.

I hope this section can be clear enough for TS beginners.