### PR TITLE
docs: fix misspell

### DIFF
--- a/src/v2/cookbook/cookbook-contributions.md
+++ b/src/v2/cookbook/cookbook-contributions.md
@@ -54,7 +54,7 @@ This section is not required, but heavily recommended. It won't make sense to wr
 
 _optional, except when the section above is provided_
 
-This section is required when you've provided the section above about avoidance. It's important to explore other methods so that people told that something is an antipattern in certain situations are not left wondering. In doing so, consider that the web is a big tent and that many people have different codebase structures and are solving different goals. Is the app large or small? Are they integrating Vue into an existing project, or are they building from scratch? Are their users only trying to achieve one goal or many? Is there a lot of asyncronous data? All of these concerns will impact alternative implementations. A good cookbook recipe gives developers this context.
+This section is required when you've provided the section above about avoidance. It's important to explore other methods so that people told that something is an antipattern in certain situations are not left wondering. In doing so, consider that the web is a big tent and that many people have different codebase structures and are solving different goals. Is the app large or small? Are they integrating Vue into an existing project, or are they building from scratch? Are their users only trying to achieve one goal or many? Is there a lot of asynchronous data? All of these concerns will impact alternative implementations. A good cookbook recipe gives developers this context.
 
 ## Thank you
 


### PR DESCRIPTION
I have replace `asyncronous` with `asynchronous`.

```diff
- Is there a lot of asyncronous data?
+ Is there a lot of asynchronous data?
```