### PR TITLE
Clarify that "slot-scope" is named "scope" before 2.5.0

### DIFF
--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -211,9 +211,7 @@ Now when we use the `<todo-list>` component, we can optionally define an alterna
 </todo-list>
 ```
 
-> Until 2.5.0, `slot-scope` was named `scope` and was limited to the `<template>` element.
-
-> In 2.5.0+, `slot-scope` is no longer limited to the `<template>` element, but can instead be used on any element or component in the slot.
+> Before 2.5.0, `slot-scope` was named `scope` and was limited to the `<template>` element. Since 2.5.0, `slot-scope` doesn't have this limitation and can instead be used on any element or component in the slot.
 
 ### Destructuring `slot-scope`
 

--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -211,6 +211,8 @@ Now when we use the `<todo-list>` component, we can optionally define an alterna
 </todo-list>
 ```
 
+> Until 2.5.0, `slot-scope` was named `scope` and was limited to the `<template>` element.
+
 > In 2.5.0+, `slot-scope` is no longer limited to the `<template>` element, but can instead be used on any element or component in the slot.
 
 ### Destructuring `slot-scope`


### PR DESCRIPTION
Fixes #1955