### PR TITLE
fix: Pine/@octref's location and role

### DIFF
--- a/src/v2/guide/team.md
+++ b/src/v2/guide/team.md
@@ -340,12 +340,12 @@ order: 803
     },
     {
       name: 'Pine Wu',
+      city: 'Shanghai, China',
       languages: ['zh', 'en', 'jp'],
       github: 'octref',
       twitter: 'octref',
       work: {
-        role: 'Engineer on VSCode',
-        org: 'Microsoft'
+        role: 'Nomad'
       },
       reposOfficial: [
         'vetur'


### PR DESCRIPTION
Left Microsoft, will travel nomadically, currently in Shanghai.