### PR TITLE
fix: avoid page scroll when switching tabs

### DIFF
--- a/src/v2/guide/components-dynamic-async.md
+++ b/src/v2/guide/components-dynamic-async.md
@@ -24,10 +24,12 @@ When switching between these components though, you'll sometimes want to maintai
     v-bind:class="['dynamic-component-demo-tab-button', { 'dynamic-component-demo-active': currentTab === tab }]"
     v-on:click="currentTab = tab"
   >{{ tab }}</button>
-  <component
-    v-bind:is="currentTabComponent"
-    class="dynamic-component-demo-tab"
-  ></component>
+  <div>
+    <component
+      v-bind:is="currentTabComponent"
+      class="dynamic-component-demo-tab"
+    ></component>
+  </div>
 </div>
 <script>
 Vue.component('tab-posts', {
@@ -170,12 +172,14 @@ Check out the result below:
     v-bind:class="['dynamic-component-demo-tab-button', { 'dynamic-component-demo-active': currentTab === tab }]"
     v-on:click="currentTab = tab"
   >{{ tab }}</button>
-  <keep-alive>
-    <component
-      v-bind:is="currentTabComponent"
-      class="dynamic-component-demo-tab"
-    ></component>
-  </keep-alive>
+  <div>
+    <keep-alive>
+      <component
+        v-bind:is="currentTabComponent"
+        class="dynamic-component-demo-tab"
+      ></component>
+    </keep-alive>
+  </div>
 </div>
 <script>
 new Vue({

--- a/src/v2/guide/components.md
+++ b/src/v2/guide/components.md
@@ -543,10 +543,12 @@ Sometimes, it's useful to dynamically switch between components, like in a tabbe
   >
     {{ tab }}
   </button>
-  <component
-    v-bind:is="currentTabComponent"
-    class="dynamic-component-demo-tab"
-  ></component>
+  <div>
+    <component
+      v-bind:is="currentTabComponent"
+      class="dynamic-component-demo-tab"
+    ></component>
+  </div>
 </div>
 <script>
 Vue.component('tab-home', { template: '<div>Home component</div>' })


### PR DESCRIPTION
Not entirely sure on the root cause for this behavior reported in #2668 but I guess that is somehow related to the fact that when changing tabs we are removing then adding an entire new div to the DOM instead of manipulating the contents of an existing one. It seems like it needs to be wrapped in a div (or some other tag?).

Updated behavior
![tab_vue](https://user-images.githubusercontent.com/6568078/90989913-6e22de00-e573-11ea-9077-60458fc3c6b4.gif)

PS.: this can still be used/revisited post v3 so opening a PR.