### PR TITLE
docs: fix typos and correct grammar ("it's" -> "its")

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -752,7 +752,7 @@ type: api
 
   - **Details:**
 
-    An alternative to string templates allowing you to leverage the full programmatic power of JavaScript. The render function receives a `createElement` method as it's first argument used to create `VNode`s.
+    An alternative to string templates allowing you to leverage the full programmatic power of JavaScript. The render function receives a `createElement` method as its first argument used to create `VNode`s.
 
     If the component is a functional component, the render function also receives an extra argument `context`, which provides access to contextual data since functional components are instance-less.
 

--- a/themes/vue/layout/page.ejs
+++ b/themes/vue/layout/page.ejs
@@ -9,7 +9,7 @@
 <% } %>
 <div class="content <%- page.type ? page.type + ' with-sidebar' : '' %> <%- page.type === 'guide' ? page.path.replace(/.+\//, '').replace('.html', '') + '-guide' : '' %>">
   <p class="tip warning v3-warning">
-    You’re browsing the documentation for v2.x and ealier.
+    You’re browsing the documentation for v2.x and earlier.
     For v3.x, <a href="https://v3.vuejs.org/">click here</a>.
   </p>
 

--- a/themes/vue/layout/partials/header.ejs
+++ b/themes/vue/layout/partials/header.ejs
@@ -1,6 +1,6 @@
 <div>
   <div id="v3-banner">
-    <span class="hidden-sm">You’re browsing the documentation for v2.x and ealier.</span>
+    <span class="hidden-sm">You’re browsing the documentation for v2.x and earlier.</span>
     <a href="https://v3.vuejs.org/">Click here</a> for v3.x documentation.
   </div>
 


### PR DESCRIPTION
It's = it is
Its = belonging to it

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
