### PR TITLE
fix: minor style fixes

### DIFF
--- a/themes/vue/source/css/_demo.styl
+++ b/themes/vue/source/css/_demo.styl
@@ -4,8 +4,6 @@
   padding: 25px 35px
   margin-top: 1em
   margin-bottom: 40px
-  font-size: 1.2em
-  line-height: 1.5em
   -webkit-user-select: none
   -moz-user-select: none
   -ms-user-select: none

--- a/themes/vue/source/css/_syntax.styl
+++ b/themes/vue/source/css/_syntax.styl
@@ -59,7 +59,7 @@ pre code
 
     &-number,
     &-literal
-      color: #ae81ff
+      color: #a32eff
 
     &-class &-title
       color: white


### PR DESCRIPTION
This is a followup to https://github.com/vuejs/vuejs.org/pull/1666/commits/0bfc43c970f02771084c24897916a8ca1f66ad5b

I noticed a couple of small things:
- The lilac color used in code blocks was overlooked, and failed contrast testing, so I've updated that
- The "demo" blocks looked overiszed sized after the font-size change. I'm not completely sure what the intention is there, but I removed the line-height and font size adjustments, and kept the "card style" outline

**Before**

Code color:
![image](https://user-images.githubusercontent.com/3816327/57399897-23d4ec80-71ca-11e9-8729-f00f2e6eff05.png)

Demo block:
![image](https://user-images.githubusercontent.com/3816327/57399965-4f57d700-71ca-11e9-9e2d-89913787af25.png)

**After**

Code color:
![image](https://user-images.githubusercontent.com/3816327/57399832-fd16b600-71c9-11e9-97d4-7a654975f437.png)

Demo block:
![image](https://user-images.githubusercontent.com/3816327/57400028-757d7700-71ca-11e9-906e-6c534d139a58.png)
