### PR TITLE
docs: fix hexo links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Hexo Configuration
-## Docs: http://zespia.tw/hexo/docs/configuration.html
-## Source: https://github.com/tommy351/hexo/
+## Docs: https://hexo.io/docs/
+## Source: https://github.com/hexojs/hexo
 
 # Site
 title: Vue.js
@@ -78,8 +78,8 @@ pagination_dir: page
 disqus_shortname:
 
 # Extensions
-## Plugins: https://github.com/tommy351/hexo/wiki/Plugins
-## Themes: https://github.com/tommy351/hexo/wiki/Themes
+## Plugins: https://github.com/hexojs/hexo/wiki/Plugins
+## Themes: https://github.com/hexojs/hexo/wiki/Themes
 theme: vue
 exclude_generator:
 
@@ -136,7 +136,7 @@ offline:
         origin: maxcdn.bootstrapcdn.com
 
 # Deployment
-## Docs: http://zespia.tw/hexo/docs/deployment.html
+## Docs: https://hexo.io/docs/one-command-deployment
 deploy:
   type: git
   repository: git@github.com:vuejs/vuejs.org.git


### PR DESCRIPTION
This PR fixes Hexo links in `/_config.yml`

There was 2 broken links : 
- Line 2
- Line 139

![preview](https://i.imgur.com/3tPDij5.png)

It also updates GitHub's links :
https://github.com/tommy351/hexo/ to https://github.com/hexojs/hexo