### PR TITLE
For emitting custom events show what does work.

### DIFF
--- a/src/v2/guide/components-custom-events.md
+++ b/src/v2/guide/components-custom-events.md
@@ -16,7 +16,7 @@ Unlike components and props, event names don't provide any automatic case transf
 this.$emit('myEvent')
 ```
 
-Listening to the kebab-cased version will have no effect:
+Listening to the kebab-cased version **will have no effect**:
 
 ```html
 <!-- Won't work -->
@@ -26,6 +26,17 @@ Listening to the kebab-cased version will have no effect:
 Unlike components and props, event names will never be used as variable or property names in JavaScript, so there's no reason to use camelCase or PascalCase. Additionally, `v-on` event listeners inside DOM templates will be automatically transformed to lowercase (due to HTML's case-insensitivity), so `v-on:myEvent` would become `v-on:myevent` -- making `myEvent` impossible to listen to.
 
 For these reasons, we recommend you **always use kebab-case for event names**.
+
+```js
+this.$emit('my-event')
+```
+
+Listening to the kebab-cased version **will have no effect**:
+
+```html
+<!-- Works! -->
+<my-component v-on:my-event="doSomething"></my-component>
+```
 
 ## Customizing Component `v-model`
 


### PR DESCRIPTION
When quickly going through the docs, it's confusing that it shows what doesn't work. I propose we at least add what does work.

We may even consider changing it further, so that the code blocks are just what does work and the text explanation tells more details about what doesn't work.