### PR TITLE
Update Vue School banner

### DIFF
--- a/themes/vue/layout/partials/vueschool_banner.ejs
+++ b/themes/vue/layout/partials/vueschool_banner.ejs
@@ -10,10 +10,7 @@
       <img src="/images/banners/vs-backpack.png" alt="Backpack">
     </div>
     <div class="vs-slogan">
-      3-months Vue School for only $49 <span style="text-decoration: line-through">$75</span>!
-      <span class="vs-slogan-light">
-        Limited Time Offer
-      </span>
+      Less than <span class="vs-slogan-light">48 hours</span> left for the Vue School offer
     </div>
     <div class="vs-button">
       GET ACCESS

--- a/themes/vue/source/css/_vueschool.styl
+++ b/themes/vue/source/css/_vueschool.styl
@@ -113,11 +113,18 @@ body.has-vs-banner
       color: #FFF
       font-weight: bold
       font-size: 14px
+      width: 150px
+      text-align: center
+      margin-left: 40px
+      @media (min-width: 400px)
+        margin-left: 60px
       @media (min-width: 680px)
+        margin-left: 0
+        width: auto
+        text-align: left
         font-size: 18px
       > .vs-slogan-light
         color: #ff5338
-        display: block
         text-align: left
         @media (min-width: 900px)
           text-align: center


### PR DESCRIPTION
This PR changes the banner on top of vuejs.org to inform visitors that it's less than 48 hours before the Summer Sale expires.

Please merge on Monday, 2021-06-21.

[Click here to see the visuals of the banner.](https://imgur.com/a/OCKhxSq)

Related to [PR 2829](https://github.com/vuejs/vuejs.org/pull/2829)
