### PR TITLE
Specified accurate url.

### DIFF
--- a/src/v2/guide/components-dynamic-async.md
+++ b/src/v2/guide/components-dynamic-async.md
@@ -235,7 +235,7 @@ Vue.component(
 )
 ```
 
-When using [local registration](components.html#Local-Registration), you can also directly provide a function that returns a `Promise`:
+When using [local registration](components-registration.html#Local-Registration), you can also directly provide a function that returns a `Promise`:
 
 ``` js
 new Vue({


### PR DESCRIPTION
Because the specification of link was not accurate, Multiple times redirect was occurring.
Since we finally transit to `https://vuejs.org/v2/guide/components-registration.html#Local-Registration`, so I specified that URL.