### PR TITLE
Fixing vm.$once arguments docstring. It's allowed to receive an array…

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1569,7 +1569,7 @@ type: api
 ### vm.$once( event, callback )
 
 - **Arguments:**
-  - `{string} event`
+  - `{string | Array<string>} event` (array only supported in 2.2.2+)
   - `{Function} callback`
 
 - **Usage:**


### PR DESCRIPTION
Fixing vm.$once arguments docstring. It's allowed to receive an arra of events as the first param.

This PR should be acceptedafter the PR #8995 (https://github.com/vuejs/vue/pull/8995) in the main vue repo gets merged and released as a stable version, since it fixes the .ts types to allow this use of vm.$once without linter errors.