### PR TITLE
Update class-and-style.md

### DIFF
--- a/src/v2/guide/class-and-style.md
+++ b/src/v2/guide/class-and-style.md
@@ -102,7 +102,7 @@ Which will render:
 If you would like to also toggle a class in the list conditionally, you can do it with a ternary expression:
 
 ``` html
-<div v-bind:class="[isActive ? activeClass : '', errorClass]"></div>
+<div v-bind:class="[isActive ? 'activeClass' : '', 'errorClass']"></div>
 ```
 
 This will always apply `errorClass`, but will only apply `activeClass` when `isActive` is truthy.


### PR DESCRIPTION
before
<div v-bind:class="[isActive ? activeClass: '', errorClass]"></div>
after
<div v-bind:class="[isActive ? 'activeClass' : '', 'errorClass']"></div>

activeClass  is not getting without single inverter coma.

Note
====
We're currently in the process of migrating Vue's documentation to v3. To ensure smooth progress, only PR's that fix critical bugs and/or misinformation will be accepted. If yours is not one of them, consider [creating an issue](https://github.com/vuejs/vuejs.org/issues/new) instead and we will label it as `post-3.0` for later tackling.
