### PR TITLE
Handles edge cases for documentation hash search

### DIFF
--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -154,6 +154,12 @@
     var hashTarget = document.getElementById(hash)
     if (!hashTarget) {
       var normalizedHash = normalizeHash(hash)
+      var edgeCases = {
+        'vue-set-target-key-value': 'vue-set'
+      }
+      if (edgeCases.hasOwnProperty(normalizedHash)) {
+        normalizedHash = edgeCases[normalizedHash];
+      }
       var possibleHashes = [].slice.call(document.querySelectorAll('[id]'))
         .map(function (el) { return el.id })
       possibleHashes.sort(function (hashA, hashB) {


### PR DESCRIPTION
It looks like in some cases the dynamic search input is incorrectly storing the hashes for some of the anchors, the case i have found concretely is when searching for "set" (as in vue set), it will actually redirect to `vue-delete`. The `levenshteinDistance` is not handling these edge cases because the length of the "set" word is short, and the distance its finding between the real hash and the suggested hash by the search input is exceeding other unrelated tags