### PR TITLE
restore 'will not work' to v-bind.sync docs

### DIFF
--- a/src/v2/guide/components-custom-events.md
+++ b/src/v2/guide/components-custom-events.md
@@ -165,4 +165,4 @@ The `.sync` modifier can also be used with `v-bind` when using an object to set 
 
 This passes each property in the `doc` object (e.g. `title`) as an individual prop, then adds `v-on` update listeners for each one.
 
-<p class="tip">Using <code>v-bind.sync</code> with a literal object, such as in <code>v-bind.sync="{ title: doc.title }"</code>, because there are too many edge cases to consider in parsing a complex expression like this.</p>
+<p class="tip">Using <code>v-bind.sync</code> with a literal object, such as in <code>v-bind.sync="{ title: doc.title }"</code>, will not work, because there are too many edge cases to consider in parsing a complex expression like this.</p>


### PR DESCRIPTION
It looks like a recent change accidentally removed "will not work". This commit just adds it back.