### PR TITLE
Default Slot content text was unclear

### DIFF
--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -136,7 +136,7 @@ There can still be one unnamed slot, which is the **default slot** that serves a
 
 There are cases when it's useful to provide a slot with default content. For example, a `<submit-button>` component might want the content of the button to be "Submit" by default, but also allow users to override with "Save", "Upload", or anything else.
 
-To achieve this, specify the default content in between the `<slot>` tags in your components template.
+To achieve this, specify the default content in between the `<slot>` tags in your component's template:
 
 ```html
 <button type="submit">

--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -136,7 +136,7 @@ There can still be one unnamed slot, which is the **default slot** that serves a
 
 There are cases when it's useful to provide a slot with default content. For example, a `<submit-button>` component might want the content of the button to be "Submit" by default, but also allow users to override with "Save", "Upload", or anything else.
 
-To achieve this, specify the default content in between the `<slot>` tags.
+To achieve this, specify the default content in between the `<slot>` tags in your components template.
 
 ```html
 <button type="submit">


### PR DESCRIPTION
I know it should be clear out of context, that the default content needs to be applied inside the template of this component.
Yet I got stuck while reading this– explicitly pointing to the template again prevents these hickups and doesn't bother people who dont need it.