### PR TITLE
Add comments about $watch behavior with a function

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1486,6 +1486,9 @@ type: api
   // function
   vm.$watch(
     function () {
+      // everytime the expression `this.a + this.b` yields a different result,
+      // the handler will be called. It's as if we were watching a computed
+      // property without defining the computed property itself
       return this.a + this.b
     },
     function (newVal, oldVal) {


### PR DESCRIPTION
I realised we are not explicit about this behaviour so I added some comments. I wonder if we should add a full example instead saying it in a comment. We could say that if we got `a === 2` and `b === 0` and we change both variables to `b = 2; a = 0`, the watcher won't get triggered