### PR TITLE
Removed slot attribute from styleguide attributes order

### DIFF
--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -1612,7 +1612,6 @@ This is the default order we recommend for component options. They're split into
 6. **Unique Attributes** (attributes that require unique values)
   - `ref`
   - `key`
-  - `slot`
 
 7. **Two-Way Binding** (combining binding and events)
   - `v-model`


### PR DESCRIPTION
This PR removes deprecated `slot` attribute from Styleguide section about recommended attributes order. I didn't add `v-slot` directive there but I am open for opinions on where it should be added in the order

Close https://github.com/vuejs/vuejs.org/issues/2405