### PR TITLE
Remove Handlebars reference (fixes 1780)

### DIFF
--- a/src/v2/guide/conditional.md
+++ b/src/v2/guide/conditional.md
@@ -6,26 +6,17 @@ order: 7
 
 ## `v-if`
 
-In string templates, for example [Handlebars](https://handlebarsjs.com/), we would write a conditional block like this:
+The directive `v-if` is used to conditionally render a block. The block will be rendered if the directive's expression returns a truthy value and vice versa.
 
 ``` html
-<!-- Handlebars template -->
-{{#if ok}}
-  <h1>Yes</h1>
-{{/if}}
-```
-
-In Vue, we use the `v-if` directive to achieve the same:
-
-``` html
-<h1 v-if="ok">Yes</h1>
+<h1 v-if="awesome">Vue is awesome!</h1>
 ```
 
 It is also possible to add an "else block" with `v-else`:
 
 ``` html
-<h1 v-if="ok">Yes</h1>
-<h1 v-else>No</h1>
+<h1 v-if="awesome">Vue is awesome!</h1>
+<h1 v-else>Oh no 😢</h1>
 ```
 
 ### Conditional Groups with `v-if` on `<template>`

--- a/src/v2/guide/conditional.md
+++ b/src/v2/guide/conditional.md
@@ -6,7 +6,7 @@ order: 7
 
 ## `v-if`
 
-The directive `v-if` is used to conditionally render a block. The block will be rendered if the directive's expression returns a truthy value and vice versa.
+The directive `v-if` is used to conditionally render a block. The block will only be rendered if the directive's expression returns a truthy value.
 
 ``` html
 <h1 v-if="awesome">Vue is awesome!</h1>


### PR DESCRIPTION
Following up and fixes #1780. This removes the (mildly sudden) reference to Handlebars by rewriting the directive's explanation. 