### PR TITLE
Update styles to enable printing docs (#1425)

### DIFF
--- a/themes/vue/source/css/_ad.styl
+++ b/themes/vue/source/css/_ad.styl
@@ -64,3 +64,7 @@
       margin-left 6px
   .default-ad
     display none
+
+@media print
+  #ad
+    display: none

--- a/themes/vue/source/css/_header.styl
+++ b/themes/vue/source/css/_header.styl
@@ -127,3 +127,7 @@ body.docs
     left: 50%
     margin-left: -15px
     background-size: 30px
+
+@media print
+  #header
+    display: none

--- a/themes/vue/source/css/_sidebar.styl
+++ b/themes/vue/source/css/_sidebar.styl
@@ -89,3 +89,7 @@
     &.open
       -webkit-transform: translate(0, 0)
       transform: translate(0, 0)
+
+@media print
+  .sidebar
+    display: none

--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -240,3 +240,7 @@
       margin-left: 0
   iframe
     margin: 0 !important
+
+@media print
+  .footer
+    display: none


### PR DESCRIPTION
The sidebar, header, footer and Advertisement elements are now hidden
when users print docs from the website.

Each of these elements had previously been displayed on top of other content on every printed page of a document.