### PR TITLE
Add VueToronto banner

### DIFF
--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -90,10 +90,14 @@
     <script type="text/javascript" defer="defer" src="https://extend.vimeocdn.com/ga/72160148.js"></script>
   </head>
   <body class="<%- isIndex ? '' : 'docs' -%>">
+    <% if (!isIndex) { %>
+      <%- partial('partials/vuetoronto_banner') %>
+    <% } %>
     <div id="mobile-bar" <%- isIndex ? 'class="top"' : '' %>>
       <a class="menu-button"></a>
       <a class="logo" href="/"></a>
     </div>
+    
     <%- partial('partials/header') %>
     <% if (!isIndex) { %>
       <div id="main" class="fix-sidebar">

--- a/themes/vue/layout/page.ejs
+++ b/themes/vue/layout/page.ejs
@@ -9,7 +9,7 @@
 <% } %>
 <div class="content <%- page.type ? page.type + ' with-sidebar' : '' %> <%- page.type === 'guide' ? page.path.replace(/.+\//, '').replace('.html', '') + '-guide' : '' %>">
   <p class="tip warning v3-warning">
-    You’re browsing the documentation for v2.x and ealier.
+    You’re browsing the documentation for v2.x and earlier.
     For v3.x, <a href="https://v3.vuejs.org/">click here</a>.
   </p>
 

--- a/themes/vue/layout/partials/header.ejs
+++ b/themes/vue/layout/partials/header.ejs
@@ -1,6 +1,6 @@
 <div>
   <div id="v3-banner">
-    <span class="hidden-sm">You’re browsing the documentation for v2.x and ealier.</span>
+    <span class="hidden-sm">You’re browsing the documentation for v2.x and earlier.</span>
     <a href="https://v3.vuejs.org/">Click here</a> for v3.x documentation.
   </div>
 

--- a/themes/vue/layout/partials/vuetoronto_banner.ejs
+++ b/themes/vue/layout/partials/vuetoronto_banner.ejs
@@ -1,0 +1,89 @@
+<div id="vs-banner" class="vueto-banner hide" role="banner">
+  <a href="https://vuetoronto.com/tickets" title="VueConf Toronto - Vue.js Conference" target="_blank">
+    <div class="vueto-banner--wrapper">
+      <p>Join 10k+ devs on the largest Vue.js conference! - November 5-6</p>
+      <button>Register for free</button>
+    </div>
+    <div id="vs-close" class="vueto-banner--close"></div>
+  </a>
+</div>
+
+<script>
+(function () {
+    // Get elements
+    var elBody = document.getElementsByTagName("body")[0];
+    var elBanner = document.getElementById("vs-banner");
+    var elClose = document.getElementById("vs-close");
+    var elMenu = document.getElementById("mobile-bar");
+    // Variable names
+    var nameWrapper = "vueto-weekend-promo";
+    var nameFixMenu = "vueto-menu-fixed";
+    var nameStorage = "vueto-banner";
+    // Defaults values
+    var isMenuFixed = false;
+    var posMenu = 80;
+    var initBanner = function () {
+    // Add event listeners
+    toggleBannerEvents(true);
+    // Add class to the body to push fixed elements
+    elBody.classList.add(nameWrapper);
+    // Display the banner
+    elBanner.style.display = "block";
+    // Init close button action
+    elClose.onclick = closeBanner;
+    // Get the menu position
+    getMenuPosition();
+    // Check current page offset position
+    isMenuFixed = isUnderBanner();
+    // And position menu accordingly
+    if (isMenuFixed) {
+        elBody.classList.add("fixed");
+    }
+    }
+    var closeBanner = function(e) {
+    // Prevent bubbling event that redirect to vueto.io
+    e.preventDefault();
+    // Remove events
+    toggleBannerEvents(false);
+    // Hide the banner
+    elBanner.style.display = "none";
+    // Remove class to the body that push fixed elements
+    elBody.classList.remove(nameWrapper);
+    // Save action in the local storage
+    localStorage.setItem(nameStorage, true);
+    }
+    var getMenuPosition = function() {
+    posMenu = elBanner.clientHeight;
+    }
+    var isUnderBanner = function() {
+    return window.pageYOffset > posMenu;
+    }
+    var fixMenuAfterBanner = function() {
+    if (isUnderBanner()) {
+        if (!isMenuFixed) {
+        // The menu will be fixed
+        toggleFixedPosition(true);
+        }
+    } else if (isMenuFixed) {
+        // The menu stay under the banner
+        toggleFixedPosition(false);
+    }
+    }
+    var toggleBannerEvents = function (on) {
+    // Add or remove event listerners attached to the DOM
+    var method = on ? "addEventListener" : "removeEventListener";
+    window[method]("resize", getMenuPosition);
+    window[method]("scroll", fixMenuAfterBanner);
+    }
+    var toggleFixedPosition = function (on) {
+    // Switch between relative and fixed position
+    var method = on ? "add" : "remove";
+    elBody.classList[method](nameFixMenu);
+    isMenuFixed = on;
+    }
+    // Load component according to user preferences
+    if (!localStorage.getItem(nameStorage)) {
+    initBanner();
+    }
+})()
+</script>

