### PR TITLE
Add DEV Community link to ecosystem dropdown

### DIFF
--- a/themes/vue/layout/partials/ecosystem_dropdown.ejs
+++ b/themes/vue/layout/partials/ecosystem_dropdown.ejs
@@ -28,6 +28,7 @@
       <li><a href="https://twitter.com/vuejs" class="nav-link" target="_blank">Twitter</a></li>
       <li><a href="https://medium.com/the-vue-point" class="nav-link" target="_blank">Blog</a></li>
       <li><a href="https://vuejobs.com/?ref=vuejs" class="nav-link" target="_blank">Jobs</a></li>
+      <li><a href="https://dev.to/t/vue" class="nav-link" target="_blank">DEV Community</a></li>
     </ul></li>
     <li><h4>Resource Lists</h4></li>
     <li><ul>


### PR DESCRIPTION
This change adds a helpful link to the ecosystem dropdown

[Vue content](https://dev.to/t/vue) has been growing in popularity on [DEV](https://dev.to) and it's become a great resource for getting started with and keeping up with the Vue ecosystem.

Several members of the Vue ecosystem have begun establishing a presence on the site:

https://dev.to/vuevixens
https://dev.to/nuxt

Overall, the DEV Community is growing to be a central resource for developers all over the world. 

![screen shot 2019-02-01 at 7 06 13 pm](https://user-images.githubusercontent.com/3102842/52154510-7eebc600-2654-11e9-8def-aafcd18af0ec.png)

A link can similarly be found on the [reactjs.org](https://reactjs.org) "channels" section of the footer.

![screen shot 2019-02-01 at 7 15 23 pm](https://user-images.githubusercontent.com/3102842/52154810-e22a2800-2655-11e9-9e2b-41ae3a9c8773.png)

If this is not the right place for the link, let me know what might be more appropriate. Thanks a lot!

Code for the platform can be found here:
https://github.com/thepracticaldev/dev.to

And admins (like myself) are always available to help the Vue team make the most of our community.