### PR TITLE
Fix the npm command and add a tip about ports

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -41,6 +41,8 @@ module.exports = {
 
 ### Launching the Application from VS Code
 
+<p class="tip">We're assuming the port to be `8080` here. If it's not the case (for instance, if `8080` has been taken and Vue CLI automatically picks another port for you), just modify the configuration accordingly.</p>
+
 Click on the Debugging icon in the Activity Bar to bring up the Debug view, then click on the gear icon to configure a launch.json file, selecting **Chrome/Firefox: Launch** as the environment. Replace content of the generated launch.json with the corresponding configuration:
 
 ![Add Chrome Configuration](/images/config_add.png)
@@ -81,7 +83,7 @@ Click on the Debugging icon in the Activity Bar to bring up the Debug view, then
 2.  Open your favorite terminal at the root folder and serve the app using Vue CLI:
 
   ```
-  npm start
+  npm run serve
   ```
 
 3.  Go to the Debug view, select the **'vuejs: chrome/firefox'** configuration, then press F5 or click the green play button.


### PR DESCRIPTION
Came across this cookbook article while triaging another issue. Since Vue CLI's version is now officially 3 with some changes (duh), I'm fixing the serve command and adding a tip about ports.