### PR TITLE
Remove smoothScroll from example

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -44,11 +44,6 @@ var example1 = new Vue({
       { message: 'Foo' },
       { message: 'Bar' }
     ]
-  },
-  watch: {
-    items: function () {
-      smoothScroll.animateScroll(document.querySelector('#example-1'))
-    }
   }
 })
 </script>
@@ -94,11 +89,6 @@ var example2 = new Vue({
       { message: 'Foo' },
       { message: 'Bar' }
     ]
-  },
-  watch: {
-    items: function () {
-      smoothScroll.animateScroll(document.querySelector('#example-2'))
-    }
   }
 })
 </script>


### PR DESCRIPTION
It gives an error in the console when trying to execute the example: example1.items.push({ message: 'Baz' })

This might confuse new people.

Perhaps it is better not to have it in the code at all, since it does nothing because of it being undefined.