### PR TITLE
Fix documentation on how to use production mode with webpack3

### DIFF
--- a/src/v2/guide/deployment.md
+++ b/src/v2/guide/deployment.md
@@ -26,7 +26,7 @@ module.exports = {
 }
 ```
 
-But in Webpack 3 and earlier, you'll need to use [DefinePlugin](https://webpack.js.org/plugins/define-plugin/):
+But in Webpack 3 and earlier, you will need to use the minified version of vue throughout (`vue.min`) and you'll need to use [DefinePlugin](https://webpack.js.org/plugins/define-plugin/):
 
 ``` js
 var webpack = require('webpack')


### PR DESCRIPTION
In order to get production mode to work with webpack 3, I needed to use vue.min, which is not part of the documentation.  The current documentation suggests you need to use vue.min only if you are *not* using a buildpack.  I have fixed the documentation below.