### PR TITLE
Enforcing `rel="noopener"` for external _blank targets`

### DIFF
--- a/themes/vue/layout/partials/resources_dropdown.ejs
+++ b/themes/vue/layout/partials/resources_dropdown.ejs
@@ -3,6 +3,6 @@
   <ul class="nav-dropdown">
     <li><a href="<%- url_for("/resources/partners.html") %>" class="nav-link">Partners</a></li>
     <li><a href="<%- url_for("/resources/themes.html") %>" class="nav-link">Themes</a></li>
-    <li><a href="https://github.com/vuejs/awesome-vue" class="nav-link" target="_blank">Awesome Vue</a></li>
+    <li><a href="https://github.com/vuejs/awesome-vue" class="nav-link" target="_blank" rel="noopener">Awesome Vue</a></li>
   </ul>
 </li>

--- a/themes/vue/layout/search-page.ejs
+++ b/themes/vue/layout/search-page.ejs
@@ -12,7 +12,7 @@
           <strong>{{ totalResults }} results</strong> found in {{ queryTime }}ms
         </template>
       </p>
-      <a target="_blank" href="https://www.algolia.com/" aria-label="Search">
+      <a target="_blank" rel="noopener" href="https://www.algolia.com/" aria-label="Search">
           <img src="/images/search-by-algolia.png" height="16">
       </a>
     </div>


### PR DESCRIPTION
See [the MDN note](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target) for for information about the privacy and security concerns.

This PR is trying to add the `rel="noopener"` in the following locations:
- Algolia Attribution - https://vuejs.org/v2/search/
- Resources dropdown

I also notice `rel="noopener noreferrer"` (as a workaround for old browsers) and `rel="noopener"` are used at the same time across the codebase. Should we make them more consistent?