### PR TITLE
fix wrong anchor link in sidebar in API detail page

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -14,8 +14,9 @@
       var apiTitles = [].slice.call(apiContent.querySelectorAll('h3'))
       apiTitles.forEach(function (titleNode) {
         var methodMatch = titleNode.textContent.match(/^([^(]+)\(/)
+        var idWithoutArguments = slugize(titleNode.textContent)
         if (methodMatch) {
-          var idWithoutArguments = slugize(methodMatch[1])
+          idWithoutArguments = slugize(methodMatch[1])
           titleNode.setAttribute('id', idWithoutArguments)
           titleNode.querySelector('a').setAttribute('href', '#' + idWithoutArguments)
         }
@@ -307,8 +308,13 @@
           return ''
         }
       }).join('').replace(/\(.*\)$/, '')
+      var methodMatch = h.textContent.match(/^([^(]+)\(/)
+      var idWithoutArguments = slugize(h.textContent)
+      if (methodMatch) {
+        idWithoutArguments = slugize(methodMatch[1])
+      }
       link.innerHTML =
-        '<a class="section-link" data-scroll href="#' + h.id + '">' +
+        '<a class="section-link" data-scroll href="#' + idWithoutArguments + '">' +
           htmlEscape(text) +
         '</a>'
       return link


### PR DESCRIPTION
**Bug Description**

Navigation Bar in [API Detail Page](https://vuejs.org/v2/api/), `href` attribute are set to wrong value in some anchor link, when click, the corresponding content in the content section can not scroll to viewport. Check the links bellow `Instance Methods / Data` and `Instance Methods / Events`.

**Why it happened**

The anchor link `href ` value in navigation bar and id value for API `<h3>` element in content section have different value source.

id for `<h3>` element in the content section has two value source:

- if regular expression `/^([^(]+)\(/` can not match any substring in `textContent` in `<h3>`, then id comes from id value in `<h3>` in HTML template.

- if `/^([^(]+)\(/` do match some substring in `textContent`, then id comes from processed `textContent` value.

While the `href ` value in anchor link just comes from id value of `<h3>` in HTML template. So, `href` value in anchor link and id value in content section can be different.

**Solution**

- Unite the source of id value in `<h3>` in content section: All come from `textContent` of `<h3>` elements. 

- Unite the source of anchor link `href ` value in navigation bar and id value of  `<h3>`  elements in content: All come from `textContent` of `<h3>` elements.

The solution has been tested.
Wish I have explain the problem clearly.