### PR TITLE
chore: add sponsor name for a11y

### DIFF
--- a/themes/vue/_config.yml
+++ b/themes/vue/_config.yml
@@ -8,6 +8,7 @@ platinum_sponsors_china:
 special_sponsors:
   - url: 'https://stdlib.com/'
     img: stdlib.png
+    name: Standard Library
     description: 'Build APIs you need in minutes instead of days, for free.'
 platinum_sponsors:
   - url: >-


### PR DESCRIPTION
The Standard Library sponsor on the sidebar is missing the name in the config, which leads to the image on the sidebar to be missing its alt property (https://github.com/vuejs/vuejs.org/blob/master/themes/vue/layout/partials/sponsors_sidebar.ejs#L7). Since the anchor is just that image without any text, having it would improve accessibility.