### PR TITLE
FIX: Cookbook - Packaging Components for npm

### DIFF
--- a/src/v2/cookbook/packaging-sfc-for-npm.md
+++ b/src/v2/cookbook/packaging-sfc-for-npm.md
@@ -50,7 +50,7 @@ For the purposes of this section, assume the following file structure:
 ```
 package.json
 build/
-   rollup.config.json
+   rollup.config.js
 src/
    wrapper.js
    my-component.vue


### PR DESCRIPTION
The example folder structure defines a rollup.config.json file, however the adjoined documentation involves creating a rollup.config.js file.