### PR TITLE
docs: add Rolf Haug from Vue School as community partner

### DIFF
--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -1125,6 +1125,22 @@ order: 803
       ]
     },
     {
+      name: 'Rolf Haug',
+      title: 'Educator & Consultant',
+      city: 'Oslo, Norway',
+      languages: ['en', 'no'],
+      github: 'rahaug',
+      twitter: 'rahaug',
+      work: {
+        role: 'Educator & Co-founder',
+        org: 'Vue School',
+        orgUrl: 'https://vueschool.io/'
+      },
+      links: [
+        'https://vueschool.io/', 'https://rah.no'
+      ]
+    },
+    {
       name: 'Andrew Tomaka',
       title: 'The Server Server',
       city: 'East Lansing, MI, USA',

--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -263,7 +263,8 @@ order: 803
     'Boston, MA, USA': [42.360081, -71.058884],
     'Kyiv, Ukraine': [50.450100, 30.523399],
     'Washington, DC, USA': [38.8935755,-77.0846156,12],
-    'Kraków, Poland': [50.064650, 19.936579]
+    'Kraków, Poland': [50.064650, 19.936579],
+    'Oslo, Norway': [59.911491, 10.757933]
   }
   var languageNameFor = {
     en: 'English',
@@ -282,7 +283,8 @@ order: 803
     fa: 'فارسی',
     ko: '한국어',
     ro: 'Română',
-    uk: 'Українська'
+    uk: 'Українська',
+    no: 'Norwegian'
   }
 
   var team = [{


### PR DESCRIPTION
This PR adds Rolf Haug (co-founder of Vue School) as a community partner.

It also adds the latitude and longitude of Oslo, Norway, and the Norwegian language variable.