### PR TITLE
3rd Party Plugin Example Update: Add trigger method to watcher in Select2 example

### DIFF
--- a/src/v2/examples/select2.md
+++ b/src/v2/examples/select2.md
@@ -6,4 +6,4 @@ order: 8
 
 > In this example we are integrating a 3rd party jQuery plugin (select2) by wrapping it inside a custom component.
 
-<iframe width="100%" height="500" src="https://jsfiddle.net/chrisvfritz/d131Lebj/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+<iframe width="100%" height="500" src="https://jsfiddle.net/d131Lebj/1591/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>


### PR DESCRIPTION
In the Select2 example, the watcher for `value` is missing the `.trigger('change')` method to update the selected drop down value in the Select2 plugin.
Without this, the `val(value)` will be set correctly, but the selected option that appears in the select box will not change.