### PR TITLE
Vue School Black Friday Announcement

### DIFF
--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -90,6 +90,7 @@
     <script type="text/javascript" defer="defer" src="https://extend.vimeocdn.com/ga/72160148.js"></script>
   </head>
   <body class="<%- isIndex ? '' : 'docs' -%>">
+    <%- partial('partials/vueschool_banner') %>
     <div id="mobile-bar" <%- isIndex ? 'class="top"' : '' %>>
       <a class="menu-button"></a>
       <a class="logo" href="/"></a>

--- a/themes/vue/layout/partials/vueschool_banner.ejs
+++ b/themes/vue/layout/partials/vueschool_banner.ejs
@@ -1,0 +1,90 @@
+<div id="vs-banner" class="vueschool-banner hide" role="banner">
+  <a href="https://vueschool.io/sales/blackfriday?friend=vuejs&utm_source=Vuejs.org&utm_medium=Link&utm_content=TopBanner&utm_campaign=Black%20Friday" title="Learn Vue.js with Vue School's video courses" target="_blank">
+    <img class="vueschool-banner--logo" src="/images/vueschool_logo.svg" alt="Vue School Logo">
+    <div class="vueschool-banner--wrapper">
+      <p>Black Friday 40% OFF at Vue School<span>Learn Vue.js through video courses.</span></p>
+    </div>
+    <div id="vs-close" class="vueschool-banner--close"></div>
+  </a>
+</div>
+
+<script>
+
+  (function () {
+    // Get elements
+    var elBody = document.getElementsByTagName("body")[0];
+    var elBanner = document.getElementById("vs-banner");
+    var elClose = document.getElementById("vs-close");
+    var elMenu = document.getElementById("mobile-bar");
+    // Variable names
+    var nameWrapper = "vueschool-weekend-promo";
+    var nameFixMenu = "vueschool-menu-fixed";
+    var nameStorage = "vueschool-banner";
+    // Defaults values
+    var isMenuFixed = false;
+    var posMenu = 80;
+    var initBanner = function () {
+      // Add event listeners
+      toggleBannerEvents(true);
+      // Add class to the body to push fixed elements
+      elBody.classList.add(nameWrapper);
+      // Display the banner
+      elBanner.style.display = "block";
+      // Init close button action
+      elClose.onclick = closeBanner;
+      // Get the menu position
+      getMenuPosition();
+      // Check current page offset position
+      isMenuFixed = isUnderBanner();
+      // And position menu accordingly
+      if (isMenuFixed) {
+        elBody.classList.add("fixed");
+      }
+    }
+    var closeBanner = function(e) {
+      // Prevent bubbling event that redirect to vueschool.io
+      e.preventDefault();
+      // Remove events
+      toggleBannerEvents(false);
+      // Hide the banner
+      elBanner.style.display = "none";
+      // Remove class to the body that push fixed elements
+      elBody.classList.remove(nameWrapper);
+      // Save action in the local storage
+      localStorage.setItem(nameStorage, true);
+    }
+    var getMenuPosition = function() {
+      posMenu = elBanner.clientHeight;
+    }
+    var isUnderBanner = function() {
+      return window.pageYOffset > posMenu;
+    }
+    var fixMenuAfterBanner = function() {
+      if (isUnderBanner()) {
+        if (!isMenuFixed) {
+          // The menu will be fixed
+          toggleFixedPosition(true);
+        }
+      } else if (isMenuFixed) {
+        // The menu stay under the banner
+        toggleFixedPosition(false);
+      }
+    }
+    var toggleBannerEvents = function (on) {
+      // Add or remove event listerners attached to the DOM
+      var method = on ? "addEventListener" : "removeEventListener";
+      window[method]("resize", getMenuPosition);
+      window[method]("scroll", fixMenuAfterBanner);
+    }
+    var toggleFixedPosition = function (on) {
+      // Switch between relative and fixed position
+      var method = on ? "add" : "remove";
+      elBody.classList[method](nameFixMenu);
+      isMenuFixed = on;
+    }
+    // Load component according to user preferences
+    if (!localStorage.getItem(nameStorage)) {
+      initBanner();
+    }
+  })()
+</script>

