### PR TITLE
 Unify examples HTML formatting

### DIFF
--- a/src/v2/guide/class-and-style.md
+++ b/src/v2/guide/class-and-style.md
@@ -21,9 +21,10 @@ The above syntax means the presence of the `active` class will be determined by 
 You can have multiple classes toggled by having more fields in the object. In addition, the `v-bind:class` directive can also co-exist with the plain `class` attribute. So given the following template:
 
 ``` html
-<div class="static"
-     v-bind:class="{ active: isActive, 'text-danger': hasError }">
-</div>
+<div
+  class="static"
+  v-bind:class="{ active: isActive, 'text-danger': hasError }"
+></div>
 ```
 
 And the following data:

--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -323,8 +323,8 @@ Now we can pass the todo into each repeated component using `v-bind`:
     <todo-item
       v-for="item in groceryList"
       v-bind:todo="item"
-      v-bind:key="item.id">
-    </todo-item>
+      v-bind:key="item.id"
+    ></todo-item>
   </ol>
 </div>
 ```


### PR DESCRIPTION
2 documentation examples were formatted differently from the rest.