### PR TITLE
fix: Add "boolean" and "symbol" types for "key" attribute.

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -2379,7 +2379,7 @@ type: api
 
 ### key
 
-- **Expects:** `number | string`
+- **Expects:** `number | string | boolean (since 2.4.2) | symbol (since 2.5.12)`
 
   The `key` special attribute is primarily used as a hint for Vue's virtual DOM algorithm to identify VNodes when diffing the new list of nodes against the old list. Without keys, Vue uses an algorithm that minimizes element movement and tries to patch/reuse elements of the same type in-place as much as possible. With keys, it will reorder elements based on the order change of keys, and elements with keys that are no longer present will always be removed/destroyed.
 


### PR DESCRIPTION
Booleans as keys are supported since [v2.4.2](https://github.com/vuejs/vue/releases/tag/v2.4.2)([commit](https://github.com/vuejs/vue/commit/be3dc9c6e923248bcf81eb8240dd4f3c168fac59)) and symbols since [v2.5.12](https://github.com/vuejs/vue/releases/tag/v2.5.12)([commit](https://github.com/vuejs/vue/commit/bacb911f7df09ff4868b4c848a6d7778872dff5c)).

I created PR as suggested [here](https://github.com/vuejs/vue/issues/7936#issuecomment-636984051). I think it now makes clear that this types are supported and not just "happens to work by accident". 

I noticed that [v-for](https://vuejs.org/v2/api/#v-for) has "since _version_" in type so I did the same.