### PR TITLE
Added dynamic slot name for shortand syntax example

### DIFF
--- a/src/v2/guide/components-slots.md
+++ b/src/v2/guide/components-slots.md
@@ -345,20 +345,6 @@ You can even define fallbacks, to be used in case a slot prop is undefined:
 </current-user>
 ```
 
-## Dynamic Slot Names
-
-> New in 2.6.0+
-
-[Dynamic directive arguments](syntax.html#Dynamic-Arguments) also work on `v-slot`, allowing the definition of dynamic slot names:
-
-``` html
-<base-layout>
-  <template v-slot:[dynamicSlotName]>
-    ...
-  </template>
-</base-layout>
-```
-
 ## Named Slots Shorthand
 
 > New in 2.6.0+
@@ -395,6 +381,30 @@ Instead, you must always specify the name of the slot if you wish to use the sho
 <current-user #default="{ user }">
   {{ user.firstName }}
 </current-user>
+```
+
+## Dynamic Slot Names
+
+> New in 2.6.0+
+
+[Dynamic directive arguments](syntax.html#Dynamic-Arguments) also work on `v-slot`, allowing the definition of dynamic slot names:
+
+``` html
+<base-layout>
+  <template v-slot:[dynamicSlotName]>
+    ...
+  </template>
+</base-layout>
+```
+
+Dynamic slot names can also be used with the [Named Slots Shorthand](syntax.html#Named-Slots-Shorthand) syntax:
+
+``` html
+<base-layout>
+  <template #[dynamicSlotName]>
+    ...
+  </template>
+</base-layout>
 ```
 
 ## Other Examples


### PR DESCRIPTION
Hello,
I think it would be useful to be mentioned that the [Dynamic Slot Name](https://vuejs.org/v2/guide/components-slots.html#Dynamic-Slot-Names) feature can be used with the [Name slot shortand](https://vuejs.org/v2/guide/components-slots.html#Named-Slots-Shorthand) syntax.

I also moved the `Dynamic Slot Names` chapter under it, for it to be consistent with my change.
Have a nice day !