### PR TITLE
Update directive documentation with tip relating to v-html and scoped styles

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1686,7 +1686,7 @@ type: api
 
   <p class="tip">Dynamically rendering arbitrary HTML on your website can be very dangerous because it can easily lead to [XSS attacks](https://en.wikipedia.org/wiki/Cross-site_scripting). Only use `v-html` on trusted content and **never** on user-provided content.</p>
 
-  <p class="tip">Using `scoped` styles will not work with this directive because the content isn't created by Vue's rendering system, it simply uses `innerHTML`. Instead, if you are using Vue template files, you can define multiple `<style>` tags. Most of your `(S)CSS` (or whatever flavour you are using) would go in `<style lang="scss" scoped>` and then only styles specific to `v-html` related content that cannot be scoped can go in `<style lang="scss">`.</p>
+  <p class="tip">In [single-file components](../guide/single-file-components.html), `scoped` styles will not apply to content inside `v-html`, because that HTML is not processed by Vue's template compiler. In you want to target `v-html` content with scoped CSS, you can instead use [CSS modules](https://vue-loader.vuejs.org/en/features/css-modules.html) or an additional, global `<style>` element with a manual scoping strategy such as BEM.</p>
 
 - **Example:**
 

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1686,6 +1686,8 @@ type: api
 
   <p class="tip">Dynamically rendering arbitrary HTML on your website can be very dangerous because it can easily lead to [XSS attacks](https://en.wikipedia.org/wiki/Cross-site_scripting). Only use `v-html` on trusted content and **never** on user-provided content.</p>
 
+  <p class="tip">Using `scoped` styles will not work with this directive because the content isn't created by Vue's rendering system, it simply uses `innerHTML`. Instead, if you are using Vue template files, you can define multiple `<style>` tags. Most of your `(S)CSS` (or whatever flavour you are using) would go in `<style lang="scss" scoped>` and then only styles specific to `v-html` related content that cannot be scoped can go in `<style lang="scss">`.</p>
+
 - **Example:**
 
   ```html


### PR DESCRIPTION
Adding a tip relating to the fact that v-html content is unaffected by scoped styling, and explaining an example way around it.