### PR TITLE
Order of the console.log statements

### DIFF
--- a/src/v2/cookbook/adding-instance-properties.md
+++ b/src/v2/cookbook/adding-instance-properties.md
@@ -58,7 +58,7 @@ new Vue({
 })
 ```
 
-It would be `"The name of some other app"`, then `"My App"`, because `this.appName` is overwritten ([sort of](https://github.com/getify/You-Dont-Know-JS/blob/master/this%20%26%20object%20prototypes/ch5.md)) by `data` when the instance is created. We scope instance properties with `$` to avoid this. You can even use your own convention if you'd like, such as `$_appName` or `ΩappName`, to prevent even conflicts with plugins or future features.
+It would be `"My App"`, then `"The name of some other app"`, because `this.appName` is overwritten ([sort of](https://github.com/getify/You-Dont-Know-JS/blob/master/this%20%26%20object%20prototypes/ch5.md)) by `data` when the instance is created. We scope instance properties with `$` to avoid this. You can even use your own convention if you'd like, such as `$_appName` or `ΩappName`, to prevent even conflicts with plugins or future features.
 
 ## Real-World Example: Replacing Vue Resource with Axios
 


### PR DESCRIPTION
Corrected the order that the console.log statements would run.

``` js

Vue.prototype.appName = 'My App'

new Vue({
  data: {
    appName: 'The name of some other app'
  },
  beforeCreate: function () {
    console.log(this.appName)
  },
  created: function () {
    console.log(this.appName)
  }
})
```

Will print first "My App" then "The name of some other app". 