### PR TITLE
docs: add mustaches vs v-html example

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -33,10 +33,28 @@ You can also perform one-time interpolations that do not update on data change b
 The double mustaches interprets the data as plain text, not HTML. In order to output real HTML, you will need to use the `v-html` directive:
 
 ``` html
-<div v-html="rawHtml"></div>
+<div>Using mustaches: {{ rawHtml }}</div>
+<div>Using v-html directive: <span v-html="rawHtml"></span></div>
 ```
 
-The contents of this `div` will be replaced with the value of the `rawHtml` property, interpreted as plain HTML - data bindings are ignored. Note that you cannot use `v-html` to compose template partials, because Vue is not a string-based templating engine. Instead, components are preferred as the fundamental unit for UI reuse and composition.
+{% raw %}
+<div id="example1" class="demo">
+  <div>Using mustaches: {{ rawHtml }}</div>
+  <div>Using v-html directive: <span v-html="rawHtml"></span></div>
+</div>
+<script>
+new Vue({
+  el: '#example1',
+  data: function () {
+  	return {
+  	  rawHtml: '<span style="color: red">This should be red.</span>'
+  	}
+  }
+})
+</script>
+{% endraw %}
+
+The contents of the `span` will be replaced with the value of the `rawHtml` property, interpreted as plain HTML - data bindings are ignored. Note that you cannot use `v-html` to compose template partials, because Vue is not a string-based templating engine. Instead, components are preferred as the fundamental unit for UI reuse and composition.
 
 <p class="tip">Dynamically rendering arbitrary HTML on your website can be very dangerous because it can easily lead to [XSS vulnerabilities](https://en.wikipedia.org/wiki/Cross-site_scripting). Only use HTML interpolation on trusted content and **never** on user-provided content.</p>
 

--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -33,14 +33,14 @@ You can also perform one-time interpolations that do not update on data change b
 The double mustaches interprets the data as plain text, not HTML. In order to output real HTML, you will need to use the `v-html` directive:
 
 ``` html
-<div>Using mustaches: {{ rawHtml }}</div>
-<div>Using v-html directive: <span v-html="rawHtml"></span></div>
+<p>Using mustaches: {{ rawHtml }}</p>
+<p>Using v-html directive: <span v-html="rawHtml"></span></p>
 ```
 
 {% raw %}
 <div id="example1" class="demo">
-  <div>Using mustaches: {{ rawHtml }}</div>
-  <div>Using v-html directive: <span v-html="rawHtml"></span></div>
+  <p>Using mustaches: {{ rawHtml }}</p>
+  <p>Using v-html directive: <span v-html="rawHtml"></span></p>
 </div>
 <script>
 new Vue({


### PR DESCRIPTION
When translating this part of the guide into Vietnamese I felt an example would explain the differences between double-mustache syntax and `v-html` directive much more clearly. If the PR is merged, we'll have something like this:

![image](https://user-images.githubusercontent.com/8056274/32701703-92a27538-c7da-11e7-9073-4d9677080a02.png)

Does this make sense?