### PR TITLE
Fix typo

### DIFF
--- a/src/v2/cookbook/unit-testing-vue-components.md
+++ b/src/v2/cookbook/unit-testing-vue-components.md
@@ -178,7 +178,7 @@ The below example improves the test by:
 
 - only making one assertion per `it` block
 - having short, clear test descriptions
-- providing only the minimum data requires for the test
+- providing only the minimum data required for the test
 - refactoring duplicated logic (creating the `wrapper` and setting the `username` variable) into a factory function
 
 *Updated test*:


### PR DESCRIPTION
A very minor change that has practically no impact. Just found it while translating.
```
providing only the minimum data require- s -> d- for the test
```
Cheers,
Bart