### PR TITLE
The keynote Github link has changed.

### DIFF
--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -391,7 +391,7 @@ order: 803
         'rollup-plugin-vue', 'vue-issue-helper'
       ],
       reposPersonal: [
-        'vue-keynote', 'bootstrap-for-vue', 'vue-interop'
+        'keynote', 'bootstrap-for-vue', 'vue-interop'
       ],
       links: [
         'https://znck.me', 'https://www.codementor.io/znck'


### PR DESCRIPTION
https://github.com/znck/vue-keynote seems to be the old github repo.
New one is: https://github.com/znck/keynote