### PR TITLE
Fix path in documentation "Debugging in VSCode"

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -57,7 +57,7 @@ Click on the Debugging icon in the Activity Bar to bring up the Debug view, then
       "webRoot": "${workspaceFolder}/src",
       "breakOnLoad": true,
       "sourceMapPathOverrides": {
-        "webpack:///src/*": "${webRoot}/*"
+        "webpack:///./src/*": "${webRoot}/*"
       }
     },
     {


### PR DESCRIPTION
* Update sourceMapPathOverrides according to https://github.com/Microsoft/VSCode-recipes/tree/master/vuejs-cli