### PR TITLE
fix: removing margins from nested ul/ol, top avoid awkward spacing.

### DIFF
--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -99,6 +99,10 @@
     padding-left: 1.5em
     // FIX: Some link click targets are covered without this
     position: inherit
+    // FIX: For nested lists, the top margins on ul/ol
+    // creates extra space at the top. (Issue: 1308)
+    ul, ol
+      margin: 0;
   a
     color: $green
     font-weight: 600


### PR DESCRIPTION
This is to address the margins in the hacker news example (https://github.com/vuejs/vuejs.org/issues/1308).

By resetting the margins to 0, this undos the trick that allows for easier text highlighting and anchor positioning.