### PR TITLE
Update state-management.md

### DIFF
--- a/src/v2/guide/state-management.md
+++ b/src/v2/guide/state-management.md
@@ -35,7 +35,7 @@ Now whenever `sourceOfTruth` is mutated, both `vmA` and `vmB` will update their 
 To help solve this problem, we can adopt a **store pattern**:
 
 ``` js
-var store = {
+const store = {
   debug: true,
   state: {
     message: 'Hello!'
@@ -56,14 +56,14 @@ Notice all actions that mutate the store's state are put inside the store itself
 In addition, each instance/component can still own and manage its own private state:
 
 ``` js
-var vmA = new Vue({
+const vmA = new Vue({
   data: {
     privateState: {},
     sharedState: store.state
   }
 })
 
-var vmB = new Vue({
+const vmB = new Vue({
   data: {
     privateState: {},
     sharedState: store.state


### PR DESCRIPTION
making the code examples consistently use `const` instead of switching to `var` as you scroll down on https://vuejs.org/v2/guide/state-management.html#Simple-State-Management-from-Scratch