### PR TITLE
Added usage information about inline-templates and x-templates

### DIFF
--- a/src/v2/guide/components-edge-cases.md
+++ b/src/v2/guide/components-edge-cases.md
@@ -331,6 +331,8 @@ When the `inline-template` special attribute is present on a child component, th
 </my-component>
 ```
 
+<p>Your inline template needs to be defined outside the DOM element to which Vue is attached.</p>
+
 <p class="tip">However, <code>inline-template</code> makes the scope of your templates harder to reason about. As a best practice, prefer defining templates inside the component using the <code>template</code> option or in a <code>&lt;template&gt;</code> element in a <code>.vue</code> file.</p>
 
 ### X-Templates
@@ -348,6 +350,8 @@ Vue.component('hello-world', {
   template: '#hello-world-template'
 })
 ```
+
+<p>Your x-template needs to be defined outside the DOM element to which Vue is attached.</p>
 
 <p class="tip">These can be useful for demos with large templates or in extremely small applications, but should otherwise be avoided, because they separate templates from the rest of the component definition.</p>
 

--- a/src/v2/guide/components-edge-cases.md
+++ b/src/v2/guide/components-edge-cases.md
@@ -331,7 +331,7 @@ When the `inline-template` special attribute is present on a child component, th
 </my-component>
 ```
 
-<p>Your inline template needs to be defined outside the DOM element to which Vue is attached.</p>
+<p>Your inline template needs to be defined inside the DOM element to which Vue is attached.</p>
 
 <p class="tip">However, <code>inline-template</code> makes the scope of your templates harder to reason about. As a best practice, prefer defining templates inside the component using the <code>template</code> option or in a <code>&lt;template&gt;</code> element in a <code>.vue</code> file.</p>
 


### PR DESCRIPTION
I wasted a whole day on this issue as it wasn't documented, AFAIK. StackOverflow people thankfully were able to help: https://stackoverflow.com/questions/52940350/vue-component-error-property-or-method-x-is-not-defined-on-the-instance-but-ref