### PR TITLE
Update the chrome launch file for vscode debugging

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -59,7 +59,7 @@ Click on the Debugging icon in the Activity Bar to bring up the Debug view, then
       "webRoot": "${workspaceFolder}/src",
       "breakOnLoad": true,
       "sourceMapPathOverrides": {
-        "webpack:///./src/*": "${webRoot}/*"
+        "webpack:///src/*": "${webRoot}/*"
       }
     },
     {


### PR DESCRIPTION
Weren't able to set breakpoints to specific lines of Vue code. The issue was fixed by removing the "./" part of the "webpack" key; inside "sourceMapPathOverrides".