### PR TITLE
Undo npm production flag

### DIFF
--- a/src/v2/cookbook/dockerize-vuejs-app.md
+++ b/src/v2/cookbook/dockerize-vuejs-app.md
@@ -22,8 +22,8 @@ WORKDIR /app
 # copy both 'package.json' and 'package-lock.json' (if available)
 COPY package*.json ./
 
-# install project dependencies leaving out dev dependencies
-RUN npm install --production
+# install project dependencies
+RUN npm install
 
 # copy project files and folders to the current working directory (i.e. 'app' folder)
 COPY . .
@@ -66,7 +66,7 @@ Let's refactor our `Dockerfile` to use NGINX:
 FROM node:lts-alpine as build-stage
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+RUN npm install
 COPY . .
 RUN npm run build
 


### PR DESCRIPTION
The production flag during npm install will likely cause problems and at the very least may confuse some people starting out.

See comment: https://github.com/vuejs/vuejs.org/pull/2365#discussion_r346776078