### PR TITLE
Reword heading in slot docs to be a bit more specific

### DIFF
--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -132,7 +132,7 @@ There can still be one unnamed slot, which is the **default slot** that serves a
 </div>
 ```
 
-## Default Content of Slots
+## Default Content for Slots
 
 There are cases when it's useful to provide a slot with default content. For example, a `<submit-button>` component might want the content of the button to be "Submit" by default, but also allow users to override with "Save", "Upload", or anything else.
 

--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -132,7 +132,7 @@ There can still be one unnamed slot, which is the **default slot** that serves a
 </div>
 ```
 
-## Default Slot Content
+## Default Content of Slots
 
 There are cases when it's useful to provide a slot with default content. For example, a `<submit-button>` component might want the content of the button to be "Submit" by default, but also allow users to override with "Save", "Upload", or anything else.
 


### PR DESCRIPTION
I was reading through the slot documentation from top to bottom and when I got to the heading [Default Slot Content](https://vuejs.org/v2/guide/components-slots.html#Default-Slot-Content) I had to pause for a second because I wasn't sure if it was talking about "content of the default slot" vs "default content of slots".

I think this confusion happened because
- I had just read about the Default Slot in the previous paragraph
- Heading could be interpreted either way 

My change is an attempt to remove the small ambiguity.