### PR TITLE
Update $options API docs

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1349,7 +1349,7 @@ type: api
     
   <p class="tip">As a rule of thumb, make sure you don't name them with the prefixes `$` or `_`, as the Vue api/internal properties or misuse or overwrite the existing ones.</p>
   
-  Note that they [won't be reactive](https://github.com/vuejs/vue/issues/1988#issuecomment-355980148). If you need reactivity, you need to initialize the properties as usual: within `data`, passing `props` or [`injecting`](provide-inject) reactive objects (advanced). Bear in mind that the recommended way of adding non-reactive properties to the current instance is using the `created()` hook, as described [here](https://github.com/vuejs/vue/issues/1988#issuecomment-163013818): 
+  Note that they [won't be reactive](https://github.com/vuejs/vue/issues/1988#issuecomment-355980148). If you need reactivity, you need to initialize the properties as usual: within [`data`](#data) (or [`computed` properties](#computed)), passing [`props`](#props) or for more advanced use cases [`injecting`](#provide-inject) reactive objects. Bear in mind that the recommended way of adding non-reactive properties to the current instance is using the `created()` hook, as described [here](https://github.com/vuejs/vue/issues/1988#issuecomment-163013818): 
   
   ``` js
   new Vue({

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1347,7 +1347,7 @@ type: api
   })
   ```
     
-  <p class="tip">As a rule of thumb, make sure you don't name them with the prefixes `$` or `_`, as the Vue api/internal properties or misuse or overwrite the existing ones.</p>
+Don't prefix these properties with `$` or `_` to avoid possible naming clashes with Vue's internal ones.
   
   Note that they [won't be reactive](https://github.com/vuejs/vue/issues/1988#issuecomment-355980148). If you need reactivity, you need to initialize the properties as usual: within [`data`](#data) (or [`computed` properties](#computed)), passing [`props`](#props) or for more advanced use cases [`injecting`](#provide-inject) reactive objects. Bear in mind that the recommended way of adding non-reactive properties to the current instance is using the `created()` hook, as described [here](https://github.com/vuejs/vue/issues/1988#issuecomment-163013818): 
   

--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -1336,7 +1336,7 @@ type: api
 
 - **Details:**
 
-  The instantiation options used for the current Vue instance. This is useful when you want to include custom properties in the options:
+  The non-reactive instantiation options used for the current Vue instance. This is useful when you want to include custom properties in the options for internal use:
 
   ``` js
   new Vue({
@@ -1346,6 +1346,23 @@ type: api
     }
   })
   ```
+    
+  <p class="tip">As a rule of thumb, make sure you don't name them with the prefixes `$` or `_`, as the Vue api/internal properties or misuse or overwrite the existing ones.</p>
+  
+  Note that they [won't be reactive](https://github.com/vuejs/vue/issues/1988#issuecomment-355980148). If you need reactivity, you need to initialize the properties as usual: within `data`, passing `props` or [`injecting`](provide-inject) reactive objects (advanced). Bear in mind that the recommended way of adding non-reactive properties to the current instance is using the `created()` hook, as described [here](https://github.com/vuejs/vue/issues/1988#issuecomment-163013818): 
+  
+  ``` js
+  new Vue({
+    data: ...
+    created: function () {
+      this.myPrivateStuff = {
+        ...
+      }
+    }
+  })
+  ```
+  
+> Options is meant for **configuration options**, such as in the case of third party components/libraries, and constants; in general, internal properties that need to remain unmutable.
 
 ### vm.$parent
 


### PR DESCRIPTION
Added explicit focus on the _non-reactive_ behaviour, because IMO those GitHub issue comments are linked too much across several articles and tutorials. And some people claim that this part is not even documented.

LMK what you think. And also, thank you for your time ❤️.