### PR TITLE
fix a typo in code example

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -618,7 +618,7 @@ The following
 is expanded into:
 
 ``` html
-<comp :foo="bar" @update:foo="val => bar = val"></comp>
+<comp :foo="bar" @update:foo="val => { bar = val }"></comp>
 ```
 
 For the child component to update `foo`'s value, it needs to explicitly emit an event instead of mutating the prop:


### PR DESCRIPTION
The previous code example is not correct(lost brace).It seems like the code even can't complie by vue-loader in `.vue` component.