### PR TITLE
Add a note about nextTick and render blocking to Reactivity in Depth

### DIFF
--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -118,3 +118,9 @@ Vue.component('example', {
   }
 })
 ```
+
+<p class="tip">`$nextTick` relies on native Promises, which means that heavy operations in a `$nextTick` callback can be render blocking. This is because the callback is pushed into the browsers microtask queue rather then the event loops normal queue. 
+
+For this reason, when you have heavy synchronized tasks, it’s it’s wise to avoid using `$nextTick`, or rather, combine it with a `setTimeout()`. A `setTimeout()` will have UI updates run before the callback is picked up by the event loop.
+
+`$nextTick` is better suited for when you have to do some lightweight or async operation _after_ the DOM has been updated.</p>


### PR DESCRIPTION
I'm not totally sold on the formatting for this one, but this takes the text from #814, and adds a note to the $nextTick section of Reactivity in Depth. I edited a bit for clarity, but I'm welcome to feedback.