### PR TITLE
Make id example with Html

### DIFF
--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -79,6 +79,10 @@ data: {
 
 In addition to data properties, Vue instances expose a number of useful instance properties and methods. These are prefixed with `$` to differentiate them from user-defined properties. For example:
 
+``` html
+  <div id="example"> </div>
+```
+
 ``` js
 var data = { a: 1 }
 var vm = new Vue({

--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -79,14 +79,9 @@ data: {
 
 In addition to data properties, Vue instances expose a number of useful instance properties and methods. These are prefixed with `$` to differentiate them from user-defined properties. For example:
 
-``` html
-  <div id="example"> </div>
-```
-
 ``` js
 var data = { a: 1 }
 var vm = new Vue({
-  el: '#example',
   data: data
 })
 


### PR DESCRIPTION
If you have not specified to write Html before JavaScript
Since the result is false, you should specify the ID in html

``` js
VM. $ el === document.getElementById ('example') // => false
```
