### PR TITLE
Wrong last name algorithm

### DIFF
--- a/src/v2/guide/computed.md
+++ b/src/v2/guide/computed.md
@@ -174,7 +174,7 @@ computed: {
     set: function (newValue) {
       var names = newValue.split(' ')
       this.firstName = names[0]
-      this.lastName = names[names.length - 1]
+      this.lastName = names[1]
     }
   }
 }


### PR DESCRIPTION
This is a classic error when trying to get the last name on a non-English language. E.g. in Latin America is common to have two last names.
It would be  better if the expression gets simplified to `this.lastName = names[1]` assuming just one first name and one last name