### PR TITLE
Accessibility fix on newsletter form input

### DIFF
--- a/themes/vue/layout/index.ejs
+++ b/themes/vue/layout/index.ejs
@@ -69,7 +69,7 @@
 
 <div id="news">
   <div class="inner">
-    <h3>Subscribe to our Weekly Newsletter</h3>
+    <h3><label for="member_email">Subscribe to our Weekly Newsletter</label></h3>
     <form
       class="newsletter-form"
       id="revue-form"


### PR DESCRIPTION
Fixes the issue: "Form elements do not have associated labels". Labels ensure that form controls are announced properly by assistive technologies, like screen readers.
https://dequeuniversity.com/rules/axe/2.2/label?application=lighthouse