### PR TITLE
Fixed rollup config

### DIFF
--- a/src/v2/cookbook/packaging-sfc-for-npm.md
+++ b/src/v2/cookbook/packaging-sfc-for-npm.md
@@ -112,11 +112,12 @@ There is no need to write your module multiple times. It is possible to prepare 
     "build:unpkg": "rollup --config build/rollup.config.js --format iife --file dist/my-component.min.js"
   },
   "devDependencies": {
-    "rollup": "^0.57.1",
-    "rollup-plugin-buble": "^0.19.2",
-    "rollup-plugin-vue": "^3.0.0",
-    "vue": "^2.5.16",
-    "vue-template-compiler": "^2.5.16",
+    "rollup": "^1.7.0",
+    "rollup-plugin-buble": "^0.19.6",
+    "rollup-plugin-commonjs": "^9.2.1",
+    "rollup-plugin-vue": "^4.7.2",
+    "vue": "^2.6.10",
+    "vue-template-compiler": "^2.6.10",
     ...
   },
   ...
@@ -171,6 +172,7 @@ With the package.json `scripts` section ready and the SFC wrapper in place, all 
 ```js
 import vue from 'rollup-plugin-vue'; // Handle .vue SFC files
 import buble from 'rollup-plugin-buble'; // Transpile/polyfill with reasonable browser support
+import commonjs from 'rollup-plugin-commonjs';
 export default {
     input: 'src/wrapper.js', // Path relative to package.json
     output: {
@@ -178,6 +180,7 @@ export default {
         exports: 'named',
     },
     plugins: [
+        commonjs(),
         vue({
             css: true, // Dynamically inject css as a <style> tag
             compileTemplate: true, // Explicitly convert template to render function

--- a/src/v2/cookbook/packaging-sfc-for-npm.md
+++ b/src/v2/cookbook/packaging-sfc-for-npm.md
@@ -173,6 +173,7 @@ With the package.json `scripts` section ready and the SFC wrapper in place, all 
 import vue from 'rollup-plugin-vue'; // Handle .vue SFC files
 import buble from 'rollup-plugin-buble'; // Transpile/polyfill with reasonable browser support
 import commonjs from 'rollup-plugin-commonjs';
+
 export default {
     input: 'src/wrapper.js', // Path relative to package.json
     output: {


### PR DESCRIPTION
Current rollup config is not working now. According to this https://github.com/vuejs/rollup-plugin-vue/commit/fd3dfb9a4440b13b220fb2dc535506274280fa0c commit, it requires 'rollup-plugin-commonjs' plugin as well. Without that, we got "Error: 'default' is not exported by node_modules/vue-runtime-helpers/dist/normalize-component.js" error.