### PR TITLE
Add Vietnamese option to language dropdown

### DIFF
--- a/themes/vue/layout/partials/language_dropdown.ejs
+++ b/themes/vue/layout/partials/language_dropdown.ejs
@@ -7,5 +7,6 @@
     <li><a href="https://kr.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">한국어</a></li>
     <li><a href="https://br.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">Português</a></li>
     <li><a href="https://fr.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">Français</a></li>
+    <li><a href="https://vi.vuejs.org/<%- page.path %>" class="nav-link" target="_blank">Tiếng Việt</a></li>
   </ul>
 </li>


### PR DESCRIPTION
First of all, Thanks for having the document suport Vietnamese. [Link Repo](https://github.com/vuejs-vn/vuejs.org)
But. It does not display in the language selection. might it not yet perfected (beta version). But it is essential to understand it. 
Thanks!