### PR TITLE
Fix: v-model example overflow problem

### DIFF
--- a/themes/vue/source/css/_demo.styl
+++ b/themes/vue/source/css/_demo.styl
@@ -37,6 +37,7 @@
   p
     margin: 0 !important
     padding: 0 !important
+    word-break: break-all
   textarea
     width: 100%
     resize: vertical


### PR DESCRIPTION
Hi,

I fixed the v-model example overflow problem.

Before:

<img width="732" alt="old" src="https://user-images.githubusercontent.com/330566/65883009-dd617380-e39e-11e9-89a3-3eaf2bbfcaee.png">

After:

<img width="724" alt="new" src="https://user-images.githubusercontent.com/330566/65883031-e5b9ae80-e39e-11e9-947a-cdf206d0567e.png">

URL: https://vuejs.org/v2/guide/