### PR TITLE
Added link to vuemeetups.org to the ecosystem drop-down menu on website.

### DIFF
--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -5,6 +5,7 @@
     <li><ul>
       <li><a href="https://forum.vuejs.org/" class="nav-link" target="_blank">Forum</a></li>
       <li><a href="https://chat.vuejs.org/" class="nav-link" target="_blank">Chat</a></li>
+      <li><a href="https://www.vuemeetups.org/" class="nav-link" target="_blank">Meetups</a></li>
     </ul></li>
     <li><h4>Tooling</h4></li>
     <li>


### PR DESCRIPTION
This Pull Request is related to the following issue: #1678 

Basically, I added one line of HTML to the /themes/vue/layout/partials/ecosystem_dropdown.ejs file.
The line is a link to the vuemeetups.org website.

Thanks for your time.