### PR TITLE
Add clarification about inheritAttrs and class/style bindings. (#1787)

### DIFF
--- a/src/v2/guide/components-props.md
+++ b/src/v2/guide/components-props.md
@@ -330,12 +330,14 @@ Vue.component('base-input', {
 })
 ```
 
+<p class="tip">Note that `inheritAttrs: false` option does **not** affect `style` and `class` bindings.</p>
+
 This pattern allows you to use base components more like raw HTML elements, without having to care about which element is actually at its root:
 
 ```html
 <base-input
-  v-model="username"
-  class="username-input"
-  placeholder="Enter your username"
+  v-model="email"
+  type="email"
+  placeholder="Enter your email"
 ></base-input>
 ```

--- a/src/v2/guide/components-props.md
+++ b/src/v2/guide/components-props.md
@@ -306,8 +306,8 @@ This can be especially useful in combination with the `$attrs` instance property
 
 ```js
 {
-  class: 'username-input',
-  placeholder: 'Enter your username'
+  type: 'email',
+  placeholder: 'Enter your email'
 }
 ```
 


### PR DESCRIPTION
I've update the guide, adding the same note that appears on API docs.

I've also changed the given example for using `inheritAttrs: false` combined with base components, removing mentions to `class` to avoid confusion.