### PR TITLE
Move hyphen to correct place

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -377,7 +377,7 @@ var app7 = new Vue({
 </script>
 {% endraw %}
 
-This is a contrived example, but we have managed to separate our app into two smaller units, and the child is reasonably well-decoupled from the parent via the props interface. We can now further improve our `<todo-item>` component with more complex template and logic without affecting the parent app.
+This is a contrived example, but we have managed to separate our app into two smaller units, and the child is reasonably-well decoupled from the parent via the props interface. We can now further improve our `<todo-item>` component with more complex template and logic without affecting the parent app.
 
 In a large application, it is necessary to divide the whole app into components to make development manageable. We will talk a lot more about components [later in the guide](components.html), but here's an (imaginary) example of what an app's template might look like with components:
 


### PR DESCRIPTION
I think it was just a mistake that the hyphen was placed between well and decoupled instead of between reasonably and well.