### PR TITLE
Fix font size for inline code

### DIFF
--- a/themes/vue/source/css/_settings.styl
+++ b/themes/vue/source/css/_settings.styl
@@ -5,7 +5,7 @@ $code-font = "Roboto Mono", Monaco, courier, monospace
 
 // font sizes
 $body-font-size = 1rem
-$code-font-size = .85rem
+$code-font-size = .85em
 
 // colors
 $dark   = #273849

--- a/themes/vue/source/css/_syntax.styl
+++ b/themes/vue/source/css/_syntax.styl
@@ -7,7 +7,7 @@ pre code
   color: #525252
   white-space: pre
   padding: 1.2em 1.4em
-  font-size: 0.9rem;
+  font-size: .85rem
   line-height: 1.6rem
   display: block
 


### PR DESCRIPTION
Currently we're using root unit `rem` for the code, which renders code inside headers pretty weird:

![image](https://user-images.githubusercontent.com/8056274/61562596-f16d2880-aa71-11e9-8c01-afab370de793.png)

This commit replaces `rem` with `em` so that inline code has its size related to the direct parent instead:

![image](https://user-images.githubusercontent.com/8056274/61562742-4741d080-aa72-11e9-96a3-11197f75b230.png)
