### PR TITLE
Convert security@vuejs.org email link to mailto link

### DIFF
--- a/src/v2/guide/security.md
+++ b/src/v2/guide/security.md
@@ -6,7 +6,7 @@ order: 504
 
 ## Reporting Vulnerabilities
 
-When a vulnerability is reported, it immediately becomes our top concern, with a full-time contributor dropping everything to work on it. To report a vulnerability, please email [security@vuejs.org](security@vuejs.org).
+When a vulnerability is reported, it immediately becomes our top concern, with a full-time contributor dropping everything to work on it. To report a vulnerability, please email [security@vuejs.org](mailto:security@vuejs.org).
 
 While the discovery of new vulnerabilities is rare, we also recommend always using the latest versions of Vue and its official companion libraries to ensure your application remains as secure as possible.
 


### PR DESCRIPTION
Earlier the link pointed to
`https://vuejs.org/v2/guide/security@vuejs.org` which is not valid url.
Now it is a mailto link.