### PR TITLE
Using the term "Base" instead of "Simple"

### DIFF
--- a/src/v2/cookbook/adding-instance-properties.md
+++ b/src/v2/cookbook/adding-instance-properties.md
@@ -4,7 +4,7 @@ type: cookbook
 order: 2
 ---
 
-## Simple Example
+## Base Example
 
 There may be data/utilities you'd like to use in many components, but you don't want to [pollute the global scope](https://github.com/getify/You-Dont-Know-JS/blob/master/scope%20%26%20closures/ch3.md). In these cases, you can make them available to each Vue instance by defining them on the prototype:
 

--- a/src/v2/cookbook/creating-custom-scroll-directives.md
+++ b/src/v2/cookbook/creating-custom-scroll-directives.md
@@ -4,14 +4,14 @@ type: cookbook
 order: 7
 ---
 
-## Simple Example
+## Base Example
 
 There are many times that we might want to add a bit of behavior, especially animation, to a scroll event on a site. There are many ways to do so, but the path with the least amount of code and dependencies is perhaps to use a [custom directive](https://vuejs.org/v2/guide/custom-directive.html) to create a hook for anything that fires off a particular scroll event.
 
 ```js
 Vue.directive('scroll', {
-  inserted: function (el, binding) {
-    let f = function (evt) {
+  inserted: function(el, binding) {
+    let f = function(evt) {
       if (binding.value(evt, el)) {
         window.removeEventListener('scroll', f)
       }
@@ -24,7 +24,7 @@ Vue.directive('scroll', {
 new Vue({
   el: '#app',
   methods: {
-    handleScroll: function (evt, el) {
+    handleScroll: function(evt, el) {
       if (window.scrollY > 50) {
         el.setAttribute(
           'style',
@@ -63,8 +63,8 @@ Or, with GreenSock(GSAP) or any other JavaScript animation library, the code bec
 
 ```js
 Vue.directive('scroll', {
-  inserted: function (el, binding) {
-    let f = function (evt) {
+  inserted: function(el, binding) {
+    let f = function(evt) {
       if (binding.value(evt, el)) {
         window.removeEventListener('scroll', f)
       }
@@ -77,7 +77,7 @@ Vue.directive('scroll', {
 new Vue({
   el: '#app',
   methods: {
-    handleScroll: function (evt, el) {
+    handleScroll: function(evt, el) {
       if (window.scrollY > 50) {
         TweenMax.to(el, 1.5, {
           y: -10,
@@ -116,8 +116,8 @@ To show how we do this, we'll take a look at the morphing shape example, where w
 
 ```js
 Vue.directive('clipscroll', {
-  inserted: function (el, binding) {
-    let f = function (evt) {
+  inserted: function(el, binding) {
+    let f = function(evt) {
       var hasRun = false
       if (!hasRun && window.scrollY > binding.value.start) {
         hasRun = true

--- a/src/v2/cookbook/creating-custom-scroll-directives.md
+++ b/src/v2/cookbook/creating-custom-scroll-directives.md
@@ -10,8 +10,8 @@ There are many times that we might want to add a bit of behavior, especially ani
 
 ```js
 Vue.directive('scroll', {
-  inserted: function(el, binding) {
-    let f = function(evt) {
+  inserted: function (el, binding) {
+    let f = function (evt) {
       if (binding.value(evt, el)) {
         window.removeEventListener('scroll', f)
       }
@@ -24,7 +24,7 @@ Vue.directive('scroll', {
 new Vue({
   el: '#app',
   methods: {
-    handleScroll: function(evt, el) {
+    handleScroll: function (evt, el) {
       if (window.scrollY > 50) {
         el.setAttribute(
           'style',
@@ -63,8 +63,8 @@ Or, with GreenSock(GSAP) or any other JavaScript animation library, the code bec
 
 ```js
 Vue.directive('scroll', {
-  inserted: function(el, binding) {
-    let f = function(evt) {
+  inserted: function (el, binding) {
+    let f = function (evt) {
       if (binding.value(evt, el)) {
         window.removeEventListener('scroll', f)
       }
@@ -77,7 +77,7 @@ Vue.directive('scroll', {
 new Vue({
   el: '#app',
   methods: {
-    handleScroll: function(evt, el) {
+    handleScroll: function (evt, el) {
       if (window.scrollY > 50) {
         TweenMax.to(el, 1.5, {
           y: -10,
@@ -116,8 +116,8 @@ To show how we do this, we'll take a look at the morphing shape example, where w
 
 ```js
 Vue.directive('clipscroll', {
-  inserted: function(el, binding) {
-    let f = function(evt) {
+  inserted: function (el, binding) {
+    let f = function (evt) {
       var hasRun = false
       if (!hasRun && window.scrollY > binding.value.start) {
         hasRun = true

--- a/src/v2/cookbook/form-validation.md
+++ b/src/v2/cookbook/form-validation.md
@@ -4,22 +4,22 @@ type: cookbook
 order: 3
 ---
 
-## Simple Example
+## Base Example
 
 Form validation is natively supported by the browser, but sometimes different browsers will handle things in a manner which makes relying on it a bit tricky. Even when validation is supported perfectly, there may be times when custom validations are needed and a more manual, Vue-based solution may be more appropriate. Let's begin with a simple example.
 
 Given a form of three fields, make two required. Let's look at the HTML first:
 
-``` html
+```html
 <form id="app" @submit="checkForm" action="https://vuejs.org/" method="post">
-  
+
   <p v-if="errors.length">
     <b>Please correct the following error(s):</b>
     <ul>
       <li v-for="error in errors">{{ error }}</li>
     </ul>
   </p>
-  
+
   <p>
     <label for="name">Name<label>
     <input type="text" name="name" id="name" v-model="name">
@@ -48,26 +48,26 @@ Given a form of three fields, make two required. Let's look at the HTML first:
 
 Let's cover it from the top. The `<form>` tag has an ID that we'll be using for the Vue component. There's a submit handler that you'll see in a bit, and the `action` is a temporary URL that would point to something real on a server someplace (where you have backup server-side validation of course).
 
-Beneath that there is a paragraph that shows or hides itself based on an error state. This will render a simple list of errors on top of the form. Also note we fire the validation on submit rather than as every field is modified. 
+Beneath that there is a paragraph that shows or hides itself based on an error state. This will render a simple list of errors on top of the form. Also note we fire the validation on submit rather than as every field is modified.
 
 The final thing to note is that each of the three fields has a corresponding `v-model` to connect them to values we will work with in the JavaScript. Now let's look at that.
 
-``` js
+```js
 const app = new Vue({
-  el:'#app',
-  data:{
-    errors:[],
-    name:null,
-    age:null,
-    movie:null
+  el: '#app',
+  data: {
+    errors: [],
+    name: null,
+    age: null,
+    movie: null
   },
-  methods:{
-    checkForm:function(e) {
-      if(this.name && this.age) return true;
-      this.errors = [];
-      if(!this.name) this.errors.push("Name required.");
-      if(!this.age) this.errors.push("Age required.");
-      e.preventDefault();
+  methods: {
+    checkForm: function(e) {
+      if (this.name && this.age) return true
+      this.errors = []
+      if (!this.name) this.errors.push('Name required.')
+      if (!this.age) this.errors.push('Age required.')
+      e.preventDefault()
     }
   }
 })
@@ -82,16 +82,16 @@ Fairly short and simple. We define an array to hold errors and set `null` values
 
 For the second example, the second text field (age) was switched to email which will be validated with a bit of custom logic. The code is taken from the StackOverflow question, [How to validate email address in JavaScript?](https://stackoverflow.com/questions/46155/how-to-validate-email-address-in-javascript). This is an awesome question because it makes your most intense Facebook political/religious argument look like a slight disagreement over who makes the best beer. Seriously - it's insane. Here is the HTML, even though it's really close to the first example.
 
-``` html
+```html
 <form id="app" @submit="checkForm" action="https://vuejs.org/" method="post" novalidate="true">
-  
+
   <p v-if="errors.length">
     <b>Please correct the following error(s):</b>
     <ul>
       <li v-for="error in errors">{{ error }}</li>
     </ul>
   </p>
-  
+
   <p>
     <label for="name">Name<label>
     <input type="text" name="name" id="name" v-model="name">
@@ -120,30 +120,30 @@ For the second example, the second text field (age) was switched to email which 
 
 While the change here is small, note the `novalidate="true"` on top. This is important because the browser will attempt to validate the email address in the field when `type="email"`. Frankly it may make more sense to trust the browser in this case, but as we wanted an example with custom validation, we're disabling it. Here's the updated JavaScript.
 
-``` js
+```js
 const app = new Vue({
-  el:'#app',
-  data:{
-    errors:[],
-    name:null,
-    email:null,
-    movie:null
+  el: '#app',
+  data: {
+    errors: [],
+    name: null,
+    email: null,
+    movie: null
   },
-  methods:{
-    checkForm:function(e) {
-      this.errors = [];
-      if(!this.name) this.errors.push("Name required.");
-      if(!this.email) {
-        this.errors.push("Email required.");
-      } else if(!this.validEmail(this.email)) {
-        this.errors.push("Valid email required.");        
+  methods: {
+    checkForm: function(e) {
+      this.errors = []
+      if (!this.name) this.errors.push('Name required.')
+      if (!this.email) {
+        this.errors.push('Email required.')
+      } else if (!this.validEmail(this.email)) {
+        this.errors.push('Valid email required.')
       }
-      if(!this.errors.length) return true;
-      e.preventDefault();
+      if (!this.errors.length) return true
+      e.preventDefault()
     },
-    validEmail:function(email) {
-      var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-      return re.test(email);
+    validEmail: function(email) {
+      var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+      return re.test(email)
     }
   }
 })
@@ -158,9 +158,9 @@ As you can see, we've added `validEmail` as a new method and it is simply called
 
 For the third example, we've built something you've probably seen in survey apps. The user is asked to spend a "budget" for a set of features for a new Star Destroyer model. The total must equal 100. First, the HTML.
 
-``` html
+```html
 <form id="app" @submit="checkForm" action="https://vuejs.org/" method="post" novalidate="true">
-  
+
   <p v-if="errors.length">
     <b>Please correct the following error(s):</b>
     <ul>
@@ -195,32 +195,34 @@ For the third example, we've built something you've probably seen in survey apps
 
 Note the set of inputs covering the five different features. Note the addition of `.number` to the `v-model` attribute. This tells Vue to cast the value to a number when you use it. However, there is a bug with this feature such that when the value is blank, it turns back into a string. You'll see the workaround below. To make it a bit easier for the user, we also added a current total right below so they can see, in real time, what their total is. Now let's look at the JavaScript.
 
-``` js
+```js
 const app = new Vue({
-  el:'#app',
-  data:{
-    errors:[],
-    weapons:0,
-    shields:0,
-    coffee:0,
-    ac:0,
-    mousedroids:0
+  el: '#app',
+  data: {
+    errors: [],
+    weapons: 0,
+    shields: 0,
+    coffee: 0,
+    ac: 0,
+    mousedroids: 0
   },
-  computed:{
-     total:function() {
-       // must parse cuz Vue turns empty value to string
-       return Number(this.weapons)+
-         Number(this.shields)+
-         Number(this.coffee)+
-         Number(this.ac+this.mousedroids);
-     }
+  computed: {
+    total: function() {
+      // must parse cuz Vue turns empty value to string
+      return (
+        Number(this.weapons) +
+        Number(this.shields) +
+        Number(this.coffee) +
+        Number(this.ac + this.mousedroids)
+      )
+    }
   },
-  methods:{
-    checkForm:function(e) {
-      this.errors = [];
-      if(this.total != 100) this.errors.push("Total must be 100!");
-      if(!this.errors.length) return true;
-      e.preventDefault();
+  methods: {
+    checkForm: function(e) {
+      this.errors = []
+      if (this.total != 100) this.errors.push('Total must be 100!')
+      if (!this.errors.length) return true
+      e.preventDefault()
     }
   }
 })
@@ -235,26 +237,22 @@ We set up the total value as a computed value, and outside of that bug I ran int
 
 In my final example, we built something that makes use of Ajax to validate at the server. The form will ask you to name a new product and will then check to ensure that the name is unique. We wrote a quick [OpenWhisk](http://openwhisk.apache.org/) serverless action to do the validation. While it isn't terribly important, here is the logic:
 
-``` js
+```js
 function main(args) {
-
-    return new Promise((resolve, reject) => {
-
-        // bad product names: vista, empire, mbp
-        let badNames = ['vista','empire','mbp'];
-        if(badNames.includes(args.name)) reject({error:'Existing product'});
-        resolve({status:'ok'});
-
-    });
-
+  return new Promise((resolve, reject) => {
+    // bad product names: vista, empire, mbp
+    let badNames = ['vista', 'empire', 'mbp']
+    if (badNames.includes(args.name)) reject({ error: 'Existing product' })
+    resolve({ status: 'ok' })
+  })
 }
 ```
 
 Basically any name but "vista", "empire", and "mbp" are acceptable. Ok, so let's look at the form.
 
-``` html
+```html
 <form id="app" @submit="checkForm" method="post">
-  
+
   <p v-if="errors.length">
     <b>Please correct the following error(s):</b>
     <ul>
@@ -276,32 +274,33 @@ Basically any name but "vista", "empire", and "mbp" are acceptable. Ok, so let's
 
 There isn't anything special here. So let's go on to the JavaScript.
 
-``` js
-const apiUrl = 'https://openwhisk.ng.bluemix.net/api/v1/web/rcamden%40us.ibm.com_My%20Space/safeToDelete/productName.json?name=';
+```js
+const apiUrl =
+  'https://openwhisk.ng.bluemix.net/api/v1/web/rcamden%40us.ibm.com_My%20Space/safeToDelete/productName.json?name='
 
 const app = new Vue({
-  el:'#app',
-  data:{
-    errors:[],
-    name:''
+  el: '#app',
+  data: {
+    errors: [],
+    name: ''
   },
-  methods:{
-    checkForm:function(e) {
-      e.preventDefault();
-      this.errors = [];
-      if(this.name === '') {
-        this.errors.push("Product name is required.");
+  methods: {
+    checkForm: function(e) {
+      e.preventDefault()
+      this.errors = []
+      if (this.name === '') {
+        this.errors.push('Product name is required.')
       } else {
-        fetch(apiUrl+encodeURIComponent(this.name))
-        .then(res => res.json())
-        .then(res => {
-          if(res.error) {
-            this.errors.push(res.error);
-          } else {
-            // redirect to a new URL, or do something on success
-            alert('ok!');
-          }
-        });
+        fetch(apiUrl + encodeURIComponent(this.name))
+          .then(res => res.json())
+          .then(res => {
+            if (res.error) {
+              this.errors.push(res.error)
+            } else {
+              // redirect to a new URL, or do something on success
+              alert('ok!')
+            }
+          })
       }
     }
   }
@@ -319,4 +318,3 @@ While this cookbook entry focused on doing form validation "by hand", there are,
 
 * [vuelidate](https://github.com/monterail/vuelidate)
 * [VeeValidate](http://vee-validate.logaretm.com/)
-

--- a/src/v2/cookbook/form-validation.md
+++ b/src/v2/cookbook/form-validation.md
@@ -10,16 +10,16 @@ Form validation is natively supported by the browser, but sometimes different br
 
 Given a form of three fields, make two required. Let's look at the HTML first:
 
-```html
+``` html
 <form id="app" @submit="checkForm" action="https://vuejs.org/" method="post">
-
+  
   <p v-if="errors.length">
     <b>Please correct the following error(s):</b>
     <ul>
       <li v-for="error in errors">{{ error }}</li>
     </ul>
   </p>
-
+  
   <p>
     <label for="name">Name<label>
     <input type="text" name="name" id="name" v-model="name">
@@ -48,26 +48,26 @@ Given a form of three fields, make two required. Let's look at the HTML first:
 
 Let's cover it from the top. The `<form>` tag has an ID that we'll be using for the Vue component. There's a submit handler that you'll see in a bit, and the `action` is a temporary URL that would point to something real on a server someplace (where you have backup server-side validation of course).
 
-Beneath that there is a paragraph that shows or hides itself based on an error state. This will render a simple list of errors on top of the form. Also note we fire the validation on submit rather than as every field is modified.
+Beneath that there is a paragraph that shows or hides itself based on an error state. This will render a simple list of errors on top of the form. Also note we fire the validation on submit rather than as every field is modified. 
 
 The final thing to note is that each of the three fields has a corresponding `v-model` to connect them to values we will work with in the JavaScript. Now let's look at that.
 
-```js
+``` js
 const app = new Vue({
-  el: '#app',
-  data: {
-    errors: [],
-    name: null,
-    age: null,
-    movie: null
+  el:'#app',
+  data:{
+    errors:[],
+    name:null,
+    age:null,
+    movie:null
   },
-  methods: {
-    checkForm: function(e) {
-      if (this.name && this.age) return true
-      this.errors = []
-      if (!this.name) this.errors.push('Name required.')
-      if (!this.age) this.errors.push('Age required.')
-      e.preventDefault()
+  methods:{
+    checkForm:function(e) {
+      if(this.name && this.age) return true;
+      this.errors = [];
+      if(!this.name) this.errors.push("Name required.");
+      if(!this.age) this.errors.push("Age required.");
+      e.preventDefault();
     }
   }
 })
@@ -82,16 +82,16 @@ Fairly short and simple. We define an array to hold errors and set `null` values
 
 For the second example, the second text field (age) was switched to email which will be validated with a bit of custom logic. The code is taken from the StackOverflow question, [How to validate email address in JavaScript?](https://stackoverflow.com/questions/46155/how-to-validate-email-address-in-javascript). This is an awesome question because it makes your most intense Facebook political/religious argument look like a slight disagreement over who makes the best beer. Seriously - it's insane. Here is the HTML, even though it's really close to the first example.
 
-```html
+``` html
 <form id="app" @submit="checkForm" action="https://vuejs.org/" method="post" novalidate="true">
-
+  
   <p v-if="errors.length">
     <b>Please correct the following error(s):</b>
     <ul>
       <li v-for="error in errors">{{ error }}</li>
     </ul>
   </p>
-
+  
   <p>
     <label for="name">Name<label>
     <input type="text" name="name" id="name" v-model="name">
@@ -120,30 +120,30 @@ For the second example, the second text field (age) was switched to email which 
 
 While the change here is small, note the `novalidate="true"` on top. This is important because the browser will attempt to validate the email address in the field when `type="email"`. Frankly it may make more sense to trust the browser in this case, but as we wanted an example with custom validation, we're disabling it. Here's the updated JavaScript.
 
-```js
+``` js
 const app = new Vue({
-  el: '#app',
-  data: {
-    errors: [],
-    name: null,
-    email: null,
-    movie: null
+  el:'#app',
+  data:{
+    errors:[],
+    name:null,
+    email:null,
+    movie:null
   },
-  methods: {
-    checkForm: function(e) {
-      this.errors = []
-      if (!this.name) this.errors.push('Name required.')
-      if (!this.email) {
-        this.errors.push('Email required.')
-      } else if (!this.validEmail(this.email)) {
-        this.errors.push('Valid email required.')
+  methods:{
+    checkForm:function(e) {
+      this.errors = [];
+      if(!this.name) this.errors.push("Name required.");
+      if(!this.email) {
+        this.errors.push("Email required.");
+      } else if(!this.validEmail(this.email)) {
+        this.errors.push("Valid email required.");        
       }
-      if (!this.errors.length) return true
-      e.preventDefault()
+      if(!this.errors.length) return true;
+      e.preventDefault();
     },
-    validEmail: function(email) {
-      var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-      return re.test(email)
+    validEmail:function(email) {
+      var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+      return re.test(email);
     }
   }
 })
@@ -158,9 +158,9 @@ As you can see, we've added `validEmail` as a new method and it is simply called
 
 For the third example, we've built something you've probably seen in survey apps. The user is asked to spend a "budget" for a set of features for a new Star Destroyer model. The total must equal 100. First, the HTML.
 
-```html
+``` html
 <form id="app" @submit="checkForm" action="https://vuejs.org/" method="post" novalidate="true">
-
+  
   <p v-if="errors.length">
     <b>Please correct the following error(s):</b>
     <ul>
@@ -195,34 +195,32 @@ For the third example, we've built something you've probably seen in survey apps
 
 Note the set of inputs covering the five different features. Note the addition of `.number` to the `v-model` attribute. This tells Vue to cast the value to a number when you use it. However, there is a bug with this feature such that when the value is blank, it turns back into a string. You'll see the workaround below. To make it a bit easier for the user, we also added a current total right below so they can see, in real time, what their total is. Now let's look at the JavaScript.
 
-```js
+``` js
 const app = new Vue({
-  el: '#app',
-  data: {
-    errors: [],
-    weapons: 0,
-    shields: 0,
-    coffee: 0,
-    ac: 0,
-    mousedroids: 0
+  el:'#app',
+  data:{
+    errors:[],
+    weapons:0,
+    shields:0,
+    coffee:0,
+    ac:0,
+    mousedroids:0
   },
-  computed: {
-    total: function() {
-      // must parse cuz Vue turns empty value to string
-      return (
-        Number(this.weapons) +
-        Number(this.shields) +
-        Number(this.coffee) +
-        Number(this.ac + this.mousedroids)
-      )
-    }
+  computed:{
+     total:function() {
+       // must parse cuz Vue turns empty value to string
+       return Number(this.weapons)+
+         Number(this.shields)+
+         Number(this.coffee)+
+         Number(this.ac+this.mousedroids);
+     }
   },
-  methods: {
-    checkForm: function(e) {
-      this.errors = []
-      if (this.total != 100) this.errors.push('Total must be 100!')
-      if (!this.errors.length) return true
-      e.preventDefault()
+  methods:{
+    checkForm:function(e) {
+      this.errors = [];
+      if(this.total != 100) this.errors.push("Total must be 100!");
+      if(!this.errors.length) return true;
+      e.preventDefault();
     }
   }
 })
@@ -237,22 +235,26 @@ We set up the total value as a computed value, and outside of that bug I ran int
 
 In my final example, we built something that makes use of Ajax to validate at the server. The form will ask you to name a new product and will then check to ensure that the name is unique. We wrote a quick [OpenWhisk](http://openwhisk.apache.org/) serverless action to do the validation. While it isn't terribly important, here is the logic:
 
-```js
+``` js
 function main(args) {
-  return new Promise((resolve, reject) => {
-    // bad product names: vista, empire, mbp
-    let badNames = ['vista', 'empire', 'mbp']
-    if (badNames.includes(args.name)) reject({ error: 'Existing product' })
-    resolve({ status: 'ok' })
-  })
+
+    return new Promise((resolve, reject) => {
+
+        // bad product names: vista, empire, mbp
+        let badNames = ['vista','empire','mbp'];
+        if(badNames.includes(args.name)) reject({error:'Existing product'});
+        resolve({status:'ok'});
+
+    });
+
 }
 ```
 
 Basically any name but "vista", "empire", and "mbp" are acceptable. Ok, so let's look at the form.
 
-```html
+``` html
 <form id="app" @submit="checkForm" method="post">
-
+  
   <p v-if="errors.length">
     <b>Please correct the following error(s):</b>
     <ul>
@@ -274,33 +276,32 @@ Basically any name but "vista", "empire", and "mbp" are acceptable. Ok, so let's
 
 There isn't anything special here. So let's go on to the JavaScript.
 
-```js
-const apiUrl =
-  'https://openwhisk.ng.bluemix.net/api/v1/web/rcamden%40us.ibm.com_My%20Space/safeToDelete/productName.json?name='
+``` js
+const apiUrl = 'https://openwhisk.ng.bluemix.net/api/v1/web/rcamden%40us.ibm.com_My%20Space/safeToDelete/productName.json?name=';
 
 const app = new Vue({
-  el: '#app',
-  data: {
-    errors: [],
-    name: ''
+  el:'#app',
+  data:{
+    errors:[],
+    name:''
   },
-  methods: {
-    checkForm: function(e) {
-      e.preventDefault()
-      this.errors = []
-      if (this.name === '') {
-        this.errors.push('Product name is required.')
+  methods:{
+    checkForm:function(e) {
+      e.preventDefault();
+      this.errors = [];
+      if(this.name === '') {
+        this.errors.push("Product name is required.");
       } else {
-        fetch(apiUrl + encodeURIComponent(this.name))
-          .then(res => res.json())
-          .then(res => {
-            if (res.error) {
-              this.errors.push(res.error)
-            } else {
-              // redirect to a new URL, or do something on success
-              alert('ok!')
-            }
-          })
+        fetch(apiUrl+encodeURIComponent(this.name))
+        .then(res => res.json())
+        .then(res => {
+          if(res.error) {
+            this.errors.push(res.error);
+          } else {
+            // redirect to a new URL, or do something on success
+            alert('ok!');
+          }
+        });
       }
     }
   }
@@ -318,3 +319,4 @@ While this cookbook entry focused on doing form validation "by hand", there are,
 
 * [vuelidate](https://github.com/monterail/vuelidate)
 * [VeeValidate](http://vee-validate.logaretm.com/)
+

--- a/src/v2/cookbook/index.md
+++ b/src/v2/cookbook/index.md
@@ -35,23 +35,23 @@ Recipes should generally:
 > * Explain the pros and cons of your strategy, including when it is and isn't appropriate
 > * Mention alternative solutions, if relevant, but leave in-depth explorations to a separate recipe
 
-### Simple Example
+### Base Example
 
 _required_
 
-1. Articulate the problem in a sentence or two.
-2. Explain the simplest possible solution in a sentence or two.
-3. Show a small code sample.
-4. Explain what this accomplishes in a sentence.
+1.  Articulate the problem in a sentence or two.
+2.  Explain the simplest possible solution in a sentence or two.
+3.  Show a small code sample.
+4.  Explain what this accomplishes in a sentence.
 
 ### Details about the Value
 
 _required_
 
-1. Address common questions that one might have while looking at the example. (Blockquotes are great for this)
-2. Show examples of common missteps and how they can be avoided.
-3. Show very simple code samples of good and bad patterns.
-4. Discuss why this may be a compelling pattern. Links for reference are not required but encouraged.
+1.  Address common questions that one might have while looking at the example. (Blockquotes are great for this)
+2.  Show examples of common missteps and how they can be avoided.
+3.  Show very simple code samples of good and bad patterns.
+4.  Discuss why this may be a compelling pattern. Links for reference are not required but encouraged.
 
 ### Real-World Example
 
@@ -59,8 +59,8 @@ _required_
 
 Demonstrate the code that would power a common or interesting use case, either by:
 
-1. Walking through a few terse examples of setup, or
-2. Embedding a codepen/jsfiddle example
+1.  Walking through a few terse examples of setup, or
+2.  Embedding a codepen/jsfiddle example
 
 If you choose to do the latter, you should still talk through what it is and does.
 

--- a/src/v2/cookbook/index.md
+++ b/src/v2/cookbook/index.md
@@ -35,6 +35,8 @@ Recipes should generally:
 > * Explain the pros and cons of your strategy, including when it is and isn't appropriate
 > * Mention alternative solutions, if relevant, but leave in-depth explorations to a separate recipe
 
+We request that you follow the template below. We understand, however, that there are times when you may necessarily need to deviate for clarity or flow. Either way, all recipes should at some point discuss the nuance of the choice made using this pattern, preferably in the form of the alternative patterns section.
+
 ### Base Example
 
 _required_

--- a/src/v2/cookbook/unit-testing-vue-components.md
+++ b/src/v2/cookbook/unit-testing-vue-components.md
@@ -4,7 +4,7 @@ type: cookbook
 order: 6
 ---
 
-## Simple Example
+## Base Example
 
 Unit testing is a fundamental part of software development. Unit tests execute the smallest units of code in isolation, in order to increase ease of adding new features and track down bugs. Vue's [single-file components](../guide/single-file-components.html) make it straight forward to write unit tests for components in isolation. This lets you develop new features with confidence you are not breaking existing ones, and helps other developers understand what your component does.
 
@@ -14,7 +14,7 @@ This simple example tests whether some text is rendered:
 <template>
   <div>
     <input v-model="username">
-    <div 
+    <div
       v-if="error"
       class="error"
     >
@@ -72,11 +72,11 @@ The above code snippet shows how to test whether an error message is rendered ba
 
 Component unit tests have lots of benefits:
 
-- Provide documentation on how the component should behave
-- Save time over testing manually
-- Reduce bugs in new features
-- Improve design
-- Facilitate refactoring
+* Provide documentation on how the component should behave
+* Save time over testing manually
+* Reduce bugs in new features
+* Improve design
+* Facilitate refactoring
 
 Automated testing allows large teams of developers to maintain complex codebases.
 
@@ -88,15 +88,15 @@ Automated testing allows large teams of developers to maintain complex codebases
 
 Unit tests should be:
 
-- Fast to run
-- Easy to understand
-- Only test a _single unit of work_
+* Fast to run
+* Easy to understand
+* Only test a _single unit of work_
 
 Let's continue building on the previous example, while introducing the idea of a <a href="https://en.wikipedia.org/wiki/Factory_(object-oriented_programming)">factory function</a> to make our test more compact and readable. The component should:
 
-- show a 'Welcome to the Vue.js cookbook' greeting.
-- prompt the user to enter their username
-- display an error if the entered username is less than seven letters
+* show a 'Welcome to the Vue.js cookbook' greeting.
+* prompt the user to enter their username
+* display an error if the entered username is less than seven letters
 
 Let's take a look at the component code first:
 
@@ -107,7 +107,7 @@ Let's take a look at the component code first:
       {{ message }}
     </div>
     Enter your username: <input v-model="username">
-    <div 
+    <div
       v-if="error"
       class="error"
     >
@@ -138,9 +138,9 @@ export default {
 
 The things that we should test are:
 
-- is the `message` rendered?
-- if `error` is `true`, `<div class="error">` should be present
-- if `error` is `false`, `<div class="error">` should not be present
+* is the `message` rendered?
+* if `error` is `true`, `<div class="error">` should be present
+* if `error` is `false`, `<div class="error">` should not be present
 
 And our first attempt at test:
 
@@ -149,46 +149,47 @@ import { shallow } from '@vue/test-utils'
 
 describe('Foo', () => {
   it('renders a message and responds correctly to user input', () => {
-      const wrapper = shallow(Foo, {
-    data: {
-      message: 'Hello World',
-      username: ''
-    }
-  })
+    const wrapper = shallow(Foo, {
+      data: {
+        message: 'Hello World',
+        username: ''
+      }
+    })
 
-  // see if the message renders
-  expect(wrapper.find('.message').text()).toEqual('Hello World')
+    // see if the message renders
+    expect(wrapper.find('.message').text()).toEqual('Hello World')
 
-  // assert the error is rendered
-  expect(wrapper.find('.error').exists()).toBeTruthy()
+    // assert the error is rendered
+    expect(wrapper.find('.error').exists()).toBeTruthy()
 
-  // update the `username` and assert error is longer rendered
-  wrapper.setData({ username: 'Lachlan' })
-  expect(wrapper.find('.error').exists()).toBeFalsy()
+    // update the `username` and assert error is longer rendered
+    wrapper.setData({ username: 'Lachlan' })
+    expect(wrapper.find('.error').exists()).toBeFalsy()
   })
 })
 ```
 
 There are some problems with the above:
 
-- a single test is making assertions about different things
-- difficult to tell the different states the component can be in, and what should be rendered
+* a single test is making assertions about different things
+* difficult to tell the different states the component can be in, and what should be rendered
 
 The below example improves the test by:
 
-- only making one assertion per `it` block
-- having short, clear test descriptions
-- providing only the minimum data requires for the test
-- refactoring duplicated logic (creating the `wrapper` and setting the `username` variable) into a factory function
+* only making one assertion per `it` block
+* having short, clear test descriptions
+* providing only the minimum data requires for the test
+* refactoring duplicated logic (creating the `wrapper` and setting the `username` variable) into a factory function
 
-*Updated test*:
+_Updated test_:
+
 ```js
 import { shallow } from '@vue/test-utils'
 import Foo from './Foo'
 
 const factory = (values = {}) => {
   return shallow(Foo, {
-    data: { ...values  }
+    data: { ...values }
   })
 }
 
@@ -196,11 +197,13 @@ describe('Foo', () => {
   it('renders a welcome message', () => {
     const wrapper = factory()
 
-    expect(wrapper.find('.message').text()).toEqual("Welcome to the Vue.js cookbook")
+    expect(wrapper.find('.message').text()).toEqual(
+      'Welcome to the Vue.js cookbook'
+    )
   })
 
   it('renders an error when username is less than 7 characters', () => {
-    const wrapper = factory({ username: ''  })
+    const wrapper = factory({ username: '' })
 
     expect(wrapper.find('.error').exists()).toBeTruthy()
   })
@@ -212,7 +215,7 @@ describe('Foo', () => {
   })
 
   it('does not render an error when username is 7 characters or more', () => {
-    const wrapper = factory({ username: 'Lachlan'  })
+    const wrapper = factory({ username: 'Lachlan' })
 
     expect(wrapper.find('.error').exists()).toBeFalsy()
   })
@@ -227,9 +230,9 @@ At the top, we declare the factory function which merges the `values` object int
 
 The above test is fairly simple, but in practice Vue components often have other behaviors you want to test, such as:
 
-- making API calls
-- committing or dispatching mutations or actions with a `Vuex` store
-- testing interaction
+* making API calls
+* committing or dispatching mutations or actions with a `Vuex` store
+* testing interaction
 
 There are more complete examples showing such tests in the Vue Test Utils [guides](https://vue-test-utils.vuejs.org/en/guides/).
 

--- a/src/v2/cookbook/unit-testing-vue-components.md
+++ b/src/v2/cookbook/unit-testing-vue-components.md
@@ -14,7 +14,7 @@ This simple example tests whether some text is rendered:
 <template>
   <div>
     <input v-model="username">
-    <div
+    <div 
       v-if="error"
       class="error"
     >
@@ -72,11 +72,11 @@ The above code snippet shows how to test whether an error message is rendered ba
 
 Component unit tests have lots of benefits:
 
-* Provide documentation on how the component should behave
-* Save time over testing manually
-* Reduce bugs in new features
-* Improve design
-* Facilitate refactoring
+- Provide documentation on how the component should behave
+- Save time over testing manually
+- Reduce bugs in new features
+- Improve design
+- Facilitate refactoring
 
 Automated testing allows large teams of developers to maintain complex codebases.
 
@@ -88,15 +88,15 @@ Automated testing allows large teams of developers to maintain complex codebases
 
 Unit tests should be:
 
-* Fast to run
-* Easy to understand
-* Only test a _single unit of work_
+- Fast to run
+- Easy to understand
+- Only test a _single unit of work_
 
 Let's continue building on the previous example, while introducing the idea of a <a href="https://en.wikipedia.org/wiki/Factory_(object-oriented_programming)">factory function</a> to make our test more compact and readable. The component should:
 
-* show a 'Welcome to the Vue.js cookbook' greeting.
-* prompt the user to enter their username
-* display an error if the entered username is less than seven letters
+- show a 'Welcome to the Vue.js cookbook' greeting.
+- prompt the user to enter their username
+- display an error if the entered username is less than seven letters
 
 Let's take a look at the component code first:
 
@@ -107,7 +107,7 @@ Let's take a look at the component code first:
       {{ message }}
     </div>
     Enter your username: <input v-model="username">
-    <div
+    <div 
       v-if="error"
       class="error"
     >
@@ -138,9 +138,9 @@ export default {
 
 The things that we should test are:
 
-* is the `message` rendered?
-* if `error` is `true`, `<div class="error">` should be present
-* if `error` is `false`, `<div class="error">` should not be present
+- is the `message` rendered?
+- if `error` is `true`, `<div class="error">` should be present
+- if `error` is `false`, `<div class="error">` should not be present
 
 And our first attempt at test:
 
@@ -149,47 +149,46 @@ import { shallow } from '@vue/test-utils'
 
 describe('Foo', () => {
   it('renders a message and responds correctly to user input', () => {
-    const wrapper = shallow(Foo, {
-      data: {
-        message: 'Hello World',
-        username: ''
-      }
-    })
+      const wrapper = shallow(Foo, {
+    data: {
+      message: 'Hello World',
+      username: ''
+    }
+  })
 
-    // see if the message renders
-    expect(wrapper.find('.message').text()).toEqual('Hello World')
+  // see if the message renders
+  expect(wrapper.find('.message').text()).toEqual('Hello World')
 
-    // assert the error is rendered
-    expect(wrapper.find('.error').exists()).toBeTruthy()
+  // assert the error is rendered
+  expect(wrapper.find('.error').exists()).toBeTruthy()
 
-    // update the `username` and assert error is longer rendered
-    wrapper.setData({ username: 'Lachlan' })
-    expect(wrapper.find('.error').exists()).toBeFalsy()
+  // update the `username` and assert error is longer rendered
+  wrapper.setData({ username: 'Lachlan' })
+  expect(wrapper.find('.error').exists()).toBeFalsy()
   })
 })
 ```
 
 There are some problems with the above:
 
-* a single test is making assertions about different things
-* difficult to tell the different states the component can be in, and what should be rendered
+- a single test is making assertions about different things
+- difficult to tell the different states the component can be in, and what should be rendered
 
 The below example improves the test by:
 
-* only making one assertion per `it` block
-* having short, clear test descriptions
-* providing only the minimum data requires for the test
-* refactoring duplicated logic (creating the `wrapper` and setting the `username` variable) into a factory function
+- only making one assertion per `it` block
+- having short, clear test descriptions
+- providing only the minimum data requires for the test
+- refactoring duplicated logic (creating the `wrapper` and setting the `username` variable) into a factory function
 
-_Updated test_:
-
+*Updated test*:
 ```js
 import { shallow } from '@vue/test-utils'
 import Foo from './Foo'
 
 const factory = (values = {}) => {
   return shallow(Foo, {
-    data: { ...values }
+    data: { ...values  }
   })
 }
 
@@ -197,13 +196,11 @@ describe('Foo', () => {
   it('renders a welcome message', () => {
     const wrapper = factory()
 
-    expect(wrapper.find('.message').text()).toEqual(
-      'Welcome to the Vue.js cookbook'
-    )
+    expect(wrapper.find('.message').text()).toEqual("Welcome to the Vue.js cookbook")
   })
 
   it('renders an error when username is less than 7 characters', () => {
-    const wrapper = factory({ username: '' })
+    const wrapper = factory({ username: ''  })
 
     expect(wrapper.find('.error').exists()).toBeTruthy()
   })
@@ -215,7 +212,7 @@ describe('Foo', () => {
   })
 
   it('does not render an error when username is 7 characters or more', () => {
-    const wrapper = factory({ username: 'Lachlan' })
+    const wrapper = factory({ username: 'Lachlan'  })
 
     expect(wrapper.find('.error').exists()).toBeFalsy()
   })
@@ -230,9 +227,9 @@ At the top, we declare the factory function which merges the `values` object int
 
 The above test is fairly simple, but in practice Vue components often have other behaviors you want to test, such as:
 
-* making API calls
-* committing or dispatching mutations or actions with a `Vuex` store
-* testing interaction
+- making API calls
+- committing or dispatching mutations or actions with a `Vuex` store
+- testing interaction
 
 There are more complete examples showing such tests in the Vue Test Utils [guides](https://vue-test-utils.vuejs.org/en/guides/).
 

--- a/src/v2/cookbook/using-axios-to-consume-apis.md
+++ b/src/v2/cookbook/using-axios-to-consume-apis.md
@@ -15,12 +15,12 @@ There are a number of ways we can request information from the API, but it's nic
 ```js
 new Vue({
   el: '#app',
-  data() {
+  data () {
     return {
       info: null
     }
   },
-  mounted() {
+  mounted () {
     axios
       .get('https://api.coindesk.com/v1/bpi/currentprice.json')
       .then(response => (this.info = response))

--- a/src/v2/cookbook/using-axios-to-consume-apis.md
+++ b/src/v2/cookbook/using-axios-to-consume-apis.md
@@ -4,7 +4,7 @@ type: cookbook
 order: 9
 ---
 
-## Simple Example
+## Base Example
 
 There are many times when building application for the web that you may want to consume and display data from an API. There are several ways to do so, but a very popular approach is to use [axios](https://github.com/axios/axios), a promise-based HTTP client.
 
@@ -15,12 +15,12 @@ There are a number of ways we can request information from the API, but it's nic
 ```js
 new Vue({
   el: '#app',
-  data () {
+  data() {
     return {
       info: null
     }
   },
-  mounted () {
+  mounted() {
     axios
       .get('https://api.coindesk.com/v1/bpi/currentprice.json')
       .then(response => (this.info = response))


### PR DESCRIPTION
- Based on a conversation with @chrisvfritz, changing the term "Simple Example" in the cookbook to "Base Example". He had the idea to change it off a recipe I made by mistake- I like it because the terms simple should be avoided when possible in communicating or documenting something- what's simple to me might not be simple to you, and thus can seem condescending. ref: [http://bradfrost.com/blog/post/just/](http://bradfrost.com/blog/post/just/)
- I also added some language about expectations for the post to allow them a bit of flexibility but clarify what we're looking for.
