### PR TITLE
Update components-props.md

### DIFF
--- a/src/v2/guide/components-props.md
+++ b/src/v2/guide/components-props.md
@@ -347,6 +347,7 @@ This pattern allows you to use base components more like raw HTML elements, with
 
 ```html
 <base-input
+  label="Username:"
   v-model="username"
   required
   placeholder="Enter your username"


### PR DESCRIPTION
Looks like from the example the label is a `prop`. The original example definitely works, but just for completeness I think label would make the example for cohesive.