### PR TITLE
Update events.md

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -186,7 +186,7 @@ To address this problem, Vue provides **event modifiers** for `v-on`. Recall tha
 <form v-on:submit.prevent></form>
 
 <!-- use capture mode when adding the event listener -->
-<!-- i.e. an event targeting an inner element is handled here after being handled by that element -->
+<!-- i.e. an event targeting an inner element is handled here before being handled by that element -->
 <div v-on:click.capture="doThis">...</div>
 
 <!-- only trigger handler if event.target is the element itself -->


### PR DESCRIPTION
The capture phase event propagation trickles downwards, so any event registered on an element on the capture phase will execute _before_ any other event is executed on any of its child elements.