### PR TITLE
Instructions for Vue devtools in chrome debugger

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -60,7 +60,8 @@ Click on the Debugging icon in the Activity Bar to bring up the Debug view, then
       "breakOnLoad": true,
       "sourceMapPathOverrides": {
         "webpack:///src/*": "${webRoot}/*"
-      }
+      },
+      "userDataDir": "${workspaceFolder}/.vscode/vscode-chrome-debug-userdatadir"
     },
     {
       "type": "firefox",
@@ -72,6 +73,11 @@ Click on the Debugging icon in the Activity Bar to bring up the Debug view, then
     }
   ]
 }
+```
+### Using the Vue.js devtools with VS Code
+One of the greatest capabilities of Vue is its extensive [devtools](https://chrome.google.com/webstore/detail/vuejs-devtools/nhdogjmejiglipccpnnnanhbledajbpd).  By default, Chrome debugger will create a new user profile for each debugging session and persists until your computer is rebooted.  While useful for testing your code in a clean environment, this also removes your extensions, including the Vue.js devtools if it's installed.  Setting `userDataDir` to `false` in the `"chrome"` section of your `launch.json` will stop this behavior but you lose the benefits of working in a clean environment.  Instead, if you wish to use the Vue.js devtools with the VS Code debugger, set the `userDataDir` property to a path in your `.vscode` directory.  This will create a user profile that persists indefinitely.  For example,
+```
+            "userDataDir": "${workspaceFolder}/.vscode/vscode-chrome-debug-userdatadir",
 ```
 
 ## Setting a Breakpoint


### PR DESCRIPTION
This was something I've been struggling with.  I could install devtools in my debugging session, but then I would have to reinstall it and reconfigure my settings every time I rebooted my computer.  [This](https://stackoverflow.com/questions/51725854/run-vscode-chrome-debugger-with-its-extensions) response has helped me