### PR TITLE
fix avatar aspect ratio

### DIFF
--- a/themes/vue/source/css/_team.styl
+++ b/themes/vue/source/css/_team.styl
@@ -35,6 +35,7 @@
       flex: 0 0 80px
       img
         border-radius: 50%
+        object-fit: cover
     .profile
       padding-left: 26px
       flex: 1


### PR DESCRIPTION
In the community partners section (https://vuejs.org/v2/guide/team.html#community-partners),  Pratik Patel's avatar image looks stretched out. 

<img width="107" alt="Screen Shot 2019-10-13 at 12 43 32 AM" src="https://user-images.githubusercontent.com/2272928/66711541-963a9180-ed53-11e9-921d-c70ecc33034a.png">


The image just happens to be "not a square" but instead it has a portrait aspect ratio (its height is bigger than its width). 

This pr fixes that issue by making the images do a cover resize.

Making the avatar look like this.

<img width="94" alt="Screen Shot 2019-10-13 at 12 44 32 AM" src="https://user-images.githubusercontent.com/2272928/66711549-a18dbd00-ed53-11e9-9343-b18abfb0c885.png">
