### PR TITLE
fix: document that Vue uses semver

### DIFF
--- a/src/v2/guide/installation.md
+++ b/src/v2/guide/installation.md
@@ -10,6 +10,10 @@ gz_size: "30.90"
 
 Vue does **not** support IE8 and below, because it uses ECMAScript 5 features that are un-shimmable in IE8. However it supports all [ECMAScript 5 compliant browsers](https://caniuse.com/#feat=es5).
 
+### Semantic Versioning
+
+Vue follows [Semantic Versioning](https://semver.org/) in all its official projects for documented features and behavior. For undocumented behavior or exposed internals, changes are described in [release notes](https://github.com/vuejs/vue/releases).
+
 ### Release Notes
 
 Latest stable version: {{vue_version}}


### PR DESCRIPTION
This PR adds a note on the fact that Vue uses semver.

fix #930