### PR TITLE
Fix last sponsor image link URL 404 - Prevent loss of sponsorship

### DIFF
--- a/themes/vue/layout/partials/sponsors.ejs
+++ b/themes/vue/layout/partials/sponsors.ejs
@@ -34,10 +34,18 @@
 
 <script>
 window.addEventListener('load', function () {
+  const searchUrl = [
+    'https://opencollective.com/vuejs/tiers/platinum-sponsors/1/website',
+    'https://opencollective.com/vuejs/tiers/gold-sponsors/7/website'
+  ];
+  const replaceUrl = 'https://opencollective.com/vuejs';
   [].forEach.call(document.querySelectorAll('.open-collective-sponsors img'), function (img) {
     if (img.width === 1) {
       img.width = 0
       img.parentElement.style.margin = '0 -1px 0 0'
+    }
+    if (searchUrl.indexOf(img.parentElement.href) !== -1) {
+      img.parentElement.setAttribute('href', replaceUrl)
     }
   })
 })


### PR DESCRIPTION
The list of sponsors, Open Collectives last sponsor image gives a 'Not found' on click, instead we should direct users through to the Open Collective vue landing page, where they can now become a sponsor, preventing loss of sponsorship.
Since its all hard coded we have to replace the URL. Another option would be to reduce the loop numbers to remove the last image and add a static button afterwards.