### PR TITLE
Clarify checkbox value bindings

### DIFF
--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -309,18 +309,19 @@ But sometimes we may want to bind the value to a dynamic property on the Vue ins
 <input
   type="checkbox"
   v-model="toggle"
-  v-bind:true-value="a"
-  v-bind:false-value="b"
+  true-value="yes"
+  false-value="no"
 >
 ```
 
 ``` js
 // when checked:
-vm.toggle === vm.a
+vm.toggle === 'yes'
 // when unchecked:
-vm.toggle === vm.b
+vm.toggle === 'no'
 ```
-<p class="tip">Note that `true-value` and `false-value` only affect the Vue instance property (not the input's `value` attribute), so they don't get sent when the form is submitted to the server. As per the HTML spec, the browser only sends the value of the `value` attribute (or "on" if the `value` attribute was omitted) when the box is checked.</p>
+
+<p class="tip">The `true-value` and `false-value` attributes don't affect the input's `value` attribute, because browsers don't include unchecked boxes in form submissions. To guarantee that one of two values are submitted in a form (e.g. "yes" or "no"), use radio inputs instead.</p>
 
 ### Radio
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -320,6 +320,7 @@ vm.toggle === vm.a
 // when unchecked:
 vm.toggle === vm.b
 ```
+<p class="tip">Note that `true-value` and `false-value` only affect the Vue instance property (not the input's `value` attribute), so they don't get sent when the form is submitted to the server. As per the HTML spec, the browser only sends the value of the `value` attribute (or "on" if the `value` attribute was omitted) when the box is checked.</p>
 
 ### Radio
 

--- a/src/v2/guide/forms.md
+++ b/src/v2/guide/forms.md
@@ -321,7 +321,7 @@ vm.toggle === 'yes'
 vm.toggle === 'no'
 ```
 
-<p class="tip">The `true-value` and `false-value` attributes don't affect the input's `value` attribute, because browsers don't include unchecked boxes in form submissions. To guarantee that one of two values are submitted in a form (e.g. "yes" or "no"), use radio inputs instead.</p>
+<p class="tip">The `true-value` and `false-value` attributes don't affect the input's `value` attribute, because browsers don't include unchecked boxes in form submissions. To guarantee that one of two values is submitted in a form (e.g. "yes" or "no"), use radio inputs instead.</p>
 
 ### Radio
 


### PR DESCRIPTION
Add a "tip" box to the section on checkbox value bindings that explains how true-value and false-value only apply to the Vue instance and are *not* submitted with form data to the server.