### PR TITLE
Replace Webpack Template with Vue CLI in Tooling

### DIFF
--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -11,7 +11,7 @@
     <li>
       <ul>
         <li><a href="https://github.com/vuejs/vue-devtools" class="nav-link" target="_blank">Devtools</a></li>
-        <li><a href="https://vuejs-templates.github.io/webpack" class="nav-link" target="_blank">Webpack Template</a></li>
+        <li><a href="https://cli.vuejs.org/" class="nav-link" target="_blank">Vue CLI</a></li>
         <li><a href="https://vue-loader.vuejs.org" class="nav-link" target="_blank">Vue Loader</a></li>
       </ul>
     </li>


### PR DESCRIPTION
Since Vue CLI is an official project and very useful to VueJS developers, I think it should be added to the menu. Otherwise, it can be a bit tricky to discover unless one is looking for it. The logical place seems to be Ecosystem > Tooling.