### PR TITLE
2299 duplicate mobile menu items

### DIFF
--- a/themes/vue/layout/partials/sidebar.ejs
+++ b/themes/vue/layout/partials/sidebar.ejs
@@ -1,8 +1,12 @@
+<% var isHomePage = page.path === 'index.html' %>
+
 <div class="sidebar">
   <div class="sidebar-inner">
-    <ul class="main-menu">
-      <%- partial('partials/main_menu', { context: 'sidebar' }) %>
-    </ul>
+    <% if (isHomePage) { %>
+      <ul class="main-menu">
+        <%- partial('partials/main_menu', { context: 'sidebar' }) %>
+      </ul>
+    <% } %>
     <div class="list">
       <%- partial('partials/sponsors_sidebar') %>
       <% if (type !== 'search') { %>

--- a/themes/vue/source/css/_settings.styl
+++ b/themes/vue/source/css/_settings.styl
@@ -18,7 +18,7 @@ $red = #ff6666
 $info = #1C90F3
 
 $radius = 2px
-$content-padding-top = 30px
+$content-padding-vertical = 35px
 
 // header settings
 $header-inner-height = 41px
@@ -26,8 +26,8 @@ $heading-padding-vertical = 10px
 $header-height = $header-inner-height + $heading-padding-vertical * 2
 $mobile-header-height = 40px
 // prevent headers from being covered by the top nav upon navigation
-$heading-link-padding-top = $header-height + $content-padding-top
-$mobile-heading-link-padding-top = $mobile-header-height + $content-padding-top
+$heading-link-padding-top = $header-height + $content-padding-vertical
+$mobile-heading-link-padding-top = $mobile-header-height + $content-padding-vertical
 $h2-margin-top = 45px
 $h3-margin-top = 52px
 

--- a/themes/vue/source/css/_sidebar.styl
+++ b/themes/vue/source/css/_sidebar.styl
@@ -74,7 +74,7 @@
     -webkit-transform: translate(-280px, 0)
     transform: translate(-280px, 0)
     .sidebar-inner
-      padding: 50px 10px 10px 20px
+      padding: 60px 10px 10px 20px
       box-sizing: border-box
     .sidebar-inner-index
       padding: 10px 10px 10px 20px

--- a/themes/vue/source/css/_sidebar.styl
+++ b/themes/vue/source/css/_sidebar.styl
@@ -74,7 +74,7 @@
     -webkit-transform: translate(-280px, 0)
     transform: translate(-280px, 0)
     .sidebar-inner
-      padding: 60px 10px 10px 20px
+      padding: 60px 10px 30px 20px
       box-sizing: border-box
     .sidebar-inner-index
       padding: 10px 10px 10px 20px

--- a/themes/vue/source/css/_sidebar.styl
+++ b/themes/vue/source/css/_sidebar.styl
@@ -21,7 +21,7 @@
     margin-top: .5em
   .sidebar-inner
     width: 260px
-    padding: 2.2em 0px 60px 20px
+    padding: $content-padding-vertical 0px 60px 20px
   .version-select
     vertical-align: middle
     margin-left: 5px

--- a/themes/vue/source/css/_sidebar.styl
+++ b/themes/vue/source/css/_sidebar.styl
@@ -21,7 +21,7 @@
     margin-top: .5em
   .sidebar-inner
     width: 260px
-    padding: $content-padding-top + 40px 0px 60px 20px
+    padding: 2.2em 0px 60px 20px
   .version-select
     vertical-align: middle
     margin-left: 5px

--- a/themes/vue/source/css/_sponsors-sidebar.styl
+++ b/themes/vue/source/css/_sponsors-sidebar.styl
@@ -25,9 +25,6 @@
   text-align: center
   margin-bottom: 20px
 
-#sidebar-sponsors-special
-  margin-top -10px
-
 #sidebar-sponsors-platinum-left
   display block
 

--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -23,7 +23,7 @@
 
 .content
   position: relative
-  padding: 2.2em 0
+  padding: $content-padding-vertical 0
   max-width: 700px
   margin: 0 auto
   padding-left: 50px


### PR DESCRIPTION
Ended up fixing a few issues here:

1. Made the home page "main menu" only show up on home page
2. Noticed that the sponsors were oddly aligned on mobile and gave it a little more breathing room
3. Noticed the sponsors were aligned too far down the page in comparison to the content

Feedback welcome if I misinterpreted any original design intentions.