### PR TITLE
Add braces to make code more clear

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -156,7 +156,9 @@ Sometimes we also need to access the original DOM event in an inline statement h
 methods: {
   warn: function (message, event) {
     // now we have access to the native event
-    if (event) event.preventDefault()
+    if (event) {
+      event.preventDefault()
+    }
     alert(message)
   }
 }


### PR DESCRIPTION
According to the general coding standards, if statements are best to add curly braces to avoid misunderstanding, and it can make code more clear.