--- a/themes/vue/source/css/_vueto.styl
+++ b/themes/vue/source/css/_vueto.styl
@@ -1,0 +1,205 @@
+.vueto-weekend-promo.docs
+  .vueto-banner
+    z-index 100
+
+.vueto-banner
+  display none
+  position relative
+  background -webkit-gradient(linear,right top,left top,from(#96c93d),to(#00b09b))
+  background linear-gradient(270deg,#96c93d,#00b09b)
+  padding 2px
+
+  &:hover
+    &:before
+      transition width .15s ease-in
+      width 50%
+    p
+      transition-delay 0
+
+
+  a
+    display flex
+    height 40px
+    width 100%
+    justify-content center
+
+  .hidden
+    display none
+
+.vueto-banner--wrapper
+  color white
+  display flex
+  height 100%
+  align-items center
+  position relative
+
+
+
+  &:hover
+    + .vueto-banner--close
+      &:before,
+      &:after
+        transform-origin 100%
+        background #fff
+
+  p
+    margin 0 30px 0 0px
+    font-size 1rem
+    position relative
+    transition-delay .15s
+    font-weight 600
+
+  span
+    font-size 1rem
+    display block
+    color #fff
+
+  button
+    cursor pointer
+    font-weight 600
+    padding 5px 18px
+    border-radius 32px
+    background white
+    border 1px solid white
+    color #00b09b
+    font-size .9rem
+    transition .3s all
+
+    &:hover
+      color white
+      background-image -webkit-gradient(linear,right top,left top,from(#96c93d),to(#00b09b))
+      background-image linear-gradient(270deg,#96c93d,#00b09b)
+      transform translateX(10px)
+
+
+.vueto-banner--logo
+  position relative
+  z-index 2
+
+.vueto-banner--close
+  position absolute
+  top 2px
+  right 25px
+  height 40px
+  width 40px
+  -webkit-tap-highlight-color transparent
+  border-radius 50%
+  cursor pointer
+
+  &:before,
+  &:after
+    content ''
+    position absolute
+    top 19px
+    left 14px
+    width 10px
+    height 2px
+    background-color #fff
+    transform-origin 50%
+    transform rotate(-45deg)
+    transition all .2s ease-out
+
+  &:after
+    transform rotate(45deg)
+
+.vueto-weekend-promo
+  #mobile-bar,
+  #mobile-bar.top
+    position relative
+    background-color #fff
+
+  &.docs:not(.vueto-menu-fixed)
+    padding-top 0
+    #header
+      position relative
+      width auto
+    #nav
+      position absolute
+
+  &.vueto-menu-fixed
+    #mobile-bar
+      position fixed
+
+@media screen and (min-width: 901px)
+  .vueto-weekend-promo.docs:not(.vueto-menu-fixed)
+    #main.fix-sidebar .sidebar .sidebar-inner
+      padding-top 110px
+
+    #sidebar-sponsors-platinum-right
+      position absolute
+      top: 170px
+
+@media screen and (min-width: 415px) and (max-width: 900px)
+  .vueto-weekend-promo.docs:not(.vueto-menu-fixed)
+    #main.fix-sidebar .sidebar .sidebar-inner
+      padding-top 140px
+
+    #sidebar-sponsors-platinum-right
+      position absolute
+      top: 170px
+
+  &.vueto-menu-fixed.docs
+    .vueto-banner
+      margin-bottom 0
+
+  .vueto-banner
+    button
+      display none
+
+@media screen and (max-width: 414px)
+  // Docs menu
+  .vueto-weekend-promo.docs:not(.vueto-menu-fixed)
+    #main.fix-sidebar .sidebar .sidebar-inner
+      padding-top 100px
+
+  .vueto-banner
+    .vueto-banner--logo
+      margin-left 0
+
+  .vueto-weekend-promo
+    &.vueto-menu-fixed
+      .vueto-banner
+        margin-bottom 40px
+
+
+@media screen and (max-width: 700px)
+  .vueto-banner
+    a
+      height 40px
+      overflow hidden
+
+    .vueto-banner--logo
+      margin-left 0
+      justify-content flex-start
+
+    p, span
+      font-size .8rem
+
+    .vueto-banner--close
+      top 0px
+      right 0px
+
+      &:before,
+      &:after
+        top 23px
+        left 14px
+        width 10px
+        height 2px
+
+@media screen and (max-width: 425px)
+  .vueto-banner
+    p
+      max-width 100%
+    span
+      display none
+    button
+      display none
+
+@media screen and (max-width 286px)
+  .vueto-banner p
+    font-size 0.6rem
+    margin -3px 28px 0 0px
+
+@media print
+  .vueto-banner
+    display none

--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -14,6 +14,7 @@
 @import "_style-guide"
 @import "_modal"
 @import "_scrimba"
+@import "_vueto"
 @import "_vue-mastery"
 @import "_themes"
 


### PR DESCRIPTION
This PR is to add a VueConf Toronto banner on the vue.js website and allowing them to register for the conference for free. 

This banner is collapsable and uses localStorage to preserve user action and state.

This banner is added to all 'pages' other than the index page to preserve the existing v2 warning banner.