### PR TITLE
Fix sourcemap overrides for Chrome debugging (fixes #2235, fixes #2617)

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -59,7 +59,8 @@ Click on the Debugging icon in the Activity Bar to bring up the Debug view, then
       "webRoot": "${workspaceFolder}/src",
       "breakOnLoad": true,
       "sourceMapPathOverrides": {
-        "webpack:///src/*": "${webRoot}/*"
+        "webpack:///src/*": "${webRoot}/*",
+        "webpack:///./src/*": "${webRoot}/*"
       }
     },
     {


### PR DESCRIPTION
With the previously documented launch config for chrome only breakpoints within Vue components did work.
The additional rules allows to set breakpoints in other files like router.js or vuex stores.

I validated this updated settings with multiple projects, a hello-world and also a bigger TypeScript based.

I did not check the firefox configuration.