### PR TITLE
stop opening tabs when user selects a language

### DIFF
--- a/themes/vue/layout/partials/language_dropdown.ejs
+++ b/themes/vue/layout/partials/language_dropdown.ejs
@@ -1,14 +1,14 @@
 <li class="nav-dropdown-container language">
   <a class="nav-link">Translations</a><span class="arrow"></span>
   <ul class="nav-dropdown">
-    <li><a href="https://cn.vuejs.org/<%- page.path %>" class="nav-link" target="_blank" rel="noopener">中文</a></li>
-    <li><a href="https://jp.vuejs.org/<%- page.path %>" class="nav-link" target="_blank" rel="noopener">日本語</a></li>
-    <li><a href="https://ru.vuejs.org/<%- page.path %>" class="nav-link" target="_blank" rel="noopener">Русский</a></li>
-    <li><a href="https://kr.vuejs.org/<%- page.path %>" class="nav-link" target="_blank" rel="noopener">한국어</a></li>
-    <li><a href="https://br.vuejs.org/<%- page.path %>" class="nav-link" target="_blank" rel="noopener">Português</a></li>
-    <li><a href="https://fr.vuejs.org/<%- page.path %>" class="nav-link" target="_blank" rel="noopener">Français</a></li>
-    <li><a href="https://vi.vuejs.org/<%- page.path %>" class="nav-link" target="_blank" rel="noopener">Tiếng Việt</a></li>
-    <li><a href="https://es.vuejs.org/<%- page.path %>" class="nav-link" target="_blank" rel="noopener">Español</a></li>
-    <li><a href="https://docs.vuejs.id/<%- page.path %>" class="nav-link" target="_blank" rel="noopener">Bahasa Indonesia</a></li>
+    <li><a href="https://cn.vuejs.org/<%- page.path %>" class="nav-link">中文</a></li>
+    <li><a href="https://jp.vuejs.org/<%- page.path %>" class="nav-link">日本語</a></li>
+    <li><a href="https://ru.vuejs.org/<%- page.path %>" class="nav-link">Русский</a></li>
+    <li><a href="https://kr.vuejs.org/<%- page.path %>" class="nav-link">한국어</a></li>
+    <li><a href="https://br.vuejs.org/<%- page.path %>" class="nav-link">Português</a></li>
+    <li><a href="https://fr.vuejs.org/<%- page.path %>" class="nav-link">Français</a></li>
+    <li><a href="https://vi.vuejs.org/<%- page.path %>" class="nav-link">Tiếng Việt</a></li>
+    <li><a href="https://es.vuejs.org/<%- page.path %>" class="nav-link">Español</a></li>
+    <li><a href="https://docs.vuejs.id/<%- page.path %>" class="nav-link">Bahasa Indonesia</a></li>
   </ul>
 </li>


### PR DESCRIPTION
As a user, when I change the language of the website, I don't expect to get another tab to be opened, and consequently be forced to close the original tab, loosing its history.

Example on MDN:
- go there: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types
- pick your preferred language
- _(you stay on the same tab and)_ just read your content in your preferred language!

Example on Vuejs.org:
- go there: https://vuejs.org/v2/guide/mixins.html
- pick your preferred language
- another tab is opened
- you decide to keep yet another tab or close the original tab (loosing its history)
- then read your content in your preferred language!

This user experience seems quite annoying in my opinion, hence this proposal. But anyone please feel free to elaborate if I'm wrong about that! 🤓