### PR TITLE
Fix component name in template example

### DIFF
--- a/src/v2/guide/components-props.md
+++ b/src/v2/guide/components-props.md
@@ -20,7 +20,7 @@ Vue.component('blog-post', {
 
 ``` html
 <!-- kebab-case in HTML -->
-<child post-title="hello!"></child>
+<blog-post post-title="hello!"></blog-post>
 ```
 
 Again, if you're using string templates, this limitation does not apply.


### PR DESCRIPTION
component was defined as "blog-post" but usage stated "<child>"