### PR TITLE
Added DEV link to community page

### DIFF
--- a/src/v2/guide/join.md
+++ b/src/v2/guide/join.md
@@ -25,6 +25,7 @@ Our [Code of Conduct](/coc) is a guide to make it easier to enrich all of us and
 
 - [The Awesome Vue Page](https://github.com/vuejs/awesome-vue): See what other awesome resources have been published by other awesome people.
 - [The "Show and Tell" Subforum](https://forum.vuejs.org/c/show-and-tell): Another great place to check out what others have built with and for the growing Vue ecosystem.
+- [DEV's Vue Community](https://dev.to/t/vue): The collection of all posts tagged Vue within the DEV Community. DEV is a network of thousands of software developers who blog about and discuss code. 
 
 ## What You Can Do
 


### PR DESCRIPTION
This pull request adds a link for the Vue tag on DEV. DEV is the fastest growing community blogging ecosystem in software and it would be a good idea to include it in the Vue Ecosystem section on the community page.

There are regularly new posts added to the Vue tag, and it's one of the most followed tags on Dev currently.