### PR TITLE
Add v3 guide URL instead of main page URL

### DIFF
--- a/themes/vue/layout/page.ejs
+++ b/themes/vue/layout/page.ejs
@@ -10,7 +10,7 @@
 <div class="content <%- page.type ? page.type + ' with-sidebar' : '' %> <%- page.type === 'guide' ? page.path.replace(/.+\//, '').replace('.html', '') + '-guide' : '' %>">
   <p class="tip warning v3-warning">
     You’re browsing the documentation for v2.x and earlier.
-    For v3.x, <a href="https://v3.vuejs.org/">click here</a>.
+    For v3.x, <a href="https://v3.vuejs.org/guide/">click here</a>.
   </p>
 
   <% if (page.type) { %>

--- a/themes/vue/layout/partials/header.ejs
+++ b/themes/vue/layout/partials/header.ejs
@@ -1,7 +1,7 @@
 <div>
   <div id="v3-banner">
     <span class="hidden-sm">You’re browsing the documentation for v2.x and earlier.</span>
-    <a href="https://v3.vuejs.org/">Click here</a> for v3.x documentation.
+    <a href="https://v3.vuejs.org/guide/">Click here</a> for v3.x documentation.
   </div>
 
   <header id="header">


### PR DESCRIPTION
Fixed two URLs that pointed to the main page instead of v3 guide/docs. More details here: https://github.com/vuejs/vuejs.org/issues/2742