### PR TITLE
Modify the api doc of extends.

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -977,7 +977,7 @@ type: api
 
   Allows declaratively extending another component (could be either a plain options object or a constructor) without having to use `Vue.extend`. This is primarily intended to make it easier to extend between single file components.
 
-  This is similar to `mixins`, you can use `mixins` instead of `extends`.
+  This is similar to `mixins`.
 
 - **Example:**
 

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -977,7 +977,7 @@ type: api
 
   Allows declaratively extending another component (could be either a plain options object or a constructor) without having to use `Vue.extend`. This is primarily intended to make it easier to extend between single file components.
 
-  This is similar to `mixins`, the difference being that the component's own options takes higher priority than the source component being extended.
+  This is similar to `mixins`, you can use `mixins` instead of `extends`.
 
 - **Example:**
 


### PR DESCRIPTION
Since the merge logic are the same, user can use `mixins` instead of `extends`.