### PR TITLE
Fix repetitive closing lines

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -627,6 +627,6 @@ It should be noted that **this limitation does _not_ apply if you are using stri
 - [Single-file (`.vue`) components](single-file-components.html)
 - [`<script type="text/x-template">`](components-edge-cases.html#X-Templates)
 
-That's all you need to know about dynamic components for now -- and actually, the end of Vue's _Essentials_. Congratulations! There's still more to learn, but first, we recommend taking a break to play with Vue yourself and build something fun.
+That's all you need to know about DOM template parsing caveats for now -- and actually, the end of Vue's _Essentials_. Congratulations! There's still more to learn, but first, we recommend taking a break to play with Vue yourself and build something fun.
 
 Once you feel comfortable with the knowledge you've just digested, we recommend coming back to read the full guide on [Dynamic & Async Components](components-dynamic-async.html), as well as the other pages in the Components In-Depth section of the sidebar.


### PR DESCRIPTION
As discussed @chrisvfritz. The phrase "That's all you need to know about dynamic components for now" is being repeated in two different sections.