### PR TITLE
Update select2 wrapper component example

### DIFF
--- a/src/v2/examples/select2.md
+++ b/src/v2/examples/select2.md
@@ -6,4 +6,4 @@ order: 8
 
 > In this example we are integrating a 3rd party jQuery plugin (select2) by wrapping it inside a custom component.
 
-<iframe width="100%" height="500" src="https://jsfiddle.net/chrisvfritz/d131Lebj/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+<iframe width="100%" height="500" src="https://jsfiddle.net/d131Lebj/78/embedded/result%2Chtml%2Cjs%2Ccss" allowfullscreen="allowfullscreen" frameborder="0"></iframe>


### PR DESCRIPTION
Specify explicit path(version) for external scripts and updated jsfiddle link in docs.

Hello!
I tried run select2 example but it's not working.
I think jsfiddle is not support redirection for external resources now.
Thanks! 😀