### PR TITLE
Change Vuetron link

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -102,7 +102,7 @@ There are other methods of debugging, varying in complexity. The most popular an
 
 ### Vuetron
 
-[Vuetron](http://vuetron.io/) is a really nice project that extends some of the work that vue-devtools has done. In addition to the normal devtools workflow, you are able to:
+[Vuetron](https://github.com/vuetwo/vuetron) is a really nice project that extends some of the work that vue-devtools has done. In addition to the normal devtools workflow, you are able to:
 
 * Quickly view API Request/Response: if you're using the fetch API for requests, this event is displayed for any request sent. The expanded card displays the request data as well as the response data.
 * Subscribe to specific parts of your application’s state for faster debugging

--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -100,16 +100,6 @@ There are other methods of debugging, varying in complexity. The most popular an
 
 <p class="tip">Please note that if the page uses a production/minified build of Vue.js (such as the standard link from a CDN), devtools inspection is disabled by default so the Vue pane won't show up. If you switch to an unminified version, you may have to give the page a hard refresh to see them.</p>
 
-### Vuetron
-
-[Vuetron](https://github.com/vuetwo/vuetron) is a really nice project that extends some of the work that vue-devtools has done. In addition to the normal devtools workflow, you are able to:
-
-* Quickly view API Request/Response: if you're using the fetch API for requests, this event is displayed for any request sent. The expanded card displays the request data as well as the response data.
-* Subscribe to specific parts of your application’s state for faster debugging
-* Visualize component hierarchy, and an animation allows you to collapse or expand the tree for specific hierarchy views.
-
-![Vuetron Hierarchy](/images/vuetron-hierarchy.gif)
-
 ### Simple Debugger Statement
 
 The example above has a great workflow. However, there is an alternative option where you can use the [native debugger statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger) directly in your code. If you choose to work this way, it's important that you remember to remove the statements when you're done.


### PR DESCRIPTION
Since vuetron.io domain was expired and redirects to some news or malware sites, I changed Vuetron link to it's github site.