### PR TITLE
Name Casing modify

### DIFF
--- a/src/v2/guide/components-registration.md
+++ b/src/v2/guide/components-registration.md
@@ -40,7 +40,7 @@ When defining a component with kebab-case, you must also use kebab-case when ref
 Vue.component('MyComponentName', { /* ... */ })
 ```
 
-When defining a component with PascalCase, you can use either case when referencing its custom element. That means both `<my-component-name>` and `<MyComponentName>` are acceptable. Note, however, that only kebab-case names are valid directly in the DOM (i.e. non-string templates).
+When defining a component with PascalCase, you can use either case when referencing its custom element. That means both `'MyComponentName'` and `'MyComponentName'` are acceptable. Note, however, that only kebab-case names are valid directly in the DOM (i.e. non-string templates).
 
 ## Global Registration
 


### PR DESCRIPTION
The manual of Name Casing “With PascalCase” section, mention about:
" both <MyComponentName> and <MyComponentName> are acceptable ".
but <MyComponentName> and <MyComponentName> could be misunderstand to DOM template ,
I modify it to 'MyComponentName' and 'MyComponentName',
may be much proper.

Note
====
We're currently in the process of migrating Vue's documentation to v3. To ensure smooth progress, only PR's that fix critical bugs and/or misinformation will be accepted. If yours is not one of them, consider [creating an issue](https://github.com/vuejs/vuejs.org/issues/new) instead and we will label it as `post-3.0` for later tackling.
