### PR TITLE
Use immediate watcher in serverless blog cookbook post

### DIFF
--- a/src/v2/cookbook/serverless-blog.md
+++ b/src/v2/cookbook/serverless-blog.md
@@ -219,7 +219,7 @@ One thing to note when using routes with params is that when the user navigates 
 
 <p class="tip">Be aware, that using the component this way will mean that the lifecycle hooks of the component will not be called. Visit the Vue Router's docs to learn more about [Dynamic Route Matching](https://router.vuejs.org/en/essentials/dynamic-matching.html)</p>
 
-To fix this we need to watch the `$route` object and call `getPost()` when the route changes.
+To fix this we need to watch the `$route` object and call `getPost()` when the route changes. Since we call the same method in our `created()` lifecycle hook, we can trigger the watcher `immediate`ly and that way remove the `created()` hook.
 
 Updated `<script>` section in `components/BlogPost.vue`:
 
@@ -244,12 +244,12 @@ Updated `<script>` section in `components/BlogPost.vue`:
       }
     },
     watch: {
-      $route(to, from) {
-        this.getPost()
+      $route: {
+        immediate: true,
+        handler(to, from) {
+          this.getPost()
+        }
       }
-    },
-    created() {
-      this.getPost()
     }
   }
 </script>

--- a/src/v2/cookbook/serverless-blog.md
+++ b/src/v2/cookbook/serverless-blog.md
@@ -219,7 +219,7 @@ One thing to note when using routes with params is that when the user navigates 
 
 <p class="tip">Be aware, that using the component this way will mean that the lifecycle hooks of the component will not be called. Visit the Vue Router's docs to learn more about [Dynamic Route Matching](https://router.vuejs.org/en/essentials/dynamic-matching.html)</p>
 
-To fix this we need to watch the `$route` object and call `getPost()` when the route changes. Since we call the same method in our `created()` lifecycle hook, we can trigger the watcher `immediate`ly and that way remove the `created()` hook.
+To fix this we need to watch the `$route` object and call `getPost()` when the route changes.
 
 Updated `<script>` section in `components/BlogPost.vue`:
 


### PR DESCRIPTION
Since the same method gets called in the created hook, we can
add the immediate property to the watcher and remove the hook.
