### PR TITLE
Add ability to translate titles in sidebar

### DIFF
--- a/themes/vue/layout/partials/sidebar.ejs
+++ b/themes/vue/layout/partials/sidebar.ejs
@@ -18,13 +18,13 @@
         Become a Sponsor
       </a>
       <h2>
-        <%-
-          type === 'api'
-            ? 'API'
-            : type === 'style-guide'
-              ? 'Style Guide<sup class="beta">beta</sup>'
-              : (type.charAt(0).toUpperCase() + type.slice(1))
-        %>
+        <% titles = {
+          api: 'API',
+          examples: 'Examples',
+          guide: 'Guide',
+          'style-guide': 'Style Guide<sup class="beta">beta</sup>'
+        } %>
+        <%- titles[type] %>
         <% if (['cookbook', 'style-guide'].indexOf(type) === -1) { %>
           <select class="version-select">
             <option value="SELF" selected>2.x</option>


### PR DESCRIPTION
Currently, there is no way to translate headers (document types) in the sidebar, this PR solves this. For example, in the [French](https://fr.vuejs.org/v2/guide/index.html) version it is noticeable, but others are trying to decide on their own:
- [Português](https://github.com/vuejs-br/br.vuejs.org/blob/master/themes/vue/layout/partials/sidebar.ejs#L29)
- [Japanese](https://github.com/vuejs/jp.vuejs.org/blob/lang-ja/themes/vue/layout/partials/sidebar.ejs#L21)
![image](https://user-images.githubusercontent.com/4408379/35634088-da2b4f72-06bb-11e8-8ebc-2a95e30f0d91.png)

![image](https://user-images.githubusercontent.com/4408379/35634356-904a4632-06bc-11e8-862d-31533b71de18.png)

