### PR TITLE
Ignore editor's directories in .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ public/
 .deploy*/
 src/_drafts
 package-lock.json
+
+# Editor directories and files
+.idea
+.vscode


### PR DESCRIPTION
This pull request will add `idea` and `vscode` directories to `.gitignore` file.