### PR TITLE
Update pre-deploy.js

### DIFF
--- a/pre-deploy.js
+++ b/pre-deploy.js
@@ -39,7 +39,7 @@ Promise.all([
     installation
       .replace(/vue_version: .*/, 'vue_version: ' + version)
       .replace(/gz_size:.*/g, `gz_size: "${prodSize}"`)
-      .replace(/\/vue@[\d\.]+\//g, `/vue@${version}/`)
+      .replace(/\/vue@[\d\.]+/g, `/vue@${version}`)
   )
   console.log(`\nSuccessfully updated Vue version and gzip file size.\n`)
 }).catch(err => {


### PR DESCRIPTION
Now only one link is being updated when pre-deploy.js is running, and the second link still points to version 2.6.0

<img width="742" alt="Снимок экрана 2019-12-17 в 23 49 53" src="https://user-images.githubusercontent.com/4497128/71033440-582d6580-2128-11ea-9cd1-54b8fd1b6483.png">
