### PR TITLE
Moving external example code to the examples folder

### DIFF
--- a/src/v2/examples/vue-20-accessing-parent-component-instance/index.html
+++ b/src/v2/examples/vue-20-accessing-parent-component-instance/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dependency Injection Google Maps Demo</title>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAHbknPTCvUSgWwU0jJ68m4h6b7vpyP6hM"></script>
+    <script src="https://unpkg.com/vue"></script>
+    <style>
+      .map {
+        width: 100%;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <google-map>
+        <google-map-marker v-bind:places="vueConfCities"></google-map-marker>
+      </google-map>
+    </div>
+
+    <script>
+      Vue.component("google-map", {
+        data: function() {
+          return {
+            map: null
+          };
+        },
+        mounted: function() {
+          this.map = new google.maps.Map(this.$el, {
+            center: { lat: 0, lng: 0 },
+            zoom: 1
+          });
+        },
+        methods: {
+          getMap: function(found) {
+            var vm = this;
+            function checkForMap() {
+              if (vm.map) {
+                found(vm.map);
+              } else {
+                setTimeout(checkForMap, 50);
+              }
+            }
+            checkForMap();
+          }
+        },
+        template: '<div class="map"><slot></slot></div>'
+      });
+
+      Vue.component("google-map-marker", {
+        props: ["places"],
+        created: function() {
+          var vm = this;
+          vm.$parent.getMap(function(map) {
+            vm.places.forEach(function(place) {
+              new google.maps.Marker({
+                position: place.position,
+                map: map
+              });
+            });
+          });
+        },
+        render(h) {
+          return null;
+        }
+      });
+
+      new Vue({
+        el: "#app",
+        data: {
+          vueConfCities: [
+            {
+              name: "Wrocław",
+              position: {
+                lat: 51.107885,
+                lng: 17.038538
+              }
+            },
+            {
+              name: "New Orleans",
+              position: {
+                lat: 29.951066,
+                lng: -90.071532
+              }
+            }
+          ]
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-accessing-parent-component-instance/package.json
+++ b/src/v2/examples/vue-20-accessing-parent-component-instance/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-accessing-parent-component-instance",
+  "version": "1.0.0",
+  "description": "Vue.js example accessing Parent Component Instance using Google Maps.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-accessing-parent-component-instance/sandbox.config.json
+++ b/src/v2/examples/vue-20-accessing-parent-component-instance/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-component-blog-post-example/index.html
+++ b/src/v2/examples/vue-20-component-blog-post-example/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Component Blog Post Example</title>
+    <script src="https://unpkg.com/vue"></script>
+  </head>
+  <body>
+    <div id="blog-post-demo" class="demo">
+      <blog-post
+        v-for="post in posts"
+        v-bind:key="post.id"
+        v-bind:title="post.title"
+      ></blog-post>
+    </div>
+
+    <script>
+      Vue.component("blog-post", {
+        props: ["title"],
+        template: "<h3>{{ title }}</h3>"
+      });
+
+      new Vue({
+        el: "#blog-post-demo",
+        data: {
+          posts: []
+        },
+        created: function() {
+          // Alias the component instance as `vm`, so that we
+          // can access it inside the promise function
+          var vm = this;
+          // Fetch our array of posts from an API
+          fetch("https://jsonplaceholder.typicode.com/posts")
+            .then(function(response) {
+              return response.json();
+            })
+            .then(function(data) {
+              vm.posts = data;
+            });
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-component-blog-post-example/package.json
+++ b/src/v2/examples/vue-20-component-blog-post-example/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-component-blog-post-example",
+  "version": "1.0.0",
+  "description": "Dynamically passing props, like when fetching posts from an API.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-component-blog-post-example/sandbox.config.json
+++ b/src/v2/examples/vue-20-component-blog-post-example/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-dependency-injection/index.html
+++ b/src/v2/examples/vue-20-dependency-injection/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dependency Injection Google Maps Demo</title>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAHbknPTCvUSgWwU0jJ68m4h6b7vpyP6hM"></script>
+    <script src="https://unpkg.com/vue"></script>
+    <style>
+      .map {
+        width: 100%;
+        height: 400px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <google-map>
+        <google-map-marker v-bind:places="vueConfCities"></google-map-marker>
+      </google-map>
+    </div>
+
+    <script>
+      Vue.component("google-map", {
+        provide: function() {
+          return {
+            getMap: this.getMap
+          };
+        },
+        data: function() {
+          return {
+            map: null
+          };
+        },
+        mounted: function() {
+          this.map = new google.maps.Map(this.$el, {
+            center: { lat: 0, lng: 0 },
+            zoom: 1
+          });
+        },
+        methods: {
+          getMap: function(found) {
+            var vm = this;
+            function checkForMap() {
+              if (vm.map) {
+                found(vm.map);
+              } else {
+                setTimeout(checkForMap, 50);
+              }
+            }
+            checkForMap();
+          }
+        },
+        template: '<div class="map"><slot></slot></div>'
+      });
+
+      Vue.component("google-map-marker", {
+        inject: ["getMap"],
+        props: ["places"],
+        created: function() {
+          var vm = this;
+          vm.getMap(function(map) {
+            vm.places.forEach(function(place) {
+              new google.maps.Marker({
+                position: place.position,
+                map: map
+              });
+            });
+          });
+        },
+        render(h) {
+          return null;
+        }
+      });
+
+      new Vue({
+        el: "#app",
+        data: {
+          vueConfCities: [
+            {
+              name: "Wrocław",
+              position: {
+                lat: 51.107885,
+                lng: 17.038538
+              }
+            },
+            {
+              name: "New Orleans",
+              position: {
+                lat: 29.951066,
+                lng: -90.071532
+              }
+            }
+          ]
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-dependency-injection/package.json
+++ b/src/v2/examples/vue-20-dependency-injection/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-dependency-injection",
+  "version": "1.0.0",
+  "description": "Vue.js Dependency Injection example using Google Maps.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-dependency-injection/sandbox.config.json
+++ b/src/v2/examples/vue-20-dependency-injection/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-dynamic-components-with-binding/index.html
+++ b/src/v2/examples/vue-20-dynamic-components-with-binding/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dynamic Components Example</title>
+    <script src="https://unpkg.com/vue"></script>
+    <style>
+      .tab-button {
+        padding: 6px 10px;
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
+        border: 1px solid #ccc;
+        cursor: pointer;
+        background: #f0f0f0;
+        margin-bottom: -1px;
+        margin-right: -1px;
+      }
+      .tab-button:hover {
+        background: #e0e0e0;
+      }
+      .tab-button.active {
+        background: #e0e0e0;
+      }
+      .tab {
+        border: 1px solid #ccc;
+        padding: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="dynamic-component-demo" class="demo">
+      <button
+        v-for="tab in tabs"
+        v-bind:key="tab.name"
+        v-bind:class="['tab-button', { active: currentTab.name === tab.name }]"
+        v-on:click="currentTab = tab"
+      >
+        {{ tab.name }}
+      </button>
+
+      <component v-bind:is="currentTab.component" class="tab"></component>
+    </div>
+
+    <script>
+      var tabs = [
+        {
+          name: "Home",
+          component: {
+            template: "<div>Home component</div>"
+          }
+        },
+        {
+          name: "Posts",
+          component: {
+            template: "<div>Posts component</div>"
+          }
+        },
+        {
+          name: "Archive",
+          component: {
+            template: "<div>Archive component</div>"
+          }
+        }
+      ];
+
+      new Vue({
+        el: "#dynamic-component-demo",
+        data: {
+          tabs: tabs,
+          currentTab: tabs[0]
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-dynamic-components-with-binding/package.json
+++ b/src/v2/examples/vue-20-dynamic-components-with-binding/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-dynamic-components-with-binding",
+  "version": "1.0.0",
+  "description": "Showing binding to a component's options object.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-dynamic-components-with-binding/sandbox.config.json
+++ b/src/v2/examples/vue-20-dynamic-components-with-binding/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-dynamic-components/index.html
+++ b/src/v2/examples/vue-20-dynamic-components/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dynamic Components Example</title>
+    <script src="https://unpkg.com/vue"></script>
+    <style>
+      .tab-button {
+        padding: 6px 10px;
+        border-top-left-radius: 3px;
+        border-top-right-radius: 3px;
+        border: 1px solid #ccc;
+        cursor: pointer;
+        background: #f0f0f0;
+        margin-bottom: -1px;
+        margin-right: -1px;
+      }
+      .tab-button:hover {
+        background: #e0e0e0;
+      }
+      .tab-button.active {
+        background: #e0e0e0;
+      }
+      .tab {
+        border: 1px solid #ccc;
+        padding: 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="dynamic-component-demo" class="demo">
+      <button
+        v-for="tab in tabs"
+        v-bind:key="tab"
+        v-bind:class="['tab-button', { active: currentTab === tab }]"
+        v-on:click="currentTab = tab"
+      >
+        {{ tab }}
+      </button>
+
+      <component v-bind:is="currentTabComponent" class="tab"></component>
+    </div>
+
+    <script>
+      Vue.component("tab-home", {
+        template: "<div>Home component</div>"
+      });
+      Vue.component("tab-posts", {
+        template: "<div>Posts component</div>"
+      });
+      Vue.component("tab-archive", {
+        template: "<div>Archive component</div>"
+      });
+
+      new Vue({
+        el: "#dynamic-component-demo",
+        data: {
+          currentTab: "Home",
+          tabs: ["Home", "Posts", "Archive"]
+        },
+        computed: {
+          currentTabComponent: function() {
+            return "tab-" + this.currentTab.toLowerCase();
+          }
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-dynamic-components/package.json
+++ b/src/v2/examples/vue-20-dynamic-components/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-dynamic-components",
+  "version": "1.0.0",
+  "description": "Used to dynamically switch between components, like in a tabbed interface.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-dynamic-components/sandbox.config.json
+++ b/src/v2/examples/vue-20-dynamic-components/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-dynamic-state-transitions/index.html
+++ b/src/v2/examples/vue-20-dynamic-state-transitions/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Dynamic State Transitions</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/1.18.5/TweenLite.min.js"></script>
+    <script src="https://unpkg.com/vue"></script>
+    <style>
+      svg {
+        display: block;
+      }
+      polygon {
+        fill: #41b883;
+      }
+      circle {
+        fill: transparent;
+        stroke: #35495e;
+      }
+      input[type="range"] {
+        display: block;
+        width: 100%;
+        margin-bottom: 15px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <svg width="200" height="200">
+        <polygon :points="points"></polygon>
+        <circle cx="100" cy="100" r="90"></circle>
+      </svg>
+      <label>Sides: {{ sides }}</label>
+      <input type="range" min="3" max="500" v-model.number="sides" />
+      <label>Minimum Radius: {{ minRadius }}%</label>
+      <input type="range" min="0" max="90" v-model.number="minRadius" />
+      <label>Update Interval: {{ updateInterval }} milliseconds</label>
+      <input type="range" min="10" max="2000" v-model.number="updateInterval" />
+    </div>
+
+    <script>
+      new Vue({
+        el: "#app",
+        data: function() {
+          var defaultSides = 10;
+          var stats = Array.apply(null, { length: defaultSides }).map(
+            function() {
+              return 100;
+            }
+          );
+          return {
+            stats: stats,
+            points: generatePoints(stats),
+            sides: defaultSides,
+            minRadius: 50,
+            interval: null,
+            updateInterval: 500
+          };
+        },
+        watch: {
+          sides: function(newSides, oldSides) {
+            var sidesDifference = newSides - oldSides;
+            if (sidesDifference > 0) {
+              for (var i = 1; i <= sidesDifference; i++) {
+                this.stats.push(this.newRandomValue());
+              }
+            } else {
+              var absoluteSidesDifference = Math.abs(sidesDifference);
+              for (var i = 1; i <= absoluteSidesDifference; i++) {
+                this.stats.shift();
+              }
+            }
+          },
+          stats: function(newStats) {
+            TweenLite.to(this.$data, this.updateInterval / 1000, {
+              points: generatePoints(newStats)
+            });
+          },
+          updateInterval: function() {
+            this.resetInterval();
+          }
+        },
+        mounted: function() {
+          this.resetInterval();
+        },
+        methods: {
+          randomizeStats: function() {
+            var vm = this;
+            this.stats = this.stats.map(function() {
+              return vm.newRandomValue();
+            });
+          },
+          newRandomValue: function() {
+            return Math.ceil(
+              this.minRadius + Math.random() * (100 - this.minRadius)
+            );
+          },
+          resetInterval: function() {
+            var vm = this;
+            clearInterval(this.interval);
+            this.randomizeStats();
+            this.interval = setInterval(function() {
+              vm.randomizeStats();
+            }, this.updateInterval);
+          }
+        }
+      });
+
+      function valueToPoint(value, index, total) {
+        var x = 0;
+        var y = -value * 0.9;
+        var angle = ((Math.PI * 2) / total) * index;
+        var cos = Math.cos(angle);
+        var sin = Math.sin(angle);
+        var tx = x * cos - y * sin + 100;
+        var ty = x * sin + y * cos + 100;
+        return { x: tx, y: ty };
+      }
+
+      function generatePoints(stats) {
+        var total = stats.length;
+        return stats
+          .map(function(stat, index) {
+            var point = valueToPoint(stat, index, total);
+            return point.x + "," + point.y;
+          })
+          .join(" ");
+      }
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-dynamic-state-transitions/package.json
+++ b/src/v2/examples/vue-20-dynamic-state-transitions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-dynamic-state-transitions",
+  "version": "1.0.0",
+  "description": "Data backing state transitions can be updated in real time, like in this example.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-dynamic-state-transitions/sandbox.config.json
+++ b/src/v2/examples/vue-20-dynamic-state-transitions/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-hello-world/index.html
+++ b/src/v2/examples/vue-20-hello-world/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script src="https://unpkg.com/vue"></script>
+    <script>
+      window.onload = function() {
+        new Vue({
+          el: "#app",
+          data: {
+            message: "Hello Vue.js!"
+          }
+        });
+      };
+    </script>
+    <title>Vue 2.0 Hello World</title>
+  </head>
+  <body>
+    <div id="app">
+      <p>{{ message }}</p>
+    </div>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-hello-world/index.html
+++ b/src/v2/examples/vue-20-hello-world/index.html
@@ -1,22 +1,21 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <script src="https://unpkg.com/vue"></script>
-    <script>
-      window.onload = function() {
-        new Vue({
-          el: "#app",
-          data: {
-            message: "Hello Vue.js!"
-          }
-        });
-      };
-    </script>
-    <title>Vue 2.0 Hello World</title>
-  </head>
-  <body>
-    <div id="app">
-      <p>{{ message }}</p>
-    </div>
-  </body>
+<html>
+<head>
+  <title>My first Vue app</title>
+  <script src="https://unpkg.com/vue"></script>
+</head>
+<body>
+  <div id="app">
+    {{ message }}
+  </div>
+
+  <script>
+    var app = new Vue({
+      el: '#app',
+      data: {
+        message: 'Hello Vue!'
+      }
+    })
+  </script>
+</body>
 </html>

--- a/src/v2/examples/vue-20-hello-world/package.json
+++ b/src/v2/examples/vue-20-hello-world/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-hello-world",
+  "version": "1.0.0",
+  "description": "The easiest way to try out Vue.js, edit this Hello World example",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-hello-world/sandbox.config.json
+++ b/src/v2/examples/vue-20-hello-world/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-keep-alive-with-dynamic-components/index.html
+++ b/src/v2/examples/vue-20-keep-alive-with-dynamic-components/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Vue Component Blog Post Example</title>
+    <script src="https://unpkg.com/vue"></script>
+    <link rel="stylesheet" type="text/css" href="/style.css" />
+  </head>
+  <body>
+    <div id="dynamic-component-demo">
+      <button
+        v-for="tab in tabs"
+        v-bind:key="tab"
+        v-bind:class="['tab-button', { active: currentTab === tab }]"
+        v-on:click="currentTab = tab"
+      >
+        {{ tab }}
+      </button>
+
+      <keep-alive>
+        <component v-bind:is="currentTabComponent" class="tab"></component>
+      </keep-alive>
+    </div>
+
+    <script>
+      Vue.component("tab-posts", {
+        data: function() {
+          return {
+            posts: [
+              {
+                id: 1,
+                title: "Cat Ipsum",
+                content:
+                  "<p>Dont wait for the storm to pass, dance in the rain kick up litter decide to want nothing to do with my owner today demand to be let outside at once, and expect owner to wait for me as i think about it cat cat moo moo lick ears lick paws so make meme, make cute face but lick the other cats. Kitty poochy chase imaginary bugs, but stand in front of the computer screen. Sweet beast cat dog hate mouse eat string barf pillow no baths hate everything stare at guinea pigs. My left donut is missing, as is my right loved it, hated it, loved it, hated it scoot butt on the rug cat not kitten around</p>"
+              },
+              {
+                id: 2,
+                title: "Hipster Ipsum",
+                content:
+                  "<p>Bushwick blue bottle scenester helvetica ugh, meh four loko. Put a bird on it lumbersexual franzen shabby chic, street art knausgaard trust fund shaman scenester live-edge mixtape taxidermy viral yuccie succulents. Keytar poke bicycle rights, crucifix street art neutra air plant PBR&B hoodie plaid venmo. Tilde swag art party fanny pack vinyl letterpress venmo jean shorts offal mumblecore. Vice blog gentrify mlkshk tattooed occupy snackwave, hoodie craft beer next level migas 8-bit chartreuse. Trust fund food truck drinking vinegar gochujang.</p>"
+              },
+              {
+                id: 3,
+                title: "Cupcake Ipsum",
+                content:
+                  "<p>Icing dessert soufflé lollipop chocolate bar sweet tart cake chupa chups. Soufflé marzipan jelly beans croissant toffee marzipan cupcake icing fruitcake. Muffin cake pudding soufflé wafer jelly bear claw sesame snaps marshmallow. Marzipan soufflé croissant lemon drops gingerbread sugar plum lemon drops apple pie gummies. Sweet roll donut oat cake toffee cake. Liquorice candy macaroon toffee cookie marzipan.</p>"
+              }
+            ],
+            selectedPost: null
+          };
+        },
+        template: `
+  	<div class="posts-tab">
+      <ul class="posts-sidebar">
+        <li
+          v-for="post in posts"
+          v-bind:key="post.id"
+          v-bind:class="{ selected: post === selectedPost }"
+					v-on:click="selectedPost = post"
+        >
+          {{ post.title }}
+        </li>
+      </ul>
+      <div class="selected-post-container">
+      	<div 
+        	v-if="selectedPost"
+          class="selected-post"
+        >
+          <h3>{{ selectedPost.title }}</h3>
+          <div v-html="selectedPost.content"></div>
+        </div>
+        <strong v-else>
+          Click on a blog title to the left to view it.
+        </strong>
+      </div>
+    </div>
+  `
+      });
+
+      Vue.component("tab-archive", {
+        template: "<div>Archive component</div>"
+      });
+
+      new Vue({
+        el: "#dynamic-component-demo",
+        data: {
+          currentTab: "Posts",
+          tabs: ["Posts", "Archive"]
+        },
+        computed: {
+          currentTabComponent: function() {
+            return "tab-" + this.currentTab.toLowerCase();
+          }
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-keep-alive-with-dynamic-components/package.json
+++ b/src/v2/examples/vue-20-keep-alive-with-dynamic-components/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-keep-alive-with-dynamic-components",
+  "version": "1.0.0",
+  "description": "The Posts tab maintains its state (the selected post) even when it's not rendered.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-keep-alive-with-dynamic-components/sandbox.config.json
+++ b/src/v2/examples/vue-20-keep-alive-with-dynamic-components/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-keep-alive-with-dynamic-components/style.css
+++ b/src/v2/examples/vue-20-keep-alive-with-dynamic-components/style.css
@@ -1,0 +1,49 @@
+.tab-button {
+  padding: 6px 10px;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  border: 1px solid #ccc;
+  cursor: pointer;
+  background: #f0f0f0;
+  margin-bottom: -1px;
+  margin-right: -1px;
+}
+.tab-button:hover {
+  background: #e0e0e0;
+}
+.tab-button.active {
+  background: #e0e0e0;
+}
+.tab {
+  border: 1px solid #ccc;
+  padding: 10px;
+}
+.posts-tab {
+  display: flex;
+}
+.posts-sidebar {
+  max-width: 40vw;
+  margin: 0;
+  padding: 0 10px 0 0;
+  list-style-type: none;
+  border-right: 1px solid #ccc;
+}
+.posts-sidebar li {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  cursor: pointer;
+}
+.posts-sidebar li:hover {
+  background: #eee;
+}
+.posts-sidebar li.selected {
+  background: lightblue;
+}
+.selected-post-container {
+  padding-left: 10px;
+}
+.selected-post > :first-child {
+  margin-top: 0;
+  padding-top: 0;
+}

--- a/src/v2/examples/vue-20-list-move-transitions/index.html
+++ b/src/v2/examples/vue-20-list-move-transitions/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>List Move Transitions Sudoku Example</title>
+    <script src="https://unpkg.com/vue"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.14.1/lodash.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="/style.css" />
+  </head>
+  <body>
+    <div id="sudoku-demo" class="demo">
+      <h1>Lazy Sudoku</h1>
+      <p>Keep hitting the shuffle button until you win.</p>
+
+      <button @click="shuffle">
+        Shuffle
+      </button>
+      <transition-group name="cell" tag="div" class="container">
+        <div v-for="cell in cells" :key="cell.id" class="cell">
+          {{ cell.number }}
+        </div>
+      </transition-group>
+    </div>
+
+    <script>
+      new Vue({
+        el: "#sudoku-demo",
+        data: {
+          cells: Array.apply(null, { length: 81 }).map(function(_, index) {
+            return {
+              id: index,
+              number: (index % 9) + 1
+            };
+          })
+        },
+        methods: {
+          shuffle: function() {
+            this.cells = _.shuffle(this.cells);
+          }
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-list-move-transitions/package.json
+++ b/src/v2/examples/vue-20-list-move-transitions/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-list-move-transitions",
+  "version": "1.0.0",
+  "description": "Example showing list entering/leaving transitions in Sudoku.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-list-move-transitions/sandbox.config.json
+++ b/src/v2/examples/vue-20-list-move-transitions/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-list-move-transitions/style.css
+++ b/src/v2/examples/vue-20-list-move-transitions/style.css
@@ -1,0 +1,25 @@
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 238px;
+  margin-top: 10px;
+}
+.cell {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  width: 25px;
+  height: 25px;
+  border: 1px solid #aaa;
+  margin-right: -1px;
+  margin-bottom: -1px;
+}
+.cell:nth-child(3n) {
+  margin-right: 0;
+}
+.cell:nth-child(27n) {
+  margin-bottom: 0;
+}
+.cell-move {
+  transition: transform 1s;
+}

--- a/src/v2/examples/vue-20-priority-d-rules-correct-example/index.html
+++ b/src/v2/examples/vue-20-priority-d-rules-correct-example/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Priority D Rules Correct Example</title>
+    <script src="https://unpkg.com/vue"></script>
+    <style>
+      .v-enter-active,
+      .v-leave-active {
+        transition: all 1s;
+      }
+      .v-enter,
+      .v-leave-to {
+        opacity: 0;
+        transform: translateY(30px);
+      }
+      .v-leave-active {
+        position: absolute;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <transition>
+        <button v-if="isEditing" key="save" v-on:click="isEditing = false">
+          Save
+        </button>
+        <button v-else key="edit" v-on:click="isEditing = true">
+          Edit
+        </button>
+      </transition>
+
+      <p>
+        With a unique <code>key</code> on each conditional element, the
+        transition is now applied.
+      </p>
+    </div>
+
+    <script>
+      new Vue({
+        el: "#app",
+        data: {
+          isEditing: false
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-priority-d-rules-correct-example/package.json
+++ b/src/v2/examples/vue-20-priority-d-rules-correct-example/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-priority-d-rules-correct-example",
+  "version": "1.0.0",
+  "description": "A unique key on each conditional element so the transition is applied.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-priority-d-rules-correct-example/sandbox.config.json
+++ b/src/v2/examples/vue-20-priority-d-rules-correct-example/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-priority-d-rules-unintended-consequences/index.html
+++ b/src/v2/examples/vue-20-priority-d-rules-unintended-consequences/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Priority D Rules Unintended Consequences</title>
+    <script src="https://unpkg.com/vue"></script>
+    <style>
+      .v-enter-active,
+      .v-leave-active {
+        transition: all 1s;
+      }
+      .v-enter,
+      .v-leave-to {
+        opacity: 0;
+        transform: translateY(30px);
+      }
+      .v-leave-active {
+        position: absolute;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app">
+      <transition>
+        <button v-if="isEditing" v-on:click="isEditing = false">
+          Save
+        </button>
+        <button v-else v-on:click="isEditing = true">
+          Edit
+        </button>
+      </transition>
+
+      <p>
+        When clicking on the <code>&lt;button&gt;</code> above, the transition
+        is never applied because Vue is reusing the same element for render
+        efficiency. To force Vue to treat these as separate elements, a
+        <a
+          href="https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-priority-d-rules-correct-example"
+          target="_blank"
+          >unique <code>key</code> must be added</a
+        >
+        to each conditional element.
+      </p>
+    </div>
+
+    <script>
+      new Vue({
+        el: "#app",
+        data: {
+          isEditing: false
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-priority-d-rules-unintended-consequences/package.json
+++ b/src/v2/examples/vue-20-priority-d-rules-unintended-consequences/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-priority-d-rules-unintended-consequences",
+  "version": "1.0.0",
+  "description": "Lacking a unique key on each conditional element, the transition is never applied.",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-priority-d-rules-unintended-consequences/sandbox.config.json
+++ b/src/v2/examples/vue-20-priority-d-rules-unintended-consequences/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-programmatic-event-listeners/index.html
+++ b/src/v2/examples/vue-20-programmatic-event-listeners/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Programmatic Event Listeners using Pikaday</title>
+    <script src="https://unpkg.com/pikaday@1.7.0"></script>
+    <script src="https://unpkg.com/vue"></script>
+  </head>
+  <body>
+    <div id="app">
+      <input ref="dateInput" v-model="date" type="date" />
+    </div>
+
+    <script>
+      new Vue({
+        el: "#app",
+        data: {
+          date: null
+        },
+        mounted: function() {
+          var picker = new Pikaday({
+            field: this.$refs.dateInput,
+            format: "YYYY-MM-DD"
+          });
+
+          this.$once("hook:beforeDestroy", function() {
+            picker.destroy();
+          });
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/v2/examples/vue-20-programmatic-event-listeners/package.json
+++ b/src/v2/examples/vue-20-programmatic-event-listeners/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "vue-20-programmatic-event-listeners",
+  "version": "1.0.0",
+  "description": "Vue.js Programmatic Event Listeners example using Pikaday",
+  "main": "index.html",
+  "scripts": {
+    "start": "serve"
+  },
+  "keywords": [],
+  "license": "MIT",
+  "devDependencies": {
+    "serve": "^11.2.0"
+  }
+}

--- a/src/v2/examples/vue-20-programmatic-event-listeners/sandbox.config.json
+++ b/src/v2/examples/vue-20-programmatic-event-listeners/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "static"
+}

--- a/src/v2/examples/vue-20-single-file-components/Hello.vue
+++ b/src/v2/examples/vue-20-single-file-components/Hello.vue
@@ -1,0 +1,20 @@
+<template>
+  <p>{{ greeting }} World!</p>
+</template>
+
+<script>
+module.exports = {
+  data: function() {
+    return {
+      greeting: "Hello"
+    };
+  }
+};
+</script>
+
+<style scoped>
+p {
+  font-size: 2em;
+  text-align: center;
+}
+</style>

--- a/src/v2/examples/vue-20-single-file-components/index.html
+++ b/src/v2/examples/vue-20-single-file-components/index.html
@@ -1,0 +1,1 @@
+<div id="app"></div>

--- a/src/v2/examples/vue-20-single-file-components/index.js
+++ b/src/v2/examples/vue-20-single-file-components/index.js
@@ -1,0 +1,10 @@
+import Vue from "vue";
+import App from "./Hello";
+
+Vue.config.productionTip = false;
+
+new Vue({
+  el: "#app",
+  template: "<App/>",
+  components: { App }
+});

--- a/src/v2/examples/vue-20-single-file-components/package.json
+++ b/src/v2/examples/vue-20-single-file-components/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "vue-20-single-file-components",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build",
+    "lint": "vue-cli-service lint"
+  },
+  "dependencies": {
+    "vue": "^2.6.11"
+  },
+  "devDependencies": {},
+  "browserslist": ["> 1%", "last 2 versions", "not ie <= 8"],
+  "keywords": [],
+  "description": "Hello.vue single-file components example using a .vue extension."
+}

--- a/src/v2/guide/components-dynamic-async.md
+++ b/src/v2/guide/components-dynamic-async.md
@@ -193,7 +193,7 @@ new Vue({
 </script>
 {% endraw %}
 
-Now the _Posts_ tab maintains its state (the selected post) even when it's not rendered. See [this fiddle](https://jsfiddle.net/chrisvfritz/Lp20op9o/) for the complete code.
+Now the _Posts_ tab maintains its state (the selected post) even when it's not rendered. See [this example](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-keep-alive-with-dynamic-components) for the complete code.
 
 <p class="tip">Note that `<keep-alive>` requires the components being switched between to all have names, either using the `name` option on a component, or through local/global registration.</p>
 

--- a/src/v2/guide/components-edge-cases.md
+++ b/src/v2/guide/components-edge-cases.md
@@ -233,7 +233,7 @@ methods: {
 }
 ```
 
-See [this fiddle](https://jsfiddle.net/09jvu65m/) for the full code. Note, however, that if you find yourself having to do a lot of setup and cleanup within a single component, the best solution will usually be to create more modular components. In this case, we'd recommend creating a reusable `<input-datepicker>` component.
+See [this example](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-programmatic-event-listeners) for the full code. Note, however, that if you find yourself having to do a lot of setup and cleanup within a single component, the best solution will usually be to create more modular components. In this case, we'd recommend creating a reusable `<input-datepicker>` component.
 
 To learn more about programmatic listeners, check out the API for [Events Instance Methods](https://vuejs.org/v2/api/#Instance-Methods-Events).
 

--- a/src/v2/guide/components-edge-cases.md
+++ b/src/v2/guide/components-edge-cases.md
@@ -154,7 +154,7 @@ Then in any descendants, we can use the `inject` option to receive specific prop
 inject: ['getMap']
 ```
 
-You can see the [full example here](https://jsfiddle.net/chrisvfritz/tdv8dt3s/). The advantage over using `$parent` is that we can access `getMap` in _any_ descendant component, without exposing the entire instance of `<google-map>`. This allows us to more safely keep developing that component, without fear that we might change/remove something that a child component is relying on. The interface between these components remains clearly defined, just as with `props`.
+You can see the [full example here](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-dependency-injection). The advantage over using `$parent` is that we can access `getMap` in _any_ descendant component, without exposing the entire instance of `<google-map>`. This allows us to more safely keep developing that component, without fear that we might change/remove something that a child component is relying on. The interface between these components remains clearly defined, just as with `props`.
 
 In fact, you can think of dependency injection as sort of "long-range props", except:
 

--- a/src/v2/guide/components-edge-cases.md
+++ b/src/v2/guide/components-edge-cases.md
@@ -63,7 +63,7 @@ There are cases however, particularly shared component libraries, when this _mig
 </google-map>
 ```
 
-The `<google-map>` component might define a `map` property that all subcomponents need access to. In this case `<google-map-markers>` might want to access that map with something like `this.$parent.getMap`, in order to add a set of markers to it. You can see this pattern [in action here](https://jsfiddle.net/chrisvfritz/ttzutdxh/).
+The `<google-map>` component might define a `map` property that all subcomponents need access to. In this case `<google-map-markers>` might want to access that map with something like `this.$parent.getMap`, in order to add a set of markers to it. You can see this pattern [in action here](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-accessing-parent-component-instance).
 
 Keep in mind, however, that components built with this pattern are still inherently fragile. For example, imagine we add a new `<google-map-region>` component and when `<google-map-markers>` appears within that, it should only render markers that fall within that region:
 

--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -203,7 +203,7 @@ Then want to render a component for each one:
 ></blog-post>
 ```
 
-Above, you'll see that we can use `v-bind` to dynamically pass props. This is especially useful when you don't know the exact content you're going to render ahead of time, like when [fetching posts from an API](https://jsfiddle.net/chrisvfritz/sbLgr0ad).
+Above, you'll see that we can use `v-bind` to dynamically pass props. This is especially useful when you don't know the exact content you're going to render ahead of time, like when [fetching posts from an API](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-component-blog-post-example).
 
 That's all you need to know about props for now, but once you've finished reading this page and feel comfortable with its content, we recommend coming back later to read the full guide on [Props](components-props.html).
 

--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -601,7 +601,7 @@ In the example above, `currentTabComponent` can contain either:
 - the name of a registered component, or
 - a component's options object
 
-See [this example](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-dynamic-components) to experiment with the full code, or [this version](https://jsfiddle.net/chrisvfritz/b2qj69o1/) for an example binding to a component's options object, instead of its registered name.
+See [this example](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-dynamic-components) to experiment with the full code, or [this version](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-dynamic-components-with-binding) for an example binding to a component's options object, instead of its registered name.
 
 Keep in mind that this attribute can be used with regular HTML elements, however they will be treated as components, which means all attributes **will be bound as DOM attributes**. For some properties such as `value` to work as you would expect, you will need to bind them using the [`.prop` modifier](../api/#v-bind).
 

--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -601,7 +601,7 @@ In the example above, `currentTabComponent` can contain either:
 - the name of a registered component, or
 - a component's options object
 
-See [this fiddle](https://jsfiddle.net/chrisvfritz/o3nycadu/) to experiment with the full code, or [this version](https://jsfiddle.net/chrisvfritz/b2qj69o1/) for an example binding to a component's options object, instead of its registered name.
+See [this example](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-dynamic-components) to experiment with the full code, or [this version](https://jsfiddle.net/chrisvfritz/b2qj69o1/) for an example binding to a component's options object, instead of its registered name.
 
 Keep in mind that this attribute can be used with regular HTML elements, however they will be treated as components, which means all attributes **will be bound as DOM attributes**. For some properties such as `value` to work as you would expect, you will need to bind them using the [`.prop` modifier](../api/#v-bind).
 

--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -20,7 +20,7 @@ If you are an experienced frontend developer and want to know how Vue compares t
 
 <p class="tip">The official guide assumes intermediate level knowledge of HTML, CSS, and JavaScript. If you are totally new to frontend development, it might not be the best idea to jump right into a framework as your first step - grasp the basics then come back! Prior experience with other frameworks helps, but is not required.</p>
 
-The easiest way to try out Vue.js is using the [JSFiddle Hello World example](https://jsfiddle.net/chrisvfritz/50wL7mdz/). Feel free to open it in another tab and follow along as we go through some basic examples. Or, you can <a href="https://gist.githubusercontent.com/chrisvfritz/7f8d7d63000b48493c336e48b3db3e52/raw/ed60c4e5d5c6fec48b0921edaed0cb60be30e87c/index.html" target="_blank" download="index.html" rel="noopener noreferrer">create an <code>index.html</code> file</a> and include Vue with:
+The easiest way to try out Vue.js is using the [Hello World example](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-hello-world). Feel free to open it in another tab and follow along as we go through some basic examples. Or, you can <a href="https://github.com/vuejs/vuejs.org/blob/master/src/v2/examples/vue-20-hello-world/index.html" target="_blank" download="index.html" rel="noopener noreferrer">create an <code>index.html</code> file</a> and include Vue with:
 
 ``` html
 <!-- development version, includes helpful console warnings -->

--- a/src/v2/guide/single-file-components.md
+++ b/src/v2/guide/single-file-components.md
@@ -21,7 +21,7 @@ All of these are solved by **single-file components** with a `.vue` extension, m
 
 Here's an example of a file we'll call `Hello.vue`:
 
-<a href="https://gist.github.com/chrisvfritz/e2b6a6110e0829d78fa4aedf7cf6b235" target="_blank" rel="noopener noreferrer"><img src="/images/vue-component.png" alt="Single-file component example (click for code as text)" style="display: block; margin: 30px auto;"></a>
+<a href="https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-single-file-components5" target="_blank" rel="noopener noreferrer"><img src="/images/vue-component.png" alt="Single-file component example (click for code as text)" style="display: block; margin: 30px auto;"></a>
 
 Now we get:
 

--- a/src/v2/guide/transitioning-state.md
+++ b/src/v2/guide/transitioning-state.md
@@ -366,7 +366,7 @@ function generatePoints (stats) {
 </style>
 {% endraw %}
 
-See [this fiddle](https://jsfiddle.net/chrisvfritz/65gLu2b6/) for the complete code behind the above demo.
+See [this example](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-dynamic-state-transitions) for the complete code behind the above demo.
 
 ## Organizing Transitions into Components
 

--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -1244,7 +1244,7 @@ new Vue({
 
 <p class="tip">One important note is that these FLIP transitions do not work with elements set to `display: inline`. As an alternative, you can use `display: inline-block` or place elements in a flex context.</p>
 
-These FLIP animations are also not limited to a single axis. Items in a multidimensional grid can be [transitioned too](https://jsfiddle.net/chrisvfritz/sLrhk1bc/):
+These FLIP animations are also not limited to a single axis. Items in a multidimensional grid can be [transitioned too](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-list-move-transitions):
 
 {% raw %}
 <div id="sudoku-demo" class="demo">

--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -1755,7 +1755,7 @@ computed: {
 
 **It's usually best to use `key` with `v-if` + `v-else`, if they are the same element type (e.g. both `<div>` elements).**
 
-By default, Vue updates the DOM as efficiently as possible. That means when switching between elements of the same type, it simply patches the existing element, rather than removing it and adding a new one in its place. This can have [unintended consequences](https://jsfiddle.net/chrisvfritz/bh8fLeds/) if these elements should not actually be considered the same.
+By default, Vue updates the DOM as efficiently as possible. That means when switching between elements of the same type, it simply patches the existing element, rather than removing it and adding a new one in its place. This can have [unintended consequences](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-priority-d-rules-unintended-consequences) if these elements should not actually be considered the same.
 
 {% raw %}<div class="style-example example-bad">{% endraw %}
 #### Bad


### PR DESCRIPTION
@NataliaTepluhina Per my DM, this PR begins to implement the idea of transitioning external code examples to the examples folder to reduce the bus-factor and improve maintainability. These then use CodeSandbox's 'Import from GitHub' feature to load the examples, so people can experiment with the code and running version of the app, while the underlying code for them is in a place anyone can access and edit.

One question about using the examples folder and https://vuejs.org/v2/examples/ - do you know if having folders inside the examples folder will cause issues with the menu of examples on the examples page?
