### PR TITLE
Explicitly specify arguments

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1590,11 +1590,11 @@ type: api
 
   - If both event and callback are given, remove the listener for that specific callback only.
 
-### vm.$emit( eventName, [...args] )
+### vm.$emit( eventName, [...arguments] )
 
 - **Arguments:**
   - `{string} eventName`
-  - `[...args]`
+  - `[...arguments]`
 
   Trigger an event on the current instance. Any additional arguments will be passed into the listener's callback function.
 


### PR DESCRIPTION
Destructuring "args" throws an error. It is not clear that you need to destructure "arguments" therefore changing this to ...arguments is more explicit.