### PR TITLE
Update syntax.md

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -139,18 +139,18 @@ Starting in version 2.6.0, it is also possible to use a JavaScript expression in
 Note that there are some constraints to the argument expression, as explained
 in the "Dynamic Argument Expression Constraints" section below.
 -->
-<a v-bind:[attributeName]="url"> ... </a>
+<a v-bind:[attribute_name]="url"> ... </a>
 ```
 
-Here `attributeName` will be dynamically evaluated as a JavaScript expression, and its evaluated value will be used as the final value for the argument. For example, if your Vue instance has a data property, `attributeName`, whose value is `"href"`, then this binding will be equivalent to `v-bind:href`.
+Here `attribute_name` will be dynamically evaluated as a JavaScript expression, and its evaluated value will be used as the final value for the argument. For example, if your Vue instance has a data property, `attribute_name`, whose value is `"href"`, then this binding will be equivalent to `v-bind:href`.
 
 Similarly, you can use dynamic arguments to bind a handler to a dynamic event name:
 
 ``` html
-<a v-on:[eventName]="doSomething"> ... </a>
+<a v-on:[event_name]="doSomething"> ... </a>
 ```
 
-In this example, when `eventName`'s value is `"focus"`, `v-on:[eventName]` will be equivalent to `v-on:focus`.
+In this example, when `event_name`'s value is `"focus"`, `v-on:[event_name]` will be equivalent to `v-on:focus`.
 
 #### Dynamic Argument Value Constraints
 


### PR DESCRIPTION
Giving examples using camelcase for dynamic attribute names is confusing to beginners, as this won't work when they try to use it in an HTML template. Having the explanation at the end of that section (line 170) is good, but the examples given should lead learners in the right direction whenever possible.

If people have strong feelings against snake case, then no special casing could be used instead, ie. attributename.

Note
====
We're currently in the process of migrating Vue's documentation to v3. To ensure smooth progress, only PR's that fix critical bugs and/or misinformation will be accepted. If yours is not one of them, consider [creating an issue](https://github.com/vuejs/vuejs.org/issues/new) instead and we will label it as `post-3.0` for later tackling.
