### PR TITLE
Added new CDN

### DIFF
--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -56,7 +56,7 @@ If you are using native ES Modules, there is also an ES Modules compatible build
 
 You can browse the source of the NPM package at [cdn.jsdelivr.net/npm/vue](https://cdn.jsdelivr.net/npm/vue/).
 
-Vue is also available on [unpkg](https://unpkg.com/vue@{{vue_version}}/dist/vue.js) and [cdnjs](https://cdnjs.cloudflare.com/ajax/libs/vue/{{vue_version}}/vue.js) (cdnjs takes some time to sync so the latest release may not be available yet).
+Vue is also available on [PageCDN](https://pagecdn.com/lib/vue.js), [unpkg](https://unpkg.com/vue@{{vue_version}}/dist/vue.js) and [cdnjs](https://cdnjs.cloudflare.com/ajax/libs/vue/{{vue_version}}/vue.js) (cdnjs takes some time to sync so the latest release may not be available yet).
 
 Make sure to read about [the different builds of Vue](#Explanation-of-Different-Builds) and use the **production
  version** in your published site, replacing `vue.js` with `vue.min.js`. This is a smaller build optimized for speed instead of development experience.


### PR DESCRIPTION
PageCDN tightly compresses files with brotli (level 11) compression. For vue.js it **saves additional 11KB** in compressed file size. So, can be a valuable addition to the docs.

Further, if you are open to work with us, we can setup the vue repo on PageCDN to fetch updates through webhooks as new releases are available on github. This way, you can easily display PageCDN links in the docs as you currently do with unpkg and give vue users benefit of smaller compressed files and [other features](https://pagecdn.com/features) like immutable caching, etc.