### PR TITLE
The Timeline panel has been renamed to the Performance panel.

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -159,7 +159,7 @@ type: api
 
 - **Usage**:
 
-  Set this to `true` to enable component init, compile, render and patch performance tracing in the browser devtool timeline. Only works in development mode and in browsers that support the [performance.mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) API.
+  Set this to `true` to enable component init, compile, render and patch performance tracing in the browser devtool performance/timeline panel. Only works in development mode and in browsers that support the [performance.mark](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark) API.
 
 ### productionTip
 


### PR DESCRIPTION
https://developers.google.com/web/updates/2017/03/devtools-release-notes
The Timeline panel has been renamed to the Performance panel.