### PR TITLE
Update example of a singe file component

### DIFF
--- a/src/v2/guide/single-file-components.md
+++ b/src/v2/guide/single-file-components.md
@@ -21,7 +21,7 @@ All of these are solved by **single-file components** with a `.vue` extension, m
 
 Here's an example of a file we'll call `Hello.vue`:
 
-<a href="https://gist.github.com/chrisvfritz/e2b6a6110e0829d78fa4aedf7cf6b235" target="_blank" rel="noopener noreferrer"><img src="/images/vue-component.png" alt="Single-file component example (click for code as text)" style="display: block; margin: 30px auto;"></a>
+<a href="https://gist.github.com/humb1t/2c914b15f2300fb29f00c09fa8f1dd66" target="_blank" rel="noopener noreferrer"><img src="/images/vue-component.png" alt="Single-file component example (click for code as text)" style="display: block; margin: 30px auto;"></a>
 
 Now we get:
 


### PR DESCRIPTION
In a https://vuejs.org/v2/guide/single-file-components.html we have `Hello.vue` example, which contains `module.exports =` semantic. I hope I'm right and it's better to use `export default` semantic instead. So I replaced gist with fork of an initial example with this small change.