### PR TITLE
fix(Events): escape @ in code tags

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -194,7 +194,7 @@ To address this problem, Vue provides **event modifiers** for `v-on`. Recall tha
 <div v-on:click.self="doThat">...</div>
 ```
 
-<p class="tip">Order matters when using modifiers because the relevant code is generated in the same order. Therefore using `@click.prevent.self` will prevent **all clicks** while `@click.self.prevent` will only prevent clicks on the element itself.</p>
+<p class="tip">Order matters when using modifiers because the relevant code is generated in the same order. Therefore using ` @click.prevent.self` will prevent **all clicks** while ` @click.self.prevent` will only prevent clicks on the element itself.</p>
 
 > New in 2.1.4+
 

--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -194,7 +194,7 @@ To address this problem, Vue provides **event modifiers** for `v-on`. Recall tha
 <div v-on:click.self="doThat">...</div>
 ```
 
-<p class="tip">Order matters when using modifiers because the relevant code is generated in the same order. Therefore using ` @click.prevent.self` will prevent **all clicks** while ` @click.self.prevent` will only prevent clicks on the element itself.</p>
+<p class="tip">Order matters when using modifiers because the relevant code is generated in the same order. Therefore using `v-on:click.prevent.self` will prevent **all clicks** while `v-on:click.self.prevent` will only prevent clicks on the element itself.</p>
 
 > New in 2.1.4+
 


### PR DESCRIPTION
Issue already mentioned in #1445 which replaces `@` with `v-bind`.

This Escape `@` in code tags by prepending a space favoring the shorthand.

![image](https://user-images.githubusercontent.com/2569015/36586253-614539b0-1881-11e8-997f-25fc5a527399.png)
