### PR TITLE
Improvement Suggestion

### DIFF
--- a/src/v2/cookbook/using-axios-to-consume-apis.md
+++ b/src/v2/cookbook/using-axios-to-consume-apis.md
@@ -109,8 +109,7 @@ new Vue({
   data () {
     return {
       info: null,
-      loading: true,
-      errored: false
+      status: 'loading',
     }
   },
   filters: {
@@ -126,9 +125,9 @@ new Vue({
       })
       .catch(error => {
         console.log(error)
-        this.errored = true
+        this.status = 'errored'
       })
-      .finally(() => this.loading = false)
+      .finally(() => this.status = 'ready')
   }
 })
 ```
@@ -137,12 +136,12 @@ new Vue({
 <div id="app">
   <h1>Bitcoin Price Index</h1>
 
-  <section v-if="errored">
+  <section v-if="status === 'errored'">
     <p>We're sorry, we're not able to retrieve this information at the moment, please try back later</p>
   </section>
 
   <section v-else>
-    <div v-if="loading">Loading...</div>
+    <div v-if="status === 'loading'">Loading...</div>
 
     <div
       v-else


### PR DESCRIPTION
Having UI status as boolean is prone to bugs. In this case, it's correct, but in other cases, the user can end up with `error` and `loading` turned on due to bad code, causing a bug. By having status as a string and not boolean, we can be safe against this type of bug.