### PR TITLE
add option for next in guide

### DIFF
--- a/themes/vue/layout/partials/sidebar.ejs
+++ b/themes/vue/layout/partials/sidebar.ejs
@@ -21,6 +21,7 @@
           <%- titles[type] %>
           <% if (['cookbook', 'style-guide'].indexOf(type) === -1) { %>
             <select class="version-select">
+              <option value="v3">next</option>
               <option value="SELF" selected>2.x</option>
               <option value="v1">1.0</option>
               <option value="012">0.12</option>

--- a/themes/vue/layout/partials/sidebar.ejs
+++ b/themes/vue/layout/partials/sidebar.ejs
@@ -21,7 +21,7 @@
           <%- titles[type] %>
           <% if (['cookbook', 'style-guide'].indexOf(type) === -1) { %>
             <select class="version-select">
-              <option value="v3">next</option>
+              <option value="v3">3.x-beta</option>
               <option value="SELF" selected>2.x</option>
               <option value="v1">1.0</option>
               <option value="012">0.12</option>


### PR DESCRIPTION
I added the option in the version select to go to the [v3](https://v3.vuejs.org)

### PR on docs-next
It seems that the v3 documentation does not follow the same sequence as for the `introduction.md' file, in all versions of vuejs it is as index.md, but in version 3 it was renamed to introduction.md.
PR on docs-next [#237](https://github.com/vuejs/docs-next/pull/237)