### PR TITLE
Remove "declarative" from "Computed Properties and Watchers"

### DIFF
--- a/src/v2/guide/computed.md
+++ b/src/v2/guide/computed.md
@@ -14,7 +14,7 @@ In-template expressions are very convenient, but they are meant for simple opera
 </div>
 ```
 
-At this point, the template is no longer simple and declarative. You have to look at it for a second before realizing that it displays `message` in reverse. The problem is made worse when you want to include the reversed message in your template more than once.
+At this point, the template is no longer simple. You have to look at it for a second before realizing that it displays `message` in reverse. The problem is made worse when you want to include the reversed message in your template more than once.
 
 That's why for any complex logic, you should use a **computed property**.
 


### PR DESCRIPTION
Hi, Vue team! Thank you for your so kindful documents!

I'm very new to Vue, but I'm a little bit familiar with Haskell/Scala. I disagree with the following description.


``` html
<div id="example">
  {{ message.split('').reverse().join('') }}
</div>
```

> At this point, the template is no longer simple and declarative. 

(from: <https://vuejs.org/v2/guide/computed.html>)


I don't think that the template is **no longer declarative**. I agree that the template is not simple and putting too much logic as you mentioned. But, I think it is still declarative. 

For example, I think the following code is NOT declarative and very imperative.

```js
// NOTE: declarative
function reverseStr1(str) {
  let result = "";
  for (let i = str.length - 1; i >= 0; i--) {
    result += str[i];
  }
  return result;
}
```

Comparing with the code above, I think the function below is written in declarative way.

```js
function reverseStr2(str) {
  return str.split('').reverse().join('')
}
```


So this PR removed "declarative" from the document.

I'd like to discuss this topic.

Thank you!