### PR TITLE
Fix broken link to repo explaining Instance names

### DIFF
--- a/src/v2/cookbook/adding-instance-properties.md
+++ b/src/v2/cookbook/adding-instance-properties.md
@@ -58,7 +58,7 @@ new Vue({
 })
 ```
 
-It would be `"My App"`, then `"The name of some other app"`, because `this.appName` is overwritten ([sort of](https://github.com/getify/You-Dont-Know-JS/blob/2nd-ed/objects-classes/ch5.md)) by `data` when the instance is created. We scope instance properties with `$` to avoid this. You can even use your own convention if you'd like, such as `$_appName` or `ΩappName`, to prevent even conflicts with plugins or future features.
+It would be `"My App"`, then `"The name of some other app"`, because `this.appName` is overwritten ([sort of](https://github.com/getify/You-Dont-Know-JS/blob/1st-ed/this%20%26%20object%20prototypes/ch5.md)) by `data` when the instance is created. We scope instance properties with `$` to avoid this. You can even use your own convention if you'd like, such as `$_appName` or `ΩappName`, to prevent even conflicts with plugins or future features.
 
 ## Real-World Example: Replacing Vue Resource with Axios
 


### PR DESCRIPTION
There is a link that is supposed to provide more detail on how data can be "overwritten" in an Instance when you do not use a $ in front of the name. The repo that the link points to has been updated and the path is no longer valid. I replaced it with what I think should be the new path.

Note: the repo link is in reference to a You-Dont-Know-JS (book series). The change in file path in that repo came because they are working on a 2nd edition. The 2nd edition is not released and does not have any info on Instance names. I referenced the archived 1st edition. It is possible that by the time this PR is processed, the 2nd edition will be released and the link may need to be changed to a file path in the 2nd edition. 
