### PR TITLE
Update deployment.md with Grunt example

### DIFF
--- a/src/v2/guide/deployment.md
+++ b/src/v2/guide/deployment.md
@@ -61,6 +61,29 @@ module.exports = {
     )
     .bundle()
   ```
+  
+- Or, using [envify](https://github.com/hughsk/envify) with Grunt and [grunt-browserify](https://github.com/jmreidy/grunt-browserify):
+
+  ``` js
+  // Use the envify custom module to specify environment variables
+  var envify = require('envify/custom')
+  
+  browserify: {
+    dist: {
+      options: {
+        // Function to deviate from grunt-browserify's default order
+        configure: b => b
+          .transform('vueify')
+          .transform(
+            // Required in order to process node_modules files
+            { global: true },
+            envify({ NODE_ENV: 'production' })
+          )
+          .bundle()
+      }
+    }
+  }
+  ```
 
 #### Rollup
 


### PR DESCRIPTION
While Grunt and it's Browserify implementation [grunt-browserify](https://github.com/jmreidy/grunt-browserify) are still very popular, the [Vue deployment docs](https://vuejs.org/v2/guide/deployment.html) lack any example on how to configure the production mode with Grunt. This PR adds an example, because it's configuration isn't quite obvious (you'll need to deviate from grunt-browserify's default transform order).