### PR TITLE
Explain key uniqueness, including when generated elements are siblings.

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -235,6 +235,8 @@ Since it's a generic mechanism for Vue to identify nodes, the `key` also has oth
 
 <p class="tip">Don't use non-primitive values like objects and arrays as `v-for` keys. Use string or numeric values instead.</p>
 
+For detailed usage of the `key` attribute, please see the [`key` API documentation](https://vuejs.org/v2/api/#key).
+
 ## Array Change Detection
 
 ### Mutation Methods


### PR DESCRIPTION
The required uniqueness of keys for `v-for` isn't documented (whether it should be globally unique, unique with some particular scope, or just unique within each `v-for`).

On the Vue forum, there is a post where [the answer was it must be "unique within each `v-for`"](https://forum.vuejs.org/t/v-for-key-does-the-key-need-to-be-unique-across-the-entire-component/28040/3), however I have found that if the generated nodes are the same type and are siblings, their keys are treated as in the same scope, and can conflict even if they were generated with different `v-for` statements.

This case could happen if you want to generate a list from two groups of items, where some items (with the same key) appear in both groups, and the lists are adjacent to each other in the DOM.

I have added a subsection to to the List Rendering->`key` documentation which explains this. As I have only started using Vue recently, I hope I haven't misunderstood the problem.

I have explained it by saying "it's unique within each v-for, with this one exception", but if there's some global rule which can be explained just as easily, that would be nicer.

