### PR TITLE
to reduce misleading, add a note for [v-for with v-if] section

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -441,6 +441,8 @@ Similar to template `v-if`, you can also use a `<template>` tag with `v-for` to 
 
 ## `v-for` with `v-if`
 
+<p class="tip">Note that it's **not** recommended to use `v-if` and `v-for` together. Refer to [style guide](/v2/style-guide/#Avoid-v-if-with-v-for-essential) for details.</p>
+
 When they exist on the same node, `v-for` has a higher priority than `v-if`. That means the `v-if` will be run on each iteration of the loop separately. This can be useful when you want to render nodes for only _some_ items, like below:
 
 ``` html
@@ -461,8 +463,6 @@ If instead, your intent is to conditionally skip execution of the loop, you can 
 </ul>
 <p v-else>No todos left!</p>
 ```
-
-<p class="tip">Note that it's **not** recommended to use `v-if` and `v-for` together. Refer to [style guide](/v2/style-guide/#Avoid-v-if-with-v-for-essential) for details.</p>
 
 ## `v-for` with a Component
 

--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -462,6 +462,8 @@ If instead, your intent is to conditionally skip execution of the loop, you can 
 <p v-else>No todos left!</p>
 ```
 
+<p class="tip">Note that it's **not** recommended to use `v-if` and `v-for` together. Refer to [style guide](/v2/style-guide/#Avoid-v-if-with-v-for-essential) for details.</p>
+
 ## `v-for` with a Component
 
 > This section assumes knowledge of [Components](components.html). Feel free to skip it and come back later.


### PR DESCRIPTION
When reading the Vue document, I found section [v-for with v-if](https://vuejs.org/v2/guide/list.html#v-for-with-v-if) doesn't include any information about the fact that `v-for` and `v-if` are **not recommended** to be used together. I see in some other [section](https://vuejs.org/v2/guide/conditional.html#v-if-with-v-for) it's kindly mentioned. I think it's necessary to also mention it here to not mislead readers.