### PR TITLE
Fix typo in v3 warning header.

### DIFF
--- a/themes/vue/layout/page.ejs
+++ b/themes/vue/layout/page.ejs
@@ -9,7 +9,7 @@
 <% } %>
 <div class="content <%- page.type ? page.type + ' with-sidebar' : '' %> <%- page.type === 'guide' ? page.path.replace(/.+\//, '').replace('.html', '') + '-guide' : '' %>">
   <p class="tip warning v3-warning">
-    You’re browsing the documentation for v2.x and ealier.
+    You’re browsing the documentation for v2.x and earlier.
     For v3.x, <a href="https://v3.vuejs.org/">click here</a>.
   </p>
 


### PR DESCRIPTION
Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
