### PR TITLE
change NODE_ENV to follow recommendations from webpack

### DIFF
--- a/src/v2/guide/deployment.md
+++ b/src/v2/guide/deployment.md
@@ -36,9 +36,7 @@ module.exports = {
   plugins: [
     // ...
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('production')
-      }
+      'process.env.NODE_ENV': NODE_ENV: JSON.stringify('production')
     })
   ]
 }

--- a/src/v2/guide/deployment.md
+++ b/src/v2/guide/deployment.md
@@ -36,7 +36,7 @@ module.exports = {
   plugins: [
     // ...
     new webpack.DefinePlugin({
-      'process.env.NODE_ENV': NODE_ENV: JSON.stringify('production')
+      'process.env.NODE_ENV': JSON.stringify('production')
     })
   ]
 }


### PR DESCRIPTION
[https://webpack.js.org/plugins/define-plugin/](https://webpack.js.org/plugins/define-plugin/#feature-flags)

> When defining values for process prefer 'process.env.NODE_ENV': JSON.stringify('production') over process: { env: { NODE_ENV: JSON.stringify('production') } }. 
Using the latter will overwrite the process object which can break compatibility with some modules that expect other values on the process object to be defined.