### PR TITLE
Change String.match method to regexObj.test

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -252,7 +252,7 @@ Mutation methods, as the name suggests, mutate the original array they are calle
 
 ``` js
 example1.items = example1.items.filter(function (item) {
-  return item.message.match(/Foo/)
+  return /Foo/.test(item.message)
 })
 ```
 


### PR DESCRIPTION
String.match returns an array with detail information about the match and then it must be checked for truthiness. But here you just want to know if the value exists in the string. The regexObj.test method returns a boolean and performs better. 
RegexObj.test is the correct method in this case.