### PR TITLE
add link to MDN event reference in v-on

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1900,6 +1900,12 @@ type: api
 
   <!-- the click event will be triggered at most once -->
   <button v-on:click.once="doThis"></button>
+
+  <!-- full list of possible events: https://developer.mozilla.org/en-US/docs/Web/Events -->
+  <select @change="onChange">
+    <option>1</option>
+    <option>2</option>
+  </select>
   ```
 
   Listening to custom events on a child component (the handler is called when "my-event" is emitted on the child):

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1861,7 +1861,7 @@ type: api
 
   Starting in 2.4.0+, `v-on` also supports binding to an object of event/listener pairs without an argument. Note when using the object syntax, it does not support any modifiers.
 
-  When used on a normal element, it listens to **native DOM events** only. When used on a custom element component, it also listens to **custom events** emitted on that child component.
+  When used on a normal element, it listens to [**native DOM events**](https://developer.mozilla.org/en-US/docs/Web/Events) only. When used on a custom element component, it listens to **custom events** emitted on that child component.
 
   When listening to native DOM events, the method receives the native event as the only argument. If using inline statement, the statement has access to the special `$event` property: `v-on:click="handle('ok', $event)"`.
 
@@ -1900,12 +1900,6 @@ type: api
 
   <!-- the click event will be triggered at most once -->
   <button v-on:click.once="doThis"></button>
-
-  <!-- full list of possible events: https://developer.mozilla.org/en-US/docs/Web/Events -->
-  <select @change="onChange">
-    <option>1</option>
-    <option>2</option>
-  </select>
   ```
 
   Listening to custom events on a child component (the handler is called when "my-event" is emitted on the child):


### PR DESCRIPTION
May be outside the scope of these docs, `v-on:change` just struck me as a common use case. The link to MDN could be useful for those that are not so familiar with how many DOM events there really are.