### PR TITLE
fix(#2668): reset unexpected behavior introduced by overflow-anchor

### DIFF
--- a/src/v2/guide/components-dynamic-async.md
+++ b/src/v2/guide/components-dynamic-async.md
@@ -106,6 +106,7 @@ new Vue({
   background: #f0f0f0;
   margin-bottom: -1px;
   margin-right: -1px;
+  overflow-anchor: none;
 }
 .dynamic-component-demo-tab-button:hover {
   background: #e0e0e0;


### PR DESCRIPTION
The problem is caused by the `overflow-anchor` property, which was supported by Chrome a while ago.

Closes both #2668 and #2675.