### PR TITLE
Add guide link in Vue.filter API

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -327,6 +327,8 @@ type: api
   var myFilter = Vue.filter('my-filter')
   ```
 
+- **See also:** [Filters](../guide/filters.html)
+
 ### Vue.component( id, [definition] )
 
 - **Arguments:**


### PR DESCRIPTION
Add a "see also" link in "Vue.filter", like other API(example, "Custom Directives", "Components").