### PR TITLE
Fix client-side-storage.md markup

### DIFF
--- a/src/v2/cookbook/client-side-storage.md
+++ b/src/v2/cookbook/client-side-storage.md
@@ -56,9 +56,7 @@ And then finally, an example in Microsoft Edge. Note that you can find applicati
 
 ![Storage devtools in Edge](/images/devtools-storage-edge.png)
 
-<p class="tip">
-As a quick aside, these dev tools also offer you a way to remove storage values. This can be very useful when testing.
-</p>
+<p class="tip">As a quick aside, these dev tools also offer you a way to remove storage values. This can be very useful when testing.</p>
 
 Immediately writing the value may not advisable. Let's consider a slightly more advanced example. First, the updated form.
 


### PR DESCRIPTION
Remove unnecessary line-break from tip-block
<img width="671" alt="2018-05-21 10 05 42" src="https://user-images.githubusercontent.com/4497128/40294524-a14613bc-5cde-11e8-9809-695d09819dbc.png">
