### PR TITLE
Binding dynamic class name

### DIFF
--- a/src/v2/guide/class-and-style.md
+++ b/src/v2/guide/class-and-style.md
@@ -113,6 +113,12 @@ However, this can be a bit verbose if you have multiple conditional classes. Tha
 <div v-bind:class="[{ active: isActive }, errorClass]"></div>
 ```
 
+Using the array syntax, you can also bind dynamic classes on the go (e.g within a v-for) like so:
+
+``` html
+<div v-bind:class="[`obj-${obj.id}`]"></div>
+```
+
 ### With Components
 
 > This section assumes knowledge of [Vue Components](components.html). Feel free to skip it and come back later.


### PR DESCRIPTION
Binding dynamic class name using array syntax to an element. A typical case would be within a for loop. I stumbled on this solution and I couldn't find it in the docs and thought i'd share.

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
