### PR TITLE
Dockerfile line for fix 404

### DIFF
--- a/src/v2/cookbook/dockerize-vuejs-app.md
+++ b/src/v2/cookbook/dockerize-vuejs-app.md
@@ -72,7 +72,8 @@ RUN npm run build
 
 # production stage
 FROM nginx:stable-alpine as production-stage
-COPY --from=build-stage /app/dist /usr/share/nginx/html
+# Optional line for 404 correction when reloading a page with router history mode
+RUN sed -i '9 a \try_files \$uri \/index.html'  /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 ```
@@ -81,6 +82,7 @@ Ok, let's see what's going on here:
 * we have split our original `Dockerfile` in multiple stages by leveraging the Docker [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) feature;
 * the first stage is responsible for building a production-ready artifact of our Vue.js app;
 * the second stage is responsible for serving such artifact using NGINX.
+  *  the optional line enables NGINX to redirect all traffic to the single index.html file, solving 404 problems for direct access or page updates.
 
 Now let's build the Docker image of our Vue.js app:
 


### PR DESCRIPTION
A simple line that solves the errors of direct access to a page when the build is done using the example of container with NGINX.

For those who use history mode on the vuejs router, it is necessary to control the redirection to index.html by the server and this line solves the problem.

Without this configuration, users who access a route from the vujs router directly receive a 404 error as it is handled by NGINX and it does not know the path.