### PR TITLE
Update custom-directive.md to link to VNode info where VNodes are first mentioned

### DIFF
--- a/src/v2/guide/custom-directive.md
+++ b/src/v2/guide/custom-directive.md
@@ -66,6 +66,8 @@ A directive definition object can provide several hook functions (all optional):
 
 - `update`: called after the containing component's VNode has updated, __but possibly before its children have updated__. The directive's value may or may not have changed, but you can skip unnecessary updates by comparing the binding's current and old values (see below on hook arguments).
 
+<p class="tip">We'll cover VNodes in more detail [later](./render-function.html#The-Virtual-DOM), when we discuss [render functions](./render-function.html).</p>
+
 - `componentUpdated`: called after the containing component's VNode __and the VNodes of its children__ have updated.
 
 - `unbind`: called only once, when the directive is unbound from the element.


### PR DESCRIPTION
Otherwise, VNode is used without definition the first time you encounter it in the Guide.  

This PR implements the preferred change from @phanan in [#1799 (comment)](https://github.com/vuejs/vuejs.org/issues/1799#issuecomment-422380734), except that I added a direct link to the section as well as the link to the page.

Fixes #1799.

First PR in Vue.  Thanks for considering this request!