### PR TITLE
Changed an example for nested loop in List Rendering

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -383,19 +383,19 @@ computed: {
 
 In situations where computed properties are not feasible (e.g. inside nested `v-for` loops), you can use a method:
 
-``` html
-<li v-for="n in even(numbers)">{{ n }}</li>
+```html
+<ul v-for="set in sets">
+  <li v-for="n in even(set)">{{ n }}</li>
+</ul>
 ```
 
-``` js
+```js
 data: {
-  numbers: [ 1, 2, 3, 4, 5 ]
+  sets: [[ 1, 2, 3, 4, 5 ], [6, 7, 8, 9, 10]]
 },
 methods: {
-  even: function (numbers) {
-    return numbers.filter(function (number) {
-      return number % 2 === 0
-    })
+  even(numbers) {
+    return numbers.filter(number => number % 2 === 0)
   }
 }
 ```

--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -394,8 +394,10 @@ data: {
   sets: [[ 1, 2, 3, 4, 5 ], [6, 7, 8, 9, 10]]
 },
 methods: {
-  even(numbers) {
-    return numbers.filter(number => number % 2 === 0)
+  even: function (numbers) {
+    return numbers.filter(function (number) {
+      return number % 2 === 0
+    })
   }
 }
 ```


### PR DESCRIPTION
The [Displaying Filtered/Sorted Results](https://vuejs.org/v2/guide/list.html#Displaying-Filtered-Sorted-Results) mentions a case with nested `v-for` loop but it's followed with an example that does not contain any nesting; more to say, `numbers` property is explicitly placed in `data`. This can raise a question: _"Is there any sense of using a method here? If `numbers` are in `data`, we can use computed again!"_

This PR adds an actual nested loop to align the description with the example