### PR TITLE
Fix Style Guide: Base component names example

### DIFF
--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -774,7 +774,7 @@ Some advantages of this convention:
 - Since these components are so frequently used, you may want to simply make them global instead of importing them everywhere. A prefix makes this possible with Webpack:
 
   ``` js
-  var requireComponent = require.context("./src", true, /^Base[A-Z]/)
+  var requireComponent = require.context("./src", true, /Base[A-Z]\w+\.(vue|js)$/)
   requireComponent.keys().forEach(function (fileName) {
     var baseComponentConfig = requireComponent(fileName)
     baseComponentConfig = baseComponentConfig.default || baseComponentConfig


### PR DESCRIPTION
Webpack `require.context` matches file relative path.
For example: `['./BaseXXX.vue', './BaseYYY.vue']`, the path starts with './'
regex `/^Base/` will get empty result.