### PR TITLE
Fixes #1427: Update simple bindings link

### DIFF
--- a/src/v2/guide/state-management.md
+++ b/src/v2/guide/state-management.md
@@ -10,7 +10,7 @@ Large applications can often grow in complexity, due to multiple pieces of state
 
 ### Information for React Developers
 
-If you're coming from React, you may be wondering how vuex compares to [redux](https://github.com/reactjs/redux), the most popular Flux implementation in that ecosystem. Redux is actually view-layer agnostic, so it can easily be used with Vue via [simple bindings](https://github.com/egoist/revue). Vuex is different in that it _knows_ it's in a Vue app. This allows it to better integrate with Vue, offering a more intuitive API and improved development experience.
+If you're coming from React, you may be wondering how vuex compares to [redux](https://github.com/reactjs/redux), the most popular Flux implementation in that ecosystem. Redux is actually view-layer agnostic, so it can easily be used with Vue via [simple bindings](https://yarnpkg.com/en/packages?q=redux%20vue&p=1). Vuex is different in that it _knows_ it's in a Vue app. This allows it to better integrate with Vue, offering a more intuitive API and improved development experience.
 
 ## Simple State Management from Scratch
 


### PR DESCRIPTION
[The revue link is dead](https://github.com/vuejs/vuejs.org/issues/1427) and [should be replaced](https://github.com/vuejs/vuejs.org/issues/1427#issuecomment-365839824).