### PR TITLE
Add negative example warning

### DIFF
--- a/src/v2/guide/components-custom-events.md
+++ b/src/v2/guide/components-custom-events.md
@@ -17,6 +17,7 @@ this.$emit('myEvent')
 Listening to the kebab-cased version will have no effect:
 
 ```html
+<!-- Won't work -->
 <my-component v-on:my-event="doSomething"></my-component>
 ```
 


### PR DESCRIPTION
This closes #1986.

I suggest a simple HTML comment to warn readers about the negative example. I saw a similar usage in the [Slots](https://vuejs.org/v2/guide/components-slots.html#Abbreviated-Syntax-for-Lone-Default-Slots) page.

However, the whole section could be rearranged differently, by providing a better context before showing the example. We could even use a tip.

Any thoughts?
Thanks!