### PR TITLE
remove deprecated repos from my team page profile

### DIFF
--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -454,7 +454,7 @@ order: 803
       github: 'LinusBorg',
       twitter: 'Linus_Borg',
       reposOfficial: [
-        'vuejs/*', 'vuejs-templates/*', 'vue-touch'
+        'vuejs/*'
       ],
       reposPersonal: [
         'portal-vue'


### PR DESCRIPTION
* vuejs-templates/* is deprecated because of Vue CLI 3
* vue-touch has been depreceated because of lack of development