### PR TITLE
Correctly nest sub-menu for h3s inside h2 list item

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vuejs.org",
   "private": true,
   "hexo": {
-    "version": "3.8.0"
+    "version": "3.8.1"
   },
   "scripts": {
     "start": "hexo server",

--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -368,12 +368,13 @@
       var headers = content.querySelectorAll('h2')
       if (headers.length) {
         each.call(headers, function (h) {
-          sectionContainer.appendChild(makeLink(h))
+          var listItem = makeLink(h)
+          sectionContainer.appendChild(listItem)
           var h3s = collectH3s(h)
           allHeaders.push(h)
           allHeaders.push.apply(allHeaders, h3s)
           if (h3s.length) {
-            sectionContainer.appendChild(makeSubLinks(h3s, isAPIOrStyleGuide))
+            listItem.appendChild(makeSubLinks(h3s, isAPIOrStyleGuide))
           }
         })
       } else {


### PR DESCRIPTION
Observed behavior:
An ```ul``` with H3 links is nested inside the parent ```ul``` and as a sibling to the ```li``` containing the link to the H2.

Fix:
The sub-menu for H3s is now nested in the same way H2 sub-menu already are.

The former incorrect nesting also constitutes an a11y issue.