### PR TITLE
在【#CSS-动画-CSS-Animations】这里html用p标签容易造成误导

### DIFF
--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -229,9 +229,9 @@ new Vue({
 
 {% raw %}
 <div id="example-2" class="demo">
-  <button @click="show = !show">Toggle show</button>
+  <button @click="show = !show">Toggle show</button><br />
   <transition name="bounce">
-    <p v-show="show">Look at me!</p>
+    <span v-show="show">Look at me!</span>
   </transition>
 </div>
 


### PR DESCRIPTION
语法：transform: scale() 默认是以元素的水平垂直中心为源心，进行扩大/缩放。、

造成问题：这里用p标签，作为块级元素，它的源心就在hello文本的右侧，进行动画的时候文本在位置上，先往左移动，然后向右移动，给不注意的读者造成以为是scale出问题的错觉。针对这个，还真有人提问的，如：https://segmentfault.com/q/1010000007612783

所以应该将它更改为 非块级标签或者给定合适的宽高更方便读着理解。