### PR TITLE
Add a note that slot-scope expects a string value

### DIFF
--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -227,3 +227,5 @@ The value of `slot-scope` can actually accept any valid JavaScript expression th
 ```
 
 This is a great way to make scoped slots a little cleaner.
+
+Note for beginners: `slot-scope` expects a literal string value of your JavaScript expression. Do __not__ use `v-bind:` with `slot-scope` __unless__ the returned value contains a string with the javascript expression you want scoped to your slot. If you're having problems accessing the scoped variables in your slot, then __make sure you haven't accidentally used `v-bind` on `slot-scope`__


### PR DESCRIPTION
I'm used to using the shorthand `:attr` for `v-bind:attr`, and I didn't notice that `v-bind` was missing for `slot-scope` in the docs. I spent several hours scouring these docs, the internet, and my code as I was trying to figure out why my slots were showing up in `vm.$slots` instead of `vm.$scopedSlots`.

I got confused because the _destructuring `slot-scope`_ section of this page said I could use any valid JS expression for `slot-scope`. I thought it might be useful to clarify that the actual attribute for `slot-scope` needs to be passed through as a literal string.