### PR TITLE
[Guide] .passive added to list of event modifiers

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -171,6 +171,7 @@ To address this problem, Vue provides **event modifiers** for `v-on`. Recall tha
 - `.capture`
 - `.self`
 - `.once`
+- `.passive`
 
 ``` html
 <!-- the click event's propagation will be stopped -->


### PR DESCRIPTION
`.passive` event modifier was added in 2.3.0. It has a separate section with detailed description. But is no mentioned in the list of all possible modifiers. I think it deserves mentioning.