### PR TITLE
DOCS: Quotes around class are unnecessary when using createElement

### DIFF
--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -171,7 +171,7 @@ One thing to note: similar to how `v-bind:class` and `v-bind:style` have special
 ``` js
 {
   // Same API as `v-bind:class`
-  'class': {
+  class: {
     foo: true,
     bar: false
   },


### PR DESCRIPTION
Related to vuejs/vue#7605