### PR TITLE
fix: fix note about `mounted`

### DIFF
--- a/src/v2/guide/migration.md
+++ b/src/v2/guide/migration.md
@@ -154,12 +154,15 @@ Use the new `beforeCreate` hook instead, which is essentially the same thing. It
 
 ### `ready` <sup>replaced</sup>
 
-Use the new `mounted` hook instead. It should be noted though that with `mounted`, there's no guarantee to be in-document. For that, also include `Vue.nextTick`/`vm.$nextTick`. For example:
+Use the new `mounted` hook instead.
+
+Note that `mounted` does not guarantee that all child components have also been mounted. If you want to wait until the entire view has been rendered, you can use `Vue.nextTick` or `vm.$nextTick` inside of `mounted`:
 
 ``` js
 mounted: function () {
   this.$nextTick(function () {
-    // code that assumes this.$el is in-document
+    // Code that will run only after the
+    // entire view has been rendered
   })
 }
 ```


### PR DESCRIPTION
The current migration guide explains that with the `mounted` lifecycle hook, there's no guarantee that the component is in-document (and the code snippet implies that there's only certainty that `this.$el` is in-document in the callback of `vm.$nextTick`.

This is incoherent with the [API reference of `mounted`](https://vuejs.org/v2/api/#mounted):

>Called after the instance has been mounted, where el is replaced by the newly created vm.$el. If the root instance is mounted to an in-document element, vm.$el will also be in-document when mounted is called.

So, `mounted` guarantees that the component itself is in-document, however, it doesn't guarantee that child components are (hence the usage of `vm.$nextTick`).

This PR uses the copy and code comment from the API reference in the migration guide, so they're both in sync.

fixes #1922