### PR TITLE
add corresponding scoped slot template comment to render function exa…

### DIFF
--- a/src/v2/guide/render-function.md
+++ b/src/v2/guide/render-function.md
@@ -441,6 +441,7 @@ To pass scoped slots to a child component using render functions, use the `scope
 
 ``` js
 render: function (createElement) {
+  // `<div><child v-slot="props"><span>{{ props.text }}</span></child></div>`
   return createElement('div', [
     createElement('child', {
       // pass `scopedSlots` in the data object


### PR DESCRIPTION
There're corresponeding template comments in other examples about slot in render function, but no in this example about scoped slot, so I added one, which I think can increase clarity.