### PR TITLE
Add clarification about inheritAttrs and class/style bindings (#1787)

### DIFF
--- a/src/v2/guide/components-props.md
+++ b/src/v2/guide/components-props.md
@@ -313,7 +313,7 @@ This can be especially useful in combination with the `$attrs` instance property
 
 ```js
 {
-  class: 'username-input',
+  required: true,
   placeholder: 'Enter your username'
 }
 ```
@@ -337,12 +337,14 @@ Vue.component('base-input', {
 })
 ```
 
+<p class="tip">Note that `inheritAttrs: false` option does **not** affect `style` and `class` bindings.</p>
+
 This pattern allows you to use base components more like raw HTML elements, without having to care about which element is actually at its root:
 
 ```html
 <base-input
   v-model="username"
-  class="username-input"
+  required
   placeholder="Enter your username"
 ></base-input>
 ```


### PR DESCRIPTION
It closes #1787, and overrides #1796.

It adds a note to the guide, clarifying that `inheritAttrs: false` doesn't affect `class` and `style` bindings, and updates a related misleading example (`class` doesn't ever appear in `$attrs`, [see fiddle](https://jsfiddle.net/leopiccionia/1zdtvbjx/)).

cc @phanan