### PR TITLE
A fix in example

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -348,7 +348,7 @@ type: api
   Vue.component('my-component', { /* ... */ })
 
   // retrieve a registered component (always return constructor)
-  var MyComponent = Vue.component('my-component')
+  var MyComponent = Vue.component('my-component', {})
   ```
 
 - **See also:** [Components](../guide/components.html)


### PR DESCRIPTION
When creating a component with the returned constructor an error is thrown `TypeError: Dp is not a constructor`. Passing an empty options object seems to fix this.