### PR TITLE
Cookbook - [14] - Practical use of scoped slots with GoogleMaps - follow-up

### DIFF
--- a/src/v2/cookbook/practical-use-of-scoped-slots.md
+++ b/src/v2/cookbook/practical-use-of-scoped-slots.md
@@ -36,7 +36,7 @@ Let’s first establish our `GoogleMapLoader.vue` template:
 Now, our script needs to pass some props to the component which allows us to set the [Google Maps API](https://developers.google.com/maps/documentation/javascript/reference/) and [Map object](https://developers.google.com/maps/documentation/javascript/reference/map#Map):
 
 ```js
-import GoogleMapsApiLoader from "google-maps-api-loader"
+import GoogleMapsApiLoader from 'google-maps-api-loader'
 
 export default {
   props: {
@@ -61,7 +61,7 @@ export default {
 
   methods: {
     initializeMap() {
-      const mapContainer = this.$refs.googleMap)
+      const mapContainer = this.$refs.googleMap
       this.map = new this.google.maps.Map(
         mapContainer, this.mapConfig
       )
@@ -96,7 +96,7 @@ Next up, our script needs to receive props from the parent component which will 
 - [apiKey](https://developers.google.com/maps/documentation/javascript/get-api-key): Our personal api key required by Google Maps
 
 ```js
-import GoogleMapsApiLoader from "google-maps-api-loader"
+import GoogleMapsApiLoader from 'google-maps-api-loader'
 
 export default {
   props: {
@@ -237,7 +237,7 @@ Now when we have our map ready we will create two factory components that will b
 `GoogleMapMarker.vue`
 
 ```js
-import { POINT_MARKER_ICON_CONFIG } from "@/constants/mapSettings"
+import { POINT_MARKER_ICON_CONFIG } from '@/constants/mapSettings'
 
 export default {
   props: {
@@ -269,7 +269,7 @@ export default {
 `GoogleMapLine.vue`
 
 ```js
-import { LINE_PATH_CONFIG } from "@/constants/mapSettings"
+import { LINE_PATH_CONFIG } from '@/constants/mapSettings'
 
 export default {
   props: {
@@ -340,9 +340,7 @@ Here we go, integrating the data points directly into the template:
 We need to import the required factory components in our script and set the data that will be passed to the markers and lines:
 
 ```js
-import {
-  mapSettings
-} from '@/constants/mapSettings'
+import { mapSettings } from '@/constants/mapSettings'
 
 export default {
   components: {
@@ -354,9 +352,9 @@ export default {
   data () {
     return {
       markers: [
-      { id: "a", position: { lat: 3, lng: 101 } },
-      { id: "b", position: { lat: 5, lng: 99 } },
-      { id: "c", position: { lat: 6, lng: 97 } },
+      { id: 'a', position: { lat: 3, lng: 101 } },
+      { id: 'b', position: { lat: 5, lng: 99 } },
+      { id: 'c', position: { lat: 6, lng: 97 } },
       ],
       lines: [
         { id: '1', path: [{ lat: 3, lng: 101 }, { lat: 5, lng: 99 }] },


### PR DESCRIPTION
This PR is a follow-up to https://github.com/vuejs/vuejs.org/pull/1754
It removes obsolete parenthesis spotted after merge and unifies quotation marks in `script` tags. 