### PR TITLE
Note that you can pass objects to the watch option

### DIFF
--- a/src/v2/guide/computed.md
+++ b/src/v2/guide/computed.md
@@ -302,4 +302,4 @@ var watchExampleVM = new Vue({
 
 In this case, using the `watch` option allows us to perform an asynchronous operation (accessing an API), limit how often we perform that operation, and set intermediary states until we get a final answer. None of that would be possible with a computed property.
 
-In addition to the `watch` option, you can also use the imperative [vm.$watch API](../api/#vm-watch).
+You can also [pass an object](../api/#watch) to the `watch` option or use the imperative [vm.$watch API](../api/#vm-watch) to specify additional options.


### PR DESCRIPTION
The guide currently only contains an example of passing a function as a `watch` option. This change adds a note that you can also pass an object to `watch` options to specify additional options. (I didn't realize this at first and thought you had to use `vm.$watch` to specify options like `deep` or `immediate`.)