### PR TITLE
Automatic Global Registration of Base Components example does not work…

### DIFF
--- a/src/v2/guide/components-registration.md
+++ b/src/v2/guide/components-registration.md
@@ -195,9 +195,9 @@ const requireComponent = require.context(
   // The relative path of the components folder
   './components',
   // Whether or not to look in subfolders
-  false,
+  true,
   // The regular expression used to match base component filenames
-  /Base[A-Z]\w+\.(vue|js)$/
+  /[A-Z]\w+\.(vue|js)$/
 )
 
 requireComponent.keys().forEach(fileName => {
@@ -205,11 +205,11 @@ requireComponent.keys().forEach(fileName => {
   const componentConfig = requireComponent(fileName)
 
   // Get PascalCase name of component
-  const componentName = upperFirst(
-    camelCase(
-      // Strip the leading `./` and extension from the filename
-      fileName.replace(/^\.\/(.*)\.\w+$/, '$1')
-    )
+  camelCase(
+    fileName
+      .split('/')
+      .pop()
+      .replace(/\.\w+$/, '')
   )
 
   // Register component globally


### PR DESCRIPTION
Automatic Global Registration of Base Components example does not work if you wanted to include subfolders. This solution has been tested and confirmed. https://stackoverflow.com/questions/53676837/registering-components-globally-in-vuejs-in-subfolders/53678945#53678945