### PR TITLE
Updated syntax

### DIFF
--- a/src/v2/guide/class-and-style.md
+++ b/src/v2/guide/class-and-style.md
@@ -100,7 +100,7 @@ Which will render:
 If you would like to also toggle a class in the list conditionally, you can do it with a ternary expression:
 
 ``` html
-<div v-bind:class="[isActive ? activeClass : '', errorClass]"></div>
+<div v-bind:class="[isActive ? 'activeClass' : '', 'errorClass']"></div>
 ```
 
 This will always apply `errorClass`, but will only apply `activeClass` when `isActive` is truthy.


### PR DESCRIPTION
Original:

`<div v-bind:class="[isActive ? activeClass : '', errorClass]"></div>`

Updated:

`<div v-bind:class="[isActive ? 'activeClass' : '', 'errorClass']"></div>`

Vue template will not compile if we will use the `Orginal syntax` that is mentioned in the doc, in order to apply classes and template to be compiled it should be replaced by `Updated syntax`