### PR TITLE
Fix Rollup instructions

### DIFF
--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -128,12 +128,13 @@ module.exports = {
 
 ``` js
 const alias = require('rollup-plugin-alias')
+const path = require('path');
 
 rollup({
   // ...
   plugins: [
     alias({
-      'vue': 'vue/dist/vue.esm.js'
+      'vue': path.resolve('node_modules/vue/dist/vue.esm.js')
     })
   ]
 })


### PR DESCRIPTION
This commit fixes broken instructions on how to bundle the Runtime + Compiler with Rollup.

Related: https://github.com/rollup/rollup/issues/2609