### PR TITLE
Replace link to webpack template with vue-cli (close #1783)

### DIFF
--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -10,8 +10,8 @@
     <li><h4>Tooling</h4></li>
     <li>
       <ul>
+        <li><a href="https://cli.vuejs.org/guide/" class="nav-link" target="_blank">Vue CLI</a></li>
         <li><a href="https://github.com/vuejs/vue-devtools" class="nav-link" target="_blank">Devtools</a></li>
-        <li><a href="https://vuejs-templates.github.io/webpack" class="nav-link" target="_blank">Webpack Template</a></li>
         <li><a href="https://vue-loader.vuejs.org" class="nav-link" target="_blank">Vue Loader</a></li>
       </ul>
     </li>


### PR DESCRIPTION
close #1783

I thought about keeping both in there, but I think we should kind of soft-deprecate the template since vue-cli is stable now, and should be considered the only officially recommended way to create projects from here on out.