### PR TITLE
Document how to disable production mode via CLI

### DIFF
--- a/src/v2/guide/deployment.md
+++ b/src/v2/guide/deployment.md
@@ -36,6 +36,13 @@ module.exports = {
 }
 ```
 
+Alternatively, you can invoke Webpack with the option `--define process.env.NODE_ENV="production"`. Also, you can
+strip all the non reached blocks with `--optimize-minimize`. As a short cut for both options, you can simply
+use:
+
+``` bash
+webpack --config webpack.config.js -p
+```
 #### Browserify
 
 - Run your bundling command with the actual `NODE_ENV` environment variable set to `"production"`. This tells `vueify` to avoid including hot-reload and development related code.


### PR DESCRIPTION
 While the option already documented is good, it hard codes
 production mode. Advanced users of webpack might already know,
 that you can use 2 config files (1 for development, and 1 for
 production) with a common base (thus 3 configuration files).
 However, for new comeres to modern javascript with a build step, it
 might be more straight forward to show also how to achieve the same
 via a command line option.
 This is also in paar with the section on Browserify which shows the
 CLI option.