### PR TITLE
Darker red background for bad examples

### DIFF
--- a/themes/vue/source/css/_style-guide.styl
+++ b/themes/vue/source/css/_style-guide.styl
@@ -1,4 +1,4 @@
-$style-guide-bad-bg = lighten(desaturate($red, 80%), 80%)
+$style-guide-bad-bg = lighten(desaturate($red, 50%), 80%)
 $style-guide-bad-text = darken(desaturate($red, 80%), 20%)
 $style-guide-good-bg = lighten(desaturate($green, 80%), 85%)
 $style-guide-good-text = darken(desaturate($green, 80%), 10%)


### PR DESCRIPTION
Currently it feels awkward that you first see a bad example and it is not highlighted enough as one

https://i.imgur.com/CLigKEr.png
-->
https://i.imgur.com/VYSdyBH.png