### PR TITLE
Address self-closing component syntax

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -51,6 +51,8 @@ new Vue({ el: '#components-demo' })
 
 Since components are reusable Vue instances, they accept the same options as `new Vue`, such as `data`, `computed`, `watch`, `methods`, and lifecycle hooks. The only exceptions are a few root-specific options like `el`.
 
+Note: Vue Component syntax is never written with self closing tags like `<br />` or `<component-name />` and must **always** be written with an accompanying closing tag. `<component-name></component-name>`
+
 ## Reusing Components
 
 Components can be reused as many times as you want:


### PR DESCRIPTION
As a user coming from other frameworks - you might expect self-closing element syntax to be acceptable. Upon creating your first component this way - it will appear to work as intended. However, no elements after this component will be rendered and there isn't any warning or error. When inspecting the elements - the DOM seems to have it's closing tags. _So_, build a component: use a `<self-closing />` syntax and it'll work as you might expect: then put that in a v-for or use it twice and everything breaks with no information on why. It could lead users to question the directive - or the CLI - or any number of things that they shouldn't be thinking about.

I'd welcome better phrasing. : )

_Note: Vue Component syntax is never written with self-closing tags like `<br />` or `<component-name />` and must **always** be written with an accompanying closing tag. `<component-name></component-name>`_ .   - I thought about saying 'regardless of slot' - but didn't want to mention slots this early.

Should there be a link to why this is? That seems unnecessary - as it's not really open for debate due to how vue uses the browser parser.

