### PR TITLE
Correct mistake of "Migration from Vue 1.x"

### DIFF
--- a/src/v2/guide/migration.md
+++ b/src/v2/guide/migration.md
@@ -364,7 +364,7 @@ computed: {
 Or with component methods:
 
 ``` js
-template: '<p>message: {{ getTimeMessage }}</p>',
+template: '<p>message: {{ getTimeMessage() }}</p>',
 methods: {
   getTimeMessage: function () {
     return Date.now() + this.message


### PR DESCRIPTION
`getTimeMessage` should not be used in Mustaches since the property is a method. It will now wrongly output `function () { [native code] }`.
And I think other translations have the same mistake. 😭 