### PR TITLE
Change Github to GitHub

### DIFF
--- a/themes/vue/layout/page.ejs
+++ b/themes/vue/layout/page.ejs
@@ -42,7 +42,7 @@
     <%_ } _%>
     Caught a mistake or want to contribute to the documentation?
     <a href="https://github.com/vuejs/vuejs.org/blob/master/src/<%- page.path.replace(/\.html$/, '.md') %>" target="_blank">
-      Edit this page on Github!
+      Edit this page on GitHub!
     </a>
   </div>
 </div>


### PR DESCRIPTION
Maybe it already was, and you use this spelling intentionally, but I think you need to use the original name.