### PR TITLE
Make the video overlay cover the header

### DIFF
--- a/themes/vue/source/css/_modal.styl
+++ b/themes/vue/source/css/_modal.styl
@@ -27,7 +27,7 @@
   left: 0
   right: 0
   background: rgba(0,0,0,.2)
-  z-index: 10
+  z-index: 101
 .stop-scroll
   overflow: hidden
   height: 100%


### PR DESCRIPTION
The video overlay's z-index is currently not large enough (10) to cover the site's header (100). This should fix the problem.

Before:
![image](https://user-images.githubusercontent.com/8056274/64633520-9ca7b780-d3fb-11e9-89b5-35cb1befdd43.png)

After:
![image](https://user-images.githubusercontent.com/8056274/64633469-8ac61480-d3fb-11e9-9ae8-ccd7012e9bdb.png)
