### PR TITLE
Fixed grid component example with different prop name

### DIFF
--- a/src/v2/examples/grid-component.md
+++ b/src/v2/examples/grid-component.md
@@ -6,4 +6,4 @@ order: 3
 
 > This is an example of creating a reusable grid component and using it with external data.
 
-<iframe width="100%" height="500" src="https://jsfiddle.net/yyx990803/xkkbfL3L/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>
+<iframe width="100%" height="500" src="https://jsfiddle.net/Tertia/vbyon64p/6/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>


### PR DESCRIPTION
The [grid component example](https://vuejs.org/v2/examples/grid-component.html) had a `demo-grid` component that accepts a prop named as `data` and if was probably confusing to new users. I changed a fiddle, here is a link to [new one](https://jsfiddle.net/Tertia/vbyon64p/6)

Close #1739 