### PR TITLE
Mention setting nested object properties

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -319,7 +319,10 @@ Vue does not allow dynamically adding new root-level reactive properties to an a
 var vm = new Vue({
   data: {
     userProfile: {
-      name: 'Anika'
+      name: 'Anika',
+      likes: {
+        dogs: true
+      }
     }
   }
 })
@@ -335,6 +338,12 @@ You can also use the `vm.$set` instance method, which is an alias for the global
 
 ``` js
 vm.$set(vm.userProfile, 'age', 27)
+```
+
+It's also possible to create reactive properties on objects nested deeper by passing a reference to them:
+
+``` js
+vm.$set(vm.userProfile.likes, 'cats', true)
 ```
 
 Sometimes you may want to assign a number of new properties to an existing object, for example using `Object.assign()` or `_.extend()`. In such cases, you should create a fresh object with properties from both objects. So instead of:

--- a/src/v2/guide/reactivity.md
+++ b/src/v2/guide/reactivity.md
@@ -46,6 +46,13 @@ You can also use the `vm.$set` instance method, which is an alias to the global 
 this.$set(this.someObject, 'b', 2)
 ```
 
+`Vue.set` can also be used to set properties of nested reactive objects by passing a reference to that object:
+
+``` js
+// assuming `vm.someObject` is `{ nested: { a: 1 } }`:
+Vue.set(vm.someObject.nested, 'a', 2);
+```
+
 Sometimes you may want to assign a number of properties to an existing object, for example using `Object.assign()` or `_.extend()`. However, new properties added to the object will not trigger changes. In such cases, create a fresh object with properties from both the original object and the mixin object:
 
 ``` js


### PR DESCRIPTION
Explains that one can pass a reference to a nested object to `Vue.set`. This answers an actual question I was asked while teaching Vue.