### PR TITLE
I don't know how to summarize this…

### DIFF
--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -739,7 +739,7 @@ components/
 These components lay the foundation for consistent styling and behavior in your application. They may **only** contain:
 
 - HTML elements,
-- other `Base`-prefixed components, and
+- other base components, and
 - 3rd-party UI components.
 
 But they'll **never** contain global state (e.g. from a Vuex store).


### PR DESCRIPTION
…but saying "[Base] components may only contain other `Base`-prefixed components" is misleading IMO. I believe the message here is "Base component may only contain _other base components_" instead.