### PR TITLE
Add video to Markdown example

### DIFF
--- a/src/v2/examples/index.md
+++ b/src/v2/examples/index.md
@@ -6,4 +6,6 @@ order: 0
 
 > Dead simple Markdown editor.
 
+<div class="vue-screencasts"><a href="https://youtu.be/THT5FefYZCo" target="_blank" rel="noopener" title="Markdown and Syntax Highlighting Tutorial"> Watch a free video on Vue Screencasts.  It adds syntax highlighting and SSR compatibility.</a></div>
+
 <iframe width="100%" height="500" src="https://jsfiddle.net/chrisvfritz/0dzvcf4d/embedded/result,html,js,css" allowfullscreen="allowfullscreen" frameborder="0"></iframe>

--- a/themes/vue/source/css/_scrimba.styl
+++ b/themes/vue/source/css/_scrimba.styl
@@ -1,4 +1,4 @@
-.scrimba, .vueschool
+.scrimba, .vueschool, .vue-screencasts
   background-color #e7ecf3
   padding 1em 1.25em
   border-radius 2px


### PR DESCRIPTION
This commit adds a tutorial video to the Markdown example.  Styling is based on other video links within the docs.

The video uses the current example as a jumping off point and adds two common use cases: SSR compatibility and syntax highlighting.

Hopefully readers will find this useful as-is, but if there's anything you'd like me to change about the video, please let me know and I can do a "docs edit" based on those recommendations.