### PR TITLE
Changed ES7 to ES2016 as per comment

### DIFF
--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -119,10 +119,11 @@ Vue.component('example', {
 })
 ```
 
-Since `$nextTick()` returns a promise, you can achieve the same as the above using the new [ES7 async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) syntax:
+Since `$nextTick()` returns a promise, you can achieve the same as the above using the new [ES2016 async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) syntax:
 
 ```
-...
+Vue.component('example', {
+  // ...
   methods: {
     async updateMessage: function () {
       this.message = 'updated'
@@ -131,5 +132,5 @@ Since `$nextTick()` returns a promise, you can achieve the same as the above usi
       console.log(this.$el.textContent) // => 'updated'
     }
   }
-...
+})
 ```

--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -99,7 +99,7 @@ Vue.nextTick(function () {
 
 There is also the `vm.$nextTick()` instance method, which is especially handy inside components, because it doesn't need global `Vue` and its callback's `this` context will be automatically bound to the current Vue instance:
 
-```
+``` js
 Vue.component('example', {
   template: '<span>{{ message }}</span>',
   data: function () {
@@ -121,7 +121,7 @@ Vue.component('example', {
 
 Since `$nextTick()` returns a promise, you can achieve the same as the above using the new [ES2016 async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) syntax:
 
-```js
+``` js
   methods: {
     async updateMessage: function () {
       this.message = 'updated'

--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -99,7 +99,7 @@ Vue.nextTick(function () {
 
 There is also the `vm.$nextTick()` instance method, which is especially handy inside components, because it doesn't need global `Vue` and its callback's `this` context will be automatically bound to the current Vue instance:
 
-``` js
+```
 Vue.component('example', {
   template: '<span>{{ message }}</span>',
   data: function () {
@@ -121,9 +121,7 @@ Vue.component('example', {
 
 Since `$nextTick()` returns a promise, you can achieve the same as the above using the new [ES2016 async/await](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function) syntax:
 
-```
-Vue.component('example', {
-  // ...
+```js
   methods: {
     async updateMessage: function () {
       this.message = 'updated'
@@ -132,5 +130,4 @@ Vue.component('example', {
       console.log(this.$el.textContent) // => 'updated'
     }
   }
-})
 ```


### PR DESCRIPTION
Changed the ES7 nickname to ES2016 as per a comment request. Also added `Vue.component` so syntax highlighter will pick up on the code.