### PR TITLE
Fix minor typo on the serverless-blog cookbook page

### DIFF
--- a/src/v2/cookbook/serverless-blog.md
+++ b/src/v2/cookbook/serverless-blog.md
@@ -132,7 +132,7 @@ Then create `components/BlogHome.vue` which will be your blog homepage that list
           <article class="media">
             <figure>
               <!-- Bind results using a `:` -->
-              <!-- Use a `v-if`/`else` if their is a `featured_image` -->
+              <!-- Use a `v-if`/`else` if there is a `featured_image` -->
               <img
                 v-if="post.featured_image"
                 :src="post.featured_image"


### PR DESCRIPTION
This PR is a small typo fix (change "if their is" to "if there is") in a code comment on the "Create a CMS-Powered Blog" cookbook page.