### PR TITLE
Fixed expects for "is" prop for dynamic components

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -2179,7 +2179,7 @@ Used to denote a `<template>` element as a scoped slot, which is replaced by [`s
 
 ### is
 
-- **Expects:** `string`
+- **Expects:** `string | Object (component’s options object)`
 
   Used for [dynamic components](../guide/components.html#Dynamic-Components) and to work around [limitations of in-DOM templates](../guide/components.html#DOM-Template-Parsing-Caveats).
 


### PR DESCRIPTION
`is` prop for dynamic components expects a globally registered name of component or component’s options object demonstrated in this [fiddle](https://jsfiddle.net/chrisvfritz/b2qj69o1/).