### PR TITLE
Change readme's translation section to post a comment on dedicated issue for community translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Vietnamese translation is maintained by [Vue.js Vietnam User group](https://gith
 
 ### Want to help with the translation?
 
-If you feel okay with translating sorta alone, you can fork the repo, create a "work-in-progress" issue to inform others that you're doing the translation, and go for it.
+If you feel okay with translating sorta alone, you can fork the repo, post a comment on the [Community Translation Announcements](https://github.com/vuejs/vuejs.org/issues/2015) issue page to inform others that you're doing the translation, and go for it.
 
 If you are more of a team player, Translation Gang might be for you. Let us know somehow that you're ready to join this international open-source translators community. Feel free to contact [Grigoriy Beziuk](https://gbezyuk.github.io) or anybody else from [the team](https://github.com/orgs/translation-gang/people).
 


### PR DESCRIPTION
As the number of community translation work grows, people have been creating "work-in-progress" issue to inform others that they are doing the translation.

As the number of issues grows, the team decided to move it into a dedicated issue page to post a translation announcement.

This PR changes the readme so that it recommends user to do so instead of creating a new issue per announcement translation.

For reference, please check https://github.com/vuejs/vuejs.org/issues/2015#issuecomment-475131464

Thank You!