### PR TITLE
Add caveats section to computed.md 

### DIFF
--- a/src/v2/guide/computed.md
+++ b/src/v2/guide/computed.md
@@ -183,6 +183,32 @@ computed: {
 
 Now when you run `vm.fullName = 'John Doe'`, the setter will be invoked and `vm.firstName` and `vm.lastName` will be updated accordingly.
 
+#### Caveats
+When it comes to reactive properties (the data option), Vue wraps some array functions to detect array mutations and invoke dependencies. That is not the case with computed properties, which are not following the same reactivity path. When a computed property returns an array, the setter will only be invoked when assigning a new array reference. Mutation won't work here.
+
+For example:
+
+``` js
+// ...
+computed: {
+  groceriesList: {
+    // getter
+    get: function () {
+      return this.groceries.map(item => item.toLocaleUpperCase());
+    },
+    // setter
+    set: function (newValue) {
+      this.groceries = newValue;
+    }
+  }
+}
+// ...
+```
+
+If you would run `vm.groceriesList.splice(0, 0, 'apples')`, the setter won't be invoked
+
+But when you run `vm.groceriesList = ['apples', ...this.groceriesList]`, the setter will be invoked, and the `vm.groceries` collection will be updated accordingly.
+
 ## Watchers
 
 While computed properties are more appropriate in most cases, there are times when a custom watcher is necessary. That's why Vue provides a more generic way to react to data changes through the `watch` option. This is most useful when you want to perform asynchronous or expensive operations in response to changing data.


### PR DESCRIPTION
Add a description about computed setter caveats when it comes to array mutations, and how it differs from reactive properties.

Note
====
We're currently in the process of migrating Vue's documentation to v3. To ensure smooth progress, only PR's that fix critical bugs and/or misinformation will be accepted. If yours is not one of them, consider [creating an issue](https://github.com/vuejs/vuejs.org/issues/new) instead and we will label it as `post-3.0` for later tackling.
