### PR TITLE
Fix Algolia docsearch dropdown visibility

### DIFF
--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -119,7 +119,8 @@
       apiKey: '85cc3221c9f23bfbaa4e3913dd7625ea',
       indexName: 'vuejs',
       inputSelector: selector,
-      algoliaOptions: { facetFilters: ["version:" + version] }
+      algoliaOptions: { facetFilters: ["version:" + version] },
+      autocompleteOptions: { hint: false, appendTo: 'body'}
       })
     })
     </script>

--- a/themes/vue/source/css/search.styl
+++ b/themes/vue/source/css/search.styl
@@ -2,6 +2,10 @@
 
 $border = #ddd
 
+@media (max-width: 900px)
+  .algolia-autocomplete
+    position: fixed!important
+
 .algolia-autocomplete
   line-height: normal
 


### PR DESCRIPTION
On tablet resolutions (568-900px) search dropdown was cut by sidebar:
![image0](https://user-images.githubusercontent.com/18719025/53870989-fcb04200-4003-11e9-8a52-59d8bd58f2a7.jpeg)

It happened because of known issue on W3C spec:
```
The computed values of ‘overflow-x’ and ‘overflow-y’ are the same as their specified values, except that some combinations with ‘visible’ are not possible: if one is specified as ‘visible’ and the other is ‘scroll’ or ‘auto’, then ‘visible’ is set to ‘auto’. The computed value of ‘overflow’ is equal to the computed value of ‘overflow-x’ if ‘overflow-y’ is the same; otherwise it is the pair of computed values of ‘overflow-x’ and ‘overflow-y’.
```

So even when `overflow-x` was set to `visible` in fact it was counted as `auto` and just added a horizontal scrollbar.

Proposed solution is not ideal (`position:fixed` will keep search dropdown visible even when scrolling down the sidebar) but probably the optimal one. Another solution would be to move search outside from `sidebar-inner-index`, set `overflow:visible` to sidebar and `overflow-y: auto` to inner sidebar wrapper. But it would mean search input will be always visible on scrolling down the sidebar.