### PR TITLE
Make it clear that cookbook isn't meant to be a step-by-step guide

### DIFF
--- a/src/v2/cookbook/index.md
+++ b/src/v2/cookbook/index.md
@@ -16,7 +16,7 @@ How is the cookbook different from the guide? Why is this necessary?
 
 * **Exploring the Ecosystem**: For advanced features, we assume some ecosystem knowledge. For example, if you want to use single-file components in Webpack, we don't explain how to configure the non-Vue parts of the Webpack config. In the cookbook, we have the space to explore these ecosystem libraries in more depth - at least to the extent that is universally useful for Vue developers.
 
-<p class="tip">With all these differences, please note that the cookbook is still _not_ a step-by-step manual. For most of its content, you are expected to have basic understanding of concepts like HTML, CSS, JavaScript, npm/yarn etc.</p>
+<p class="tip">With all these differences, please note that the cookbook is still _not_ a step-by-step manual. For most of its content, you are expected to have a basic understanding of concepts like HTML, CSS, JavaScript, npm/yarn, etc.</p>
 
 ## Cookbook Contributions
 

--- a/src/v2/cookbook/index.md
+++ b/src/v2/cookbook/index.md
@@ -16,7 +16,7 @@ How is the cookbook different from the guide? Why is this necessary?
 
 * **Exploring the Ecosystem**: For advanced features, we assume some ecosystem knowledge. For example, if you want to use single-file components in Webpack, we don't explain how to configure the non-Vue parts of the Webpack config. In the cookbook, we have the space to explore these ecosystem libraries in more depth - at least to the extent that is universally useful for Vue developers.
 
-<p class="tip">With all these differences, please note that the cookbook is still _not_ a step-by-step manual. For most of its content, you are expected to have some basic knowledge of HTML, CSS, JavaScript, and the surrounding ecosystem.</p>
+<p class="tip">With all these differences, please note that the cookbook is still _not_ a step-by-step manual. For most of its content, you are expected to have basic understanding of concepts like HTML, CSS, JavaScript, npm/yarn etc.</p>
 
 ## Cookbook Contributions
 

--- a/src/v2/cookbook/index.md
+++ b/src/v2/cookbook/index.md
@@ -16,6 +16,8 @@ How is the cookbook different from the guide? Why is this necessary?
 
 * **Exploring the Ecosystem**: For advanced features, we assume some ecosystem knowledge. For example, if you want to use single-file components in Webpack, we don't explain how to configure the non-Vue parts of the Webpack config. In the cookbook, we have the space to explore these ecosystem libraries in more depth - at least to the extent that is universally useful for Vue developers.
 
+<p class="tip">With all these differences, please note that the cookbook is still _not_ a step-by-step manual. For most of its content, you are expected to have some basic knowledge of HTML, CSS, JavaScript, and the surrounding ecosystem.</p>
+
 ## Cookbook Contributions
 
 ### What we're looking for


### PR DESCRIPTION
As some of our users followed the cookbook tutorials literally step-by-step and were surprised when things like `npm` commands didn't work out of the box, we feel the need of adding this note.