### PR TITLE
Include .fade-enter-to and .fade-leave class in css example

### DIFF
--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -53,6 +53,9 @@ new Vue({
 .fade-enter, .fade-leave-to /* .fade-leave-active below version 2.1.8 */ {
   opacity: 0;
 }
+.fade-enter-to, .fade-leave {
+  opacity: 1;
+}
 ```
 
 {% raw %}


### PR DESCRIPTION
In the original documentation, we implicitly assume that element got `opacity:1`.
I think we should explicitly include the `opacity:1` on fade-enter-to and fade-leave class. This will make the transition from `.fade-enter -> .fade-enter-to` and `.fade-leave -> .fade-leave-to` easier to understand