### PR TITLE
Fix npm sfc package reference from build/wrapper.js to src/wrapper.js

### DIFF
--- a/src/v2/cookbook/packaging-sfc-for-npm.md
+++ b/src/v2/cookbook/packaging-sfc-for-npm.md
@@ -172,7 +172,7 @@ With the package.json `scripts` section ready and the SFC wrapper in place, all 
 import vue from 'rollup-plugin-vue'; // Handle .vue SFC files
 import buble from 'rollup-plugin-buble'; // Transpile/polyfill with reasonable browser support
 export default {
-    input: 'build/wrapper.js', // Path relative to package.json
+    input: 'src/wrapper.js', // Path relative to package.json
     output: {
         name: 'MyComponent',
         exports: 'named',


### PR DESCRIPTION
Fix a typo in `rollup.config.js` to correctly reference `src/wrapper.js`. 