### PR TITLE
use production npm install for docker examples

### DIFF
--- a/src/v2/cookbook/dockerize-vuejs-app.md
+++ b/src/v2/cookbook/dockerize-vuejs-app.md
@@ -22,8 +22,8 @@ WORKDIR /app
 # copy both 'package.json' and 'package-lock.json' (if available)
 COPY package*.json ./
 
-# install project dependencies
-RUN npm install
+# install project dependencies leaving out dev dependencies
+RUN npm install --production
 
 # copy project files and folders to the current working directory (i.e. 'app' folder)
 COPY . .
@@ -66,7 +66,7 @@ Let's refactor our `Dockerfile` to use NGINX:
 FROM node:lts-alpine as build-stage
 WORKDIR /app
 COPY package*.json ./
-RUN npm install
+RUN npm install --production
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
recommend using npm production install to minimize docker image sizes 