### PR TITLE
Update index.md

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -330,7 +330,7 @@ Now we can pass the todo into each repeated component using `v-bind`:
     -->
     <todo-item
       v-for="item in groceryList"
-      v-bind:todo="item"
+      v-bind:todo="item.text"
       v-bind:key="item.id"
     ></todo-item>
   </ol>


### PR DESCRIPTION
minor fix:. in line 333. should be v-bind:todo="item.text" and not v-bind:todo="item"

Note
====
We're currently in the process of migrating Vue's documentation to v3. To ensure smooth progress, only PR's that fix critical bugs and/or misinformation will be accepted. If yours is not one of them, consider [creating an issue](https://github.com/vuejs/vuejs.org/issues/new) instead and we will label it as `post-3.0` for later tackling.
