### PR TITLE
Replace deprecated slot syntax in render-function.md

### DIFF
--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -626,7 +626,7 @@ You may wonder why we need both `slots()` and `children`. Wouldn't `slots().defa
 
 ``` html
 <my-functional-component>
-  <p slot="foo">
+  <p v-slot:foo>
     first
   </p>
   <p>second</p>


### PR DESCRIPTION
Hey there 👋 

I found one example that was still using the deprecated slot syntax. Hope my correction is correct 😁 