### PR TITLE
Invalid link to HackerNews Clone updated in hackernews.md

### DIFF
--- a/src/v2/examples/hackernews.md
+++ b/src/v2/examples/hackernews.md
@@ -14,7 +14,7 @@ order: 12
 </div>
 {% endraw %}
 
-> [Live Demo](https://vue-hn.now.sh/)
+> [Live Demo](https://vue-hn.herokuapp.com/)
 > Note: the demo may need some spin up time if nobody has accessed it for a certain period.
 >
 > [[Source](https://github.com/vuejs/vue-hackernews-2.0)]


### PR DESCRIPTION
The link to the live demo is not up-to-date. I've updated it to the same one as noted in [vue-hackernews-2.0](https://github.com/vuejs/vue-hackernews-2.0/blob/master/README.md).

The old link [vue-hn.now.sh](https://vue-hn.now.sh/) seems to be expired. It shows a 402 with the message `Payment required`.