### PR TITLE
Adding Why Vue.js video to Introduction page

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -377,6 +377,4 @@ You may have noticed that Vue components are very similar to **Custom Elements**
 
 We've briefly introduced the most basic features of Vue.js core - the rest of this guide will cover them and other advanced features with much finer details, so make sure to read through it all!
 
-<div id="video-modal" class="modal">
-  <div class="vimeo-space" style="padding: 56.25% 0 0 0; position: relative;"><iframe src="https://player.vimeo.com/video/247494684" style="height: 100%; left: 0; position: absolute; top: 0; width: 100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
-</div>
+<div id="video-modal" class="modal"><div class="vimeo-space" style="padding: 56.25% 0 0 0; position: relative;"><iframe src="https://player.vimeo.com/video/247494684" style="height: 100%; left: 0; position: absolute; top: 0; width: 100%; margin: 0" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script></div>

--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -8,6 +8,8 @@ order: 2
 
 Vue (pronounced /vjuː/, like **view**) is a **progressive framework** for building user interfaces. Unlike other monolithic frameworks, Vue is designed from the ground up to be incrementally adoptable. The core library is focused on the view layer only, and is easy to pick up and integrate with other libraries or existing projects. On the other hand, Vue is also perfectly capable of powering sophisticated Single-Page Applications when used in combination with [modern tooling](single-file-components.html) and [supporting libraries](https://github.com/vuejs/awesome-vue#components--libraries).
 
+If you’d like to learn more about Vue before diving in, we <a id="modal-player"  href="javascript:;">created a video</a> walking through the core principles and a sample project.
+
 If you are an experienced frontend developer and want to know how Vue compares to other libraries/frameworks, check out the [Comparison with Other Frameworks](comparison.html).
 
 ## Getting Started
@@ -374,3 +376,7 @@ You may have noticed that Vue components are very similar to **Custom Elements**
 ## Ready for More?
 
 We've briefly introduced the most basic features of Vue.js core - the rest of this guide will cover them and other advanced features with much finer details, so make sure to read through it all!
+
+<div id="video-modal" class="modal">
+  <div class="vimeo-space" style="padding: 56.25% 0 0 0; position: relative;"><iframe src="https://player.vimeo.com/video/247494684" style="height: 100%; left: 0; position: absolute; top: 0; width: 100%;" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
+</div>

--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -9,6 +9,7 @@
 @import "_offline-menu"
 @import "_team"
 @import "_style-guide"
+@import "_modal"
 
 #header
   box-shadow: 0 0 1px rgba(0,0,0,.25)


### PR DESCRIPTION
As discussed with @chrisvfritz, adding a link to the Why Vue video from the Guide Introduction.  

![introduction vue js](https://user-images.githubusercontent.com/2618/34728589-454781cc-f528-11e7-93a7-c37436e6f3ba.gif)
