### PR TITLE
Update _config.yml

### DIFF
--- a/themes/vue/_config.yml
+++ b/themes/vue/_config.yml
@@ -112,7 +112,7 @@ gold_sponsors:
   - url: 'https://piratebay.ink'
     img: piratebay_proxy.png
     name: Piratebay Proxy
-  - url: 'https:/www.programmers.io'
+  - url: 'https://www.programmers.io'
     img: programmers_io.png
     name: Programmers.io
 silver_sponsors:


### PR DESCRIPTION
Broken link for Patreon gold sponsor due to malformed URL. 