### PR TITLE
Update name description

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1141,7 +1141,7 @@ type: api
 
   Allow the component to recursively invoke itself in its template. Note that when a component is registered globally with `Vue.component()`, the global ID is automatically set as its name.
 
-  Another benefit of specifying a `name` option is debugging. Named components result in more helpful warning messages. Also, when inspecting an app in the [vue-devtools](https://github.com/vuejs/vue-devtools), unnamed components will show up as `<AnonymousComponent>`, which isn't very informative. By providing the `name` option, you will get a much more informative component tree.
+  Another benefit of specifying a `name` option is debugging. When inspecting an app in the [vue-devtools](https://github.com/vuejs/vue-devtools), unnamed components will show up as `<AnonymousComponent>`, which isn't very informative. By providing the `name` option, you will get a much more informative component tree.
 
 ### delimiters
 


### PR DESCRIPTION
To me it seems, the removed part no longer holds true. In stack traces the component names no longer show. Instead the uniform "VueComponent" is used.