### PR TITLE
Specify which types are allowed as values for 'key' of 'v-for'

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -233,6 +233,8 @@ It is recommended to provide a `key` with `v-for` whenever possible, unless the 
 
 Since it's a generic mechanism for Vue to identify nodes, the `key` also has other uses that are not specifically tied to `v-for`, as we will see later in the guide.
 
+<p class="tip">Don't use non-primitive values like objects and arrays as `v-for` keys. Use string or numeric values instead.</p>
+
 ## Array Change Detection
 
 ### Mutation Methods


### PR DESCRIPTION
[List Rendering](https://vuejs.org/v2/guide/list.html#key) guide doesn't mention what types of values user can supply for `key` of `v-for`. There is a console warning for this already but it's hard to point people to it. This pull request fixes the issue.