### PR TITLE
Clarify falsy conditions for attribute description

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -54,6 +54,8 @@ It also works for boolean attributes - the attribute will be removed if the cond
 <button v-bind:disabled="isButtonDisabled">Button</button>
 ```
 
+This will be removed if the value is `null`, `undefined`, or `false`. `0` and `NaN` will still be displayed.
+
 ### Using JavaScript Expressions
 
 So far we've only been binding to simple property keys in our templates. But Vue.js actually supports the full power of JavaScript expressions inside all data bindings:

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -42,19 +42,19 @@ The contents of this `div` will be replaced with the value of the `rawHtml` prop
 
 ### Attributes
 
-Mustaches cannot be used inside HTML attributes, instead use a [v-bind directive](../api/#v-bind):
+Mustaches cannot be used inside HTML attributes. Instead, use a [v-bind directive](../api/#v-bind):
 
 ``` html
 <div v-bind:id="dynamicId"></div>
 ```
 
-It also works for boolean attributes - the attribute will be removed if the condition evaluates to a falsy value:
+In the case of boolean attributes, where their mere existence implies `true`, `v-bind` works a little differently. In this example: 
 
 ``` html
 <button v-bind:disabled="isButtonDisabled">Button</button>
 ```
 
-This will be removed if the value is `null`, `undefined`, or `false`. `0` and `NaN` will still be displayed.
+If `isButtonDisabled` has the value of `null`, `undefined`, or `false`, the `disabled` attribute will not even be included in the rendered `<button>` element.
 
 ### Using JavaScript Expressions
 


### PR DESCRIPTION
In #1250, Evan clarifies what values are considered falsy, so updating the attribute description to reflect that and provide a little more clarity.