### PR TITLE
Document gotcha with :is and DOM props

### DIFF
--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -603,6 +603,8 @@ In the example above, `currentTabComponent` can contain either:
 
 See [this fiddle](https://jsfiddle.net/chrisvfritz/o3nycadu/) to experiment with the full code, or [this version](https://jsfiddle.net/chrisvfritz/b2qj69o1/) for an example binding to a component's options object, instead of its registered name.
 
+Keep in mind that this attribute can be used with regular HTML elements, however they will be treated as components, which means all attributes **will be bound as DOM attributes**. For some properties such as `value` to work as you would expect, you will need to bind them using the [`.prop` modifier](../api/#v-bind).
+
 That's all you need to know about dynamic components for now, but once you've finished reading this page and feel comfortable with its content, we recommend coming back later to read the full guide on [Dynamic & Async Components](components-dynamic-async.html).
 
 ## DOM Template Parsing Caveats


### PR DESCRIPTION
This is #2241 reborn. The motivation for it is that this snippet of code:

```html
<component :is="multiline ? 'textarea' : 'input'" v-model="value">
```

Won't work as would expect, so we are documenting that you should, instead, use `:value.prop` and `@input` instead of `v-model`.