### PR TITLE
Move the footnote about using v-for with v-if to list.md

### DIFF
--- a/src/v2/guide/conditional.md
+++ b/src/v2/guide/conditional.md
@@ -194,8 +194,3 @@ In comparison, `v-show` is much simpler - the element is always rendered regardl
 
 Generally speaking, `v-if` has higher toggle costs while `v-show` has higher initial render costs. So prefer `v-show` if you need to toggle something very often, and prefer `v-if` if the condition is unlikely to change at runtime.
 
-## `v-if` with `v-for`
-
-<p class="tip">Using `v-if` and `v-for` together is **not recommended**. See the [style guide](/v2/style-guide/#Avoid-v-if-with-v-for-essential) for further information.</p>
-
-When used together with `v-if`, `v-for` has a higher priority than `v-if`. See the <a href="../guide/list.html#V-for-and-v-if">list rendering guide</a> for details.

--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -453,6 +453,8 @@ The above only renders the todos that are not complete.
 
 If instead, your intent is to conditionally skip execution of the loop, you can place the `v-if` on a wrapper element (or [`<template>`](conditional.html#Conditional-Groups-with-v-if-on-lt-template-gt)). For example:
 
+<p class="tip">Using `v-if` and `v-for` together is **not recommended**. See the [style guide](/v2/style-guide/#Avoid-v-if-with-v-for-essential) for further information.</p>
+
 ``` html
 <ul v-if="todos.length">
   <li v-for="todo in todos">


### PR DESCRIPTION
The footnote about using v-for with v-if shouldn't be present in conditional rendering docs, because list rendering has not been introduced yet.
Also, v-for with v-if is also described in the list rendering docs, which can mislead people.

It would be better if the whole information about it was present in the list rendering docs.