### PR TITLE
Update W3C link about custom element naming

### DIFF
--- a/src/v2/guide/components-registration.md
+++ b/src/v2/guide/components-registration.md
@@ -16,7 +16,7 @@ Vue.component('my-component-name', { /* ... */ })
 
 The component's name is the first argument of `Vue.component`.
 
-The name you give a component may depend on where you intend to use it. When using a component directly in the DOM (as opposed to in a string template or [single-file component](single-file-components.html)), we strongly recommend following the [W3C rules](https://www.w3.org/TR/custom-elements/#concepts) for custom tag names (all-lowercase, must contain a hyphen). This helps you avoid conflicts with current and future HTML elements.
+The name you give a component may depend on where you intend to use it. When using a component directly in the DOM (as opposed to in a string template or [single-file component](single-file-components.html)), we strongly recommend following the [W3C rules](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) for custom tag names (all-lowercase, must contain a hyphen). This helps you avoid conflicts with current and future HTML elements.
 
 You can see other recommendations for component names in the [Style Guide](../style-guide/#Base-component-names-strongly-recommended).
 


### PR DESCRIPTION
The link currently referenced goes to a warning about looking up the spec somewhere else.
I am linking to that page instead.