### PR TITLE
Add tip about `done` callbacks in transition hooks

### DIFF
--- a/src/v2/guide/transitions.md
+++ b/src/v2/guide/transitions.md
@@ -442,6 +442,8 @@ These hooks can be used in combination with CSS transitions/animations or on the
 
 <p class="tip">When using JavaScript-only transitions, **the `done` callbacks are required for the `enter` and `leave` hooks**. Otherwise, the hooks will be called synchronously and the transition will finish immediately.</p>
 
+<p class="tip">When using CSS transitions, **the `enter` and `leave` functions should not accept the `done` parameter if they do not use it**. Including the `done` parameter in the function definition signals to Vue that you want to have control over the transition, so not calling it can cause unexpected behavior.</p>
+
 <p class="tip">It's also a good idea to explicitly add `v-bind:css="false"` for JavaScript-only transitions so that Vue can skip the CSS detection. This also prevents CSS rules from accidentally interfering with the transition.</p>
 
 Now let's dive into an example. Here's a JavaScript transition using Velocity.js:


### PR DESCRIPTION
It took me *hours* to figure out why my `onAfterEnter` function was not being called. It turns out that if your `onEnter` function *accepts* the `done` parameter but does not *use* the parameter then the `onAfterEnter` function never gets called.

JSFiddle to show the behaviour: https://jsfiddle.net/adamalton/7f0kca4m/54/

I considered making a bug report for it, but from looking at discussions on similar issues it seems that Vue's sniffing of the function parameters is intentional, so the behaviour is arguably deliberate. So instead I'm just adding a tip to the docs so that others after me don't need to go through the same pain 🙂.