### PR TITLE
Use consistent object key syntax

### DIFF
--- a/src/v2/guide/class-and-style.md
+++ b/src/v2/guide/class-and-style.md
@@ -54,7 +54,7 @@ The bound object doesn't have to be inline:
 data: {
   classObject: {
     active: true,
-    'text-danger': false
+    text-danger: false
   }
 }
 ```
@@ -73,7 +73,7 @@ computed: {
   classObject: function () {
     return {
       active: this.isActive && !this.error,
-      'text-danger': this.error && this.error.type === 'fatal'
+      text-danger: this.error && this.error.type === 'fatal'
     }
   }
 }


### PR DESCRIPTION
Forgive me if I'm missing something (I'm just learning Vue from this tutorial now) but it seems like there is an unnecessary inconsistency between the key syntax for the `active` and `text-danger` classes. Is there a reason why `text-danger` is rendered with single quotes while `active` is not? If so, it should be stated. But it seems to me like an inconsistency that could confuse a novice like myself, or at least make it slightly less reader friendly.