### PR TITLE
Clarify that custom events do not bubble

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -340,6 +340,9 @@ Then on our blog post, we can listen for this event with `v-on`, just as we woul
 ></blog-post>
 ```
 
+<p class="tip">Unlike native events, custom events do not bubble up to ancestors in the DOM. The only place you can listen for a custom event is within the parent component on the component element referencing the one where the emitting happens, like where you would put the `v-model` attribute. Listening in any grandparent component or in any ancestor element of the component element within the parent component will not work.</p>
+
+
 {% raw %}
 <div id="blog-posts-events-demo" class="demo">
   <div :style="{ fontSize: postFontSize + 'em' }">


### PR DESCRIPTION
This may be a bit wordy, but I remember when I was first working with VueJS, it confused me that custom events didn't bubble up. I thought I could listen to custom events on any grandparent element.

With these changes, I would like to have this pointed out to people if I'm not alone on this.

The text I used might be a bit wordy, so feel free to suggest changes.