### PR TITLE
fixed message test

### DIFF
--- a/src/v2/cookbook/unit-testing-vue-components.md
+++ b/src/v2/cookbook/unit-testing-vue-components.md
@@ -194,7 +194,7 @@ const factory = (values = {}) => {
 
 describe('Foo', () => {
   it('renders a welcome message', () => {
-    const wrapper = factory()
+    const wrapper = factory({ message: 'Welcome to the Vue.js cookbook' })
 
     expect(wrapper.find('.message').text()).toEqual("Welcome to the Vue.js cookbook")
   })


### PR DESCRIPTION
Passing the 'message' attribute in the updated tests was missing.
Passing no object would result in the 'data' property being empty, which in turn wouldn't render 'Welcome to the Vue.js cookbook'.