### PR TITLE
Fixed 404 Error from CDN

### DIFF
--- a/src/v2/examples/select2.md
+++ b/src/v2/examples/select2.md
@@ -6,4 +6,4 @@ order: 8
 
 > In this example we are integrating a 3rd party jQuery plugin (select2) by wrapping it inside a custom component.
 
-<iframe width="100%" height="500" src="https://jsfiddle.net/chrisvfritz/d131Lebj/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+<iframe width="100%" height="500" src="https://jsfiddle.net/rak_pw/spxgmc0a/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>


### PR DESCRIPTION
The resource, select2@4.0.3, was returning 404 and breaking this example
Resolved by updating resource from [unpkg.com/select2@4.0.3/index.js](unpkg.com/select2@4.0.3/index.js) to [https://unpkg.com/select2@4.0.3/dist/js/select2.min.js](https://unpkg.com/select2@4.0.3/dist/js/select2.min.js)