### PR TITLE
docs: add a filter example

### DIFF
--- a/src/v2/guide/filters.md
+++ b/src/v2/guide/filters.md
@@ -36,6 +36,32 @@ Vue.filter('capitalize', function (value) {
 })
 ```
 
+Below is an example of our `capitalize` filter being used:
+
+{% raw %}
+<div id="example_1" class="demo">
+  <input type="text" v-model="message">
+  <p>{{ message | capitalize }}</p>
+</div>
+<script>
+  new Vue({
+    el: '#example_1',
+    data: function () {
+      return {
+        message: 'john'
+      }
+    },
+    filters: {
+      capitalize: function (value) {
+        if (!value) return ''
+        value = value.toString()
+        return value.charAt(0).toUpperCase() + value.slice(1)
+      }
+    }
+  })
+</script>
+{% endraw %}
+
 The filter's function always receives the expression's value (the result of the former chain) as its first argument. In the above example, the `capitalize` filter function will receive the value of `message` as its argument.
 
 Filters can be chained:


### PR DESCRIPTION
Currently, we only have the code of the example, not the demo example itself. This PR would add something like this into the page:

![image](https://user-images.githubusercontent.com/8056274/32985103-deca3b4e-ccb2-11e7-9add-d28444d911ad.png)

which helps the page to be a bit more visual. What do you think?