### PR TITLE
Add Function type to props

### DIFF
--- a/src/v2/guide/components-props.md
+++ b/src/v2/guide/components-props.md
@@ -41,7 +41,8 @@ props: {
   likes: Number,
   isPublished: Boolean,
   commentIds: Array,
-  author: Object
+  author: Object,
+  callback: Function
 }
 ```
 

--- a/src/v2/guide/components-props.md
+++ b/src/v2/guide/components-props.md
@@ -42,7 +42,8 @@ props: {
   isPublished: Boolean,
   commentIds: Array,
   author: Object,
-  callback: Function
+  callback: Function,
+  contactsPromise: Promise // or any other constructor
 }
 ```
 


### PR DESCRIPTION
Hi, I realized we are not showing we can accept a Function which is a basic type in JS, it has misled people to believe they cannot use Functions.

However, I believe we can do better than just adding the line with callback: Function because we can also specify custom constructors or new ones like Promise

Looking forward to hear your feedback