### PR TITLE
Fix double period usage in the axios cookbook

### DIFF
--- a/src/v2/cookbook/using-axios-to-consume-apis.md
+++ b/src/v2/cookbook/using-axios-to-consume-apis.md
@@ -124,7 +124,7 @@ new Vue({
       .catch(error => {
         console.log(error)
         this.errored = true
-      }).
+      })
       .finally(() => this.loading = false)
   }
 })


### PR DESCRIPTION
Previously there was a syntax error with the unexpected second full stop.