### PR TITLE
Add comment to components code example

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -293,6 +293,8 @@ Vue.component('todo-item', {
   template: '<li>This is a todo</li>'
 })
 
+// The component must be registered before creating a Vue instance,
+// otherwise the instance will not have access to it.
 var app = new Vue(...)
 ```
 


### PR DESCRIPTION
In the code example for registering a new component I've added a comment that the registration must take place prior to creating the root Vue instance. This is mentioned later in the Component Registration section but as a new user I spent a lot of time trying to figure out why my component wasn't rendering when trying to build a a small web app with the information I had learned from the introduction/essentials sections because I didn't realize order was important. In hindsight it makes sense why that is necessary but I still think it may be useful to point this out.

Note
====
We're currently in the process of migrating Vue's documentation to v3. To ensure smooth progress, only PR's that fix critical bugs and/or misinformation will be accepted. If yours is not one of them, consider [creating an issue](https://github.com/vuejs/vuejs.org/issues/new) instead and we will label it as `post-3.0` for later tackling.
