### PR TITLE
Update package-lock.json because of security vuneribility in moment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1963,7 +1963,7 @@
         "js-yaml": "3.10.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
-        "moment": "2.19.2",
+        "moment": "2.19.3",
         "moment-timezone": "0.5.14",
         "nunjucks": "2.5.2",
         "pretty-hrtime": "1.0.3",


### PR DESCRIPTION
Updating moment.js because we were alerted that there was a security vunerability.

<img width="773" alt="screen shot 2018-03-06 at 11 17 41 pm" src="https://user-images.githubusercontent.com/2281088/37064422-d23e9a28-2194-11e8-91cc-61151ee04b8c.png">
