### PR TITLE
#2240 fix and updated versions for 'Packaging SFC' cookbook page

### DIFF
--- a/src/v2/cookbook/packaging-sfc-for-npm.md
+++ b/src/v2/cookbook/packaging-sfc-for-npm.md
@@ -112,11 +112,12 @@ There is no need to write your module multiple times. It is possible to prepare 
     "build:unpkg": "rollup --config build/rollup.config.js --format iife --file dist/my-component.min.js"
   },
   "devDependencies": {
-    "rollup": "^0.57.1",
-    "rollup-plugin-buble": "^0.19.2",
-    "rollup-plugin-vue": "^3.0.0",
-    "vue": "^2.5.16",
-    "vue-template-compiler": "^2.5.16",
+    "rollup": "^1.17.0",
+    "rollup-plugin-buble": "^0.19.8",
+    "rollup-plugin-commonjs": "^10.0.1",
+    "rollup-plugin-vue": "^5.0.1",
+    "vue": "^2.6.10",
+    "vue-template-compiler": "^2.6.10"
     ...
   },
   ...
@@ -169,6 +170,7 @@ Notice the first line directly imports your SFC, and the last line exports it un
 With the package.json `scripts` section ready and the SFC wrapper in place, all that is left is to ensure Rollup is properly configured. Fortunately, this can be done with a small 16 line rollup.config.js file:
 
 ```js
+import commonjs from 'rollup-plugin-commonjs'; // Convert CommonJS modules to ES6
 import vue from 'rollup-plugin-vue'; // Handle .vue SFC files
 import buble from 'rollup-plugin-buble'; // Transpile/polyfill with reasonable browser support
 export default {
@@ -178,6 +180,7 @@ export default {
         exports: 'named',
     },
     plugins: [
+        commonjs(),
         vue({
             css: true, // Dynamically inject css as a <style> tag
             compileTemplate: true, // Explicitly convert template to render function


### PR DESCRIPTION
Did some changes after following the cookbook leaded me to either outdated packages or a build failure due to a major version update of a rollup plugin (see #2240)

This PR should be ready to deploy as it is