### PR TITLE
npm run serve is dependent on package.json

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -85,6 +85,7 @@ Click on the Debugging icon in the Activity Bar to bring up the Debug view, then
   ```
   npm run serve
   ```
+  Add details here - what shoud be in package.json for this to work?
 
 3.  Go to the Debug view, select the **'vuejs: chrome/firefox'** configuration, then press F5 or click the green play button.
 


### PR DESCRIPTION
Following this howto page assumes that you have a serve script in your package.json file.

There is no such script in the project I have inherited so this howto fails miserably....