--- a/themes/vue/source/css/_vueschool.styl
+++ b/themes/vue/source/css/_vueschool.styl
@@ -198,7 +198,7 @@
 @media screen and (max-width: 425px)
   .vueschool-banner
     p
-      max-width 185px
+      max-width 200px
     span
       display none
 

--- a/themes/vue/source/css/_vueschool.styl
+++ b/themes/vue/source/css/_vueschool.styl
@@ -1,0 +1,212 @@
+.vueschool-weekend-promo.docs
+  .vueschool-banner
+    z-index 100
+
+.vueschool-banner
+  display none
+  background #4fc08d
+  background-image linear-gradient(to right, #35495E, #35495E 50%, #4fc08d 50%)
+  overflow hidden
+  position relative
+
+  &:before
+    content ''
+    background #35495E
+    background-image linear-gradient(to right, #4fc08d, #4fc08d 80%, #35495E 100%)
+    position absolute
+    top 0
+    bottom 0
+    left 0
+    width 0
+    transition width .15s ease-out .1s
+
+  &:hover
+    &:before
+      transition width .15s ease-in
+      width 50%
+    p
+      transition-delay 0
+      color #fff
+
+    .vueschool-banner--wrapper::before
+      width 100vw
+      transition width .15s ease-in .10s
+
+  a
+    display flex
+    height 80px
+    justify-content center
+
+  .hidden
+    display none
+
+.vueschool-banner--wrapper
+  display flex
+  height 100%
+  align-items center
+  background #4fc08d
+  margin-left -50px
+  padding-left 50px
+  position relative
+
+  &:before
+    content ''
+    pointer-events none
+    background #35495E
+    background-image linear-gradient(to right, #35495E, #35495E 80%, #4fc08d 100%)
+    position absolute
+    top 0
+    bottom 0
+    left 0
+    width 0
+    transition width .15s ease-out
+
+  &:hover
+    + .vueschool-banner--close
+      &:before,
+      &:after
+        transform-origin 100%
+
+  p
+    margin -3px 50px 0 20px
+    font-size 1.17rem
+    font-weight 600
+    color #2c3e50
+    position relative
+    transition-delay .15s
+
+  span
+    font-size 1rem
+    display block
+    color #fff
+
+.vueschool-banner--logo
+  height 102%
+  margin-top: -1px
+  margin-left 125px
+  position relative
+  z-index 2
+
+.vueschool-banner--close
+  position absolute
+  top 20px
+  right 25px
+  height 40px
+  width 40px
+  -webkit-tap-highlight-color transparent
+  border-radius 50%
+  cursor pointer
+
+  &:before,
+  &:after
+    content ''
+    position absolute
+    top 19px
+    left 14px
+    width 25px
+    height 2px
+    background-color #fff
+    transform-origin 50%
+    transform rotate(-45deg)
+    transition all .2s ease-out
+
+  &:after
+    transform rotate(45deg)
+
+  &:hover
+    &:before,
+    &:after
+      transform rotate(180deg)
+
+.vueschool-weekend-promo
+  #mobile-bar,
+  #mobile-bar.top
+    position relative
+    background-color #fff
+
+  &.docs:not(.vueschool-menu-fixed)
+    padding-top 0
+    #header
+      position relative
+      width auto
+    #nav
+      position absolute
+
+  &.vueschool-menu-fixed
+    #mobile-bar
+      position fixed
+
+@media screen and (min-width: 901px)
+  .vueschool-weekend-promo.docs:not(.vueschool-menu-fixed)
+    #main.fix-sidebar .sidebar .sidebar-inner
+      padding-top 110px
+
+@media screen and (min-width: 415px) and (max-width: 900px)
+  .vueschool-weekend-promo.docs:not(.vueschool-menu-fixed)
+      #main.fix-sidebar .sidebar .sidebar-inner
+        padding-top 140px
+
+      #sidebar-sponsors-platinum-right
+        position absolute
+        top: 170px;
+
+    &.vueschool-menu-fixed.docs
+      .vueschool-banner
+        margin-bottom 0
+
+@media screen and (max-width: 414px)
+  // Docs menu
+  .vueschool-weekend-promo.docs:not(.vueschool-menu-fixed)
+    #main.fix-sidebar .sidebar .sidebar-inner
+     padding-top 100px
+
+  .vueschool-banner
+    .vueschool-banner--logo
+      margin-left 0
+
+  .vueschool-weekend-promo
+    &.vueschool-menu-fixed
+      .vueschool-banner
+        margin-bottom 40px
+
+
+@media screen and (max-width: 700px)
+  .vueschool-banner
+    a
+      height 40px
+      overflow hidden
+
+    .vueschool-banner--logo
+      margin-left 0
+      justify-content flex-start
+
+    p, span
+      font-size .8rem
+      color #fff
+
+    .vueschool-banner--close
+      top 0px
+      right 0px
+
+      &:before,
+      &:after
+        top 19px
+        left 14px
+        width 15px
+        height 2px
+
+@media screen and (max-width: 425px)
+  .vueschool-banner
+    p
+      max-width 185px
+    span
+      display none
+
+@media screen and (max-width 286px)
+  .vueschool-banner p
+    font-size 0.6rem
+    margin -3px 28px 0 0px
+
+@media print
+  .vueschool-banner
+    display none

--- a/themes/vue/source/css/index.styl
+++ b/themes/vue/source/css/index.styl
@@ -4,6 +4,7 @@
 @import "_sponsors-index"
 @import "_modal"
 @import "_themes"
+@import "_vueschool"
 
 $width = 900px
 $space = 40px

--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -15,6 +15,7 @@
 @import "_modal"
 @import "_scrimba"
 @import "_vue-mastery"
+@import "_vueschool"
 @import "_themes"
 
 #header

--- a/themes/vue/source/images/vueschool_logo.svg
+++ b/themes/vue/source/images/vueschool_logo.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Слой_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 356 181.3" style="enable-background:new 0 0 356 181.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:url(#Path_1_);}
+	.st2{fill:url(#Path_2_);}
+	.st3{fill:url(#Path_3_);}
+	.st4{fill:url(#Path_4_);}
+	.st5{fill:url(#Path_5_);}
+</style>
+<title>existing_color</title>
+<desc>Created with Sketch.</desc>
+<path class="st0" d="M110.1,0.3H356L245.7,181.6H0L110.1,0.3z"/>
+<g>
+	
+		<linearGradient id="Path_1_" gradientUnits="userSpaceOnUse" x1="-517.1764" y1="909.538" x2="-517.1221" y2="908.8699" gradientTransform="matrix(14.2876 0.6702 2.4631 -52.5069 5325.0068 48166.8047)">
+		<stop  offset="0" style="stop-color:#131057"/>
+		<stop  offset="1" style="stop-color:#4F48AD"/>
+	</linearGradient>
+	<path id="Path_6_" class="st1" d="M166.5,103.9c-6.1-39.6,2.6-65,2.6-65s-2.7,15.6,11.8,41.6c-1.7,31.3,3.7,47.9,3.7,47.9l1.3-0.9
+		l-1.3,1C184.6,128.6,175.7,120.5,166.5,103.9z"/>
+	
+		<linearGradient id="Path_2_" gradientUnits="userSpaceOnUse" x1="-496.2607" y1="887.6491" x2="-496.0965" y2="886.2806" gradientTransform="matrix(10.2942 0.4829 1.2024 -25.6314 4253.4224 23054.8262)">
+		<stop  offset="0" style="stop-color:#131057"/>
+		<stop  offset="1" style="stop-color:#4F48AD"/>
+	</linearGradient>
+	<path id="Path_7_" class="st2" d="M204,100.1c3.6,4,7,6.8,9.5,8.2c0,0,0,0,0,0c0,0,2.8,1.2,3.3,0.5c3.7-3.5,4.8-10.4,3.1-23.5
+		c-12.9-8.2-14.1-20.2-14.1-20.2S202.7,81.5,204,100.1z"/>
+	
+		<linearGradient id="Path_3_" gradientUnits="userSpaceOnUse" x1="-535.6442" y1="914.1013" x2="-535.7375" y2="914.7805" gradientTransform="matrix(22.3455 1.0482 3.2801 -69.9231 9125.6562 64590.3438)">
+		<stop  offset="0" style="stop-color:#EE6D93"/>
+		<stop  offset="1" style="stop-color:#F7C6B8"/>
+	</linearGradient>
+	<path id="Path_8_" class="st3" d="M169.1,38.9c0,0-12.7,37.1,3.3,91.5c0.4,1.6-0.2,3.3-1.5,4.2l-20.2,12.8c-1.9,1.3-4.6,0.3-5.3-2
+		c-4.5-14.5-16.6-62.4,0.3-113.4c0.8-2,3-3.1,5-2.2L169.1,38.9z"/>
+	
+		<linearGradient id="Path_4_" gradientUnits="userSpaceOnUse" x1="-519.8013" y1="904.6569" x2="-519.8253" y2="906.3208" gradientTransform="matrix(15.2455 0.7152 2.1064 -44.9039 6210.8237 41121.9414)">
+		<stop  offset="0" style="stop-color:#3CAC96"/>
+		<stop  offset="1" style="stop-color:#5FCEB8"/>
+	</linearGradient>
+	<path id="Path_9_" class="st4" d="M202.9,116.2l-18.3,12.2c0,0-8.2-25.5-1.1-72.8c0.5-2.7,3.4-4,5.7-2.5l16.6,12
+		c0,0-4.5,23-0.6,45.6C205.6,112.9,204.7,115.1,202.9,116.2z"/>
+	
+		<linearGradient id="Path_5_" gradientUnits="userSpaceOnUse" x1="-515.9165" y1="873.0706" x2="-516.3951" y2="871.6553" gradientTransform="matrix(14.4546 0.6781 0.9018 -19.2238 6902.4282 17207.0957)">
+		<stop  offset="0" style="stop-color:#80C3FF"/>
+		<stop  offset="0.4554" style="stop-color:#349BF7"/>
+		<stop  offset="1" style="stop-color:#714DD6"/>
+	</linearGradient>
+	<path id="Path_10_" class="st5" d="M236.9,88.7l-15.8-11.6c-1-0.7-2.5,0.2-2.3,1.4c3.1,17.5,2.1,26.1-2.1,30.2
+		c-0.5,0.7-3.3-0.5-3.3-0.5c2.6,1.5,3.3,0.8,3.3,0.8c2.8-1.9,13.2-8.8,19.8-13C239.2,94.3,239.4,90.6,236.9,88.7z"/>
+</g>
+</svg>


### PR DESCRIPTION
This PR adds a banner on top of vuejs.org to inform users about Vue School’s Black Friday Promotion.

The banner is a non-sticky, closable, banner for the top that opens [Vue School's Black Friday page](https://vueschool.io/sales/blackfriday) in a new tab.

The banner will not reappear if a user has closed it (stored in local storage). 

The banner respects the different sidebar behavior on the home page and the guide, on mobile, tablet, and desktop.

As discussed in email, we’ve based the promotion on a previously used marketing banner.

**Visuals**
[Desktop Demo](https://cl.ly/adce98b4894d)
[Tablet Demo](https://cl.ly/d13fb13e8062)
[Mobile Demo](https://cl.ly/3d3a3b47cc33)