### PR TITLE
Update comparison between `data` and `vm` objects

### DIFF
--- a/src/v2/guide/instance.md
+++ b/src/v2/guide/instance.md
@@ -47,7 +47,7 @@ var vm = new Vue({
 })
 
 // These reference the same object!
-vm.a === data.a // => true
+vm === data // => true
 
 // Setting the property on the instance
 // also affects the original data


### PR DESCRIPTION
The comparison `vm.a === data.a` does not show that `vm` and `data` reference the same object, but rather that the `a` property of both objects is the same value. My updated example compares the `vm` and `data` object directly, thereby adding to the next two examples which indicate that changes to the `vm` object's properties are reflected in the `data` (and vice-versa).