### PR TITLE
Proposal: change mutation name style

### DIFF
--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -1940,13 +1940,13 @@ export default {
     list: []
   },
   mutations: {
-    REMOVE_TODO (state, todoId) {
+    todoRemoved (state, todoId) {
       state.list = state.list.filter(todo => todo.id !== todoId)
     }
   },
   actions: {
     removeTodo ({ commit, state }, todo) {
-      commit('REMOVE_TODO', todo.id)
+      commit('todoRemoved', todo.id)
     }
   }
 }


### PR DESCRIPTION
The original text uses `REMOVE_TODO` (uppercase constant style, reminiscent of React and Redux) as mutation name in an example. I propose that it changes to `todoRemoved`, a style that will match the rest of the code, while maintaining a clear distinction from related actions.