### PR TITLE
correct definition of modifiers

### DIFF
--- a/src/v2/guide/custom-directive.md
+++ b/src/v2/guide/custom-directive.md
@@ -96,7 +96,7 @@ Directive hooks are passed these arguments:
 An example of a custom directive using some of these properties:
 
 ``` html
-<div id="hook-arguments-example" v-demo:foo.a.b="message"></div>
+<div id="hook-arguments-example" v-demo.foo.a.b="message"></div>
 ```
 
 ``` js


### PR DESCRIPTION
<div id="hook-arguments-example" v-demo:foo.a.b="message"></div>

Colon must be a dot.