### PR TITLE
Add Bugsnag integration to errorHandler docs

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -83,7 +83,7 @@ type: api
 
   > In 2.4.0+ this hook also captures errors thrown inside Vue custom event handlers.
 
-  > [Sentry](https://sentry.io), an error tracking service, provides [official integration](https://sentry.io/for/vue/) using this option.
+  > Error tracking services [Sentry](https://sentry.io/for/vue/) and [Bugsnag](https://docs.bugsnag.com/platforms/browsers/vue/) provide official integrations using this option.
 
 ### warnHandler
 
@@ -231,7 +231,7 @@ type: api
   Vue.nextTick(function () {
     // DOM updated
   })
-  
+
   // usage as a promise (2.1.0+, see note below)
   Vue.nextTick()
     .then(function () {


### PR DESCRIPTION
Hi there 👋

I work on the JavaScript platforms at @bugsnag. We just released a complete rewrite of our [JS notifier](https://github.com/bugsnag/bugsnag-js), and along with it added first-class Vue support via our official [bugsnag-vue plugin](https://github.com/bugsnag/bugsnag-vue).

It would be great for our support to be listed here where you already mention Sentry's, and potentially beneficial for your users who may already be Bugsnag users that don't know about the new integration yet.

I reworked the wording of the section in the way I thought best, but happy for it to go a different way if desired.

Let me know what you think! Cheers

_**Before**_

![image](https://user-images.githubusercontent.com/609579/33726795-f38946aa-db6d-11e7-8cfe-e9a6e01a71a0.png)

_**After**_

![image](https://user-images.githubusercontent.com/609579/33726781-eb9a80bc-db6d-11e7-9ca3-66d4755db3b8.png)
