### PR TITLE
Vertically center current nav-link indication

### DIFF
--- a/themes/vue/source/css/_header.styl
+++ b/themes/vue/source/css/_header.styl
@@ -60,7 +60,7 @@ body.docs
           border-bottom: 3px solid transparent
           position: absolute
           top: 50%
-          margin-top: -4px
+          transform: translateY(-50%)
           left: 8px
       &.new::before
         red-dot-before(8px)


### PR DESCRIPTION
The link '.nav-link.current' indication arrow currently is a little bit out of place.
The indication arrow will now be vertically centered.