### PR TITLE
docs: update scrimba link

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -34,7 +34,7 @@ or:
 
 The [Installation](installation.html) page provides more options of installing Vue. Note: We **do not** recommend that beginners start with `vue-cli`, especially if you are not yet familiar with Node.js-based build tools.
 
-If you prefer something more interactive, you can also check out [this tutorial series on Scrimba](https://scrimba.com/playlist/pXKqta), which gives you a mix of screencast and code playground that you can pause and play around with anytime.
+If you prefer something more interactive, you can also check out [this tutorial series on Scrimba](https://scrimba.com/g/gvuedocs), which gives you a mix of screencast and code playground that you can pause and play around with anytime.
 
 ## Declarative Rendering
 


### PR DESCRIPTION
Hi,

We've improved the page for the Vue tutorial on Scrimba. It features a better overview of the screencasts (list view instead of grid view) and more information regarding the tutorials. Created this PR which includes the updated link :)