### PR TITLE
Fix mixin data merging documentation

### DIFF
--- a/src/v2/guide/mixins.md
+++ b/src/v2/guide/mixins.md
@@ -35,7 +35,7 @@ var component = new Component() // => "hello from mixin!"
 
 When a mixin and the component itself contain overlapping options, they will be "merged" using appropriate strategies.
 
-For example, data objects undergo a shallow merge (one property deep), with the component's data taking priority in cases of conflicts.
+For example, data objects undergo a recursive merge, with the component's data taking priority in cases of conflicts.
 
 ``` js
 var mixin = {


### PR DESCRIPTION
The current documentation states that `data` defined by a mixin gets merged with the component's `data` using a shallow merge. This is not true - the merge is actually a recursive one. This is a small wording change so that the documentation correctly describes current behavior.

This behavior can be easily seen in the source for the function that merges `data` (in `optionMergeStrategies`): https://github.com/vuejs/vue/blob/master/src/core/util/options.js#L48. The function will recursively merge keys from both objects.