### PR TITLE
Update list.md

### DIFF
--- a/src/v2/guide/list.md
+++ b/src/v2/guide/list.md
@@ -294,11 +294,7 @@ You can also use the [`vm.$set`](https://vuejs.org/v2/api/#vm-set) instance meth
 vm.$set(vm.items, indexOfItem, newValue)
 ```
 
-To deal with caveat 2, you can use `splice`:
-
-``` js
-vm.items.splice(newLength)
-```
+To deal with caveat 2: TODO:
 
 ## Object Change Detection Caveats
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice the start parameter of splice function is resettled to array.length if it greater than it ...