### PR TITLE
docs: revamp Style Guide

### DIFF
--- a/src/v2/style-guide/index.md
+++ b/src/v2/style-guide/index.md
@@ -7,45 +7,12 @@ This is the official style guide for Vue-specific code. If you use Vue in a proj
 
 For the most part, we also avoid suggestions about JavaScript or HTML in general. We don't mind whether you use semicolons or trailing commas. We don't mind whether your HTML uses single-quotes or double-quotes for attribute values. Some exceptions will exist however, where we've found that a particular pattern is helpful in the context of Vue.
 
-> **Soon, we'll also provide tips for enforcement.** Sometimes you'll simply have to be disciplined, but wherever possible, we'll try to show you how to use ESLint and other automated processes to make enforcement simpler.
 
-Finally, we've split rules into four categories:
+## Naming
 
+### DO use multi-word component names
 
-
-## Rule Categories
-
-### Priority A: Essential
-
-These rules help prevent errors, so learn and abide by them at all costs. Exceptions may exist, but should be very rare and only be made by those with expert knowledge of both JavaScript and Vue.
-
-### Priority B: Strongly Recommended
-
-These rules have been found to improve readability and/or developer experience in most projects. Your code will still run if you violate them, but violations should be rare and well-justified.
-
-### Priority C: Recommended
-
-Where multiple, equally good options exist, an arbitrary choice can be made to ensure consistency. In these rules, we describe each acceptable option and suggest a default choice. That means you can feel free to make a different choice in your own codebase, as long as you're consistent and have a good reason. Please do have a good reason though! By adapting to the community standard, you will:
-
-1. train your brain to more easily parse most of the community code you encounter
-2. be able to copy and paste most community code examples without modification
-3. often find new hires are already accustomed to your preferred coding style, at least in regards to Vue
-
-### Priority D: Use with Caution
-
-Some features of Vue exist to accommodate rare edge cases or smoother migrations from a legacy code base. When overused however, they can make your code more difficult to maintain or even become a source of bugs. These rules shine a light on potentially risky features, describing when and why they should be avoided.
-
-
-
-## Priority A Rules: Essential (Error Prevention)
-
-
-
-### Multi-word component names <sup data-p="a">essential</sup>
-
-**Component names should always be multi-word, except for root `App` components, and built-in components provided by Vue, such as `<transition>` or `<component>`.**
-
-This [prevents conflicts](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) with existing and future HTML elements, since all HTML elements are a single word.
+Component names should always be multi-word, except for root `App` components, and built-in components provided by Vue, such as `<transition>` or `<component>`. This [prevents conflicts](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) with existing and future HTML elements, since all HTML elements are a single word.
 
 {% raw %}<div class="style-example example-bad">{% endraw %}
 #### Bad
@@ -81,13 +48,9 @@ export default {
 ```
 {% raw %}</div>{% endraw %}
 
+### DO use a prefix for base component names
 
-
-### Component data <sup data-p="a">essential</sup>
-
-**Component `data` must be a function.**
-
-When using the `data` property on a component (i.e. anywhere except on `new Vue`), the value must be a function that returns an object.
+Base components (a.k.a. presentational, dumb, or pure components) that apply app-specific styling and conventions should all begin with a specific prefix, such as `Base`, `App`, or `V`.
 
 {% raw %}
 <details>
@@ -96,91 +59,105 @@ When using the `data` property on a component (i.e. anywhere except on `new Vue`
 </summary>
 {% endraw %}
 
-When the value of `data` is an object, it's shared across all instances of a component. Imagine, for example, a `TodoList` component with this data:
+These components lay the foundation for consistent styling and behavior in your application. They may **only** contain:
 
-``` js
-data: {
-  listTitle: '',
-  todos: []
-}
-```
+- HTML elements,
+- other base components, and
+- 3rd-party UI components.
 
-We might want to reuse this component, allowing users to maintain multiple lists (e.g. for shopping, wishlists, daily chores, etc). There's a problem though. Since every instance of the component references the same data object, changing the title of one list will also change the title of every other list. The same is true for adding/editing/deleting a todo.
+But they'll **never** contain global state (e.g. from a Vuex store).
 
-Instead, we want each component instance to only manage its own data. For that to happen, each instance must generate a unique data object. In JavaScript, this can be accomplished by returning the object in a function:
+Their names often include the name of an element they wrap (e.g. `BaseButton`, `BaseTable`), unless no element exists for their specific purpose (e.g. `BaseIcon`). If you build similar components for a more specific context, they will almost always consume these components (e.g. `BaseButton` may be used in `ButtonSubmit`).
 
-``` js
-data: function () {
-  return {
-    listTitle: '',
-    todos: []
-  }
-}
-```
+Some advantages of this convention:
+
+- When organized alphabetically in editors, your app's base components are all listed together, making them easier to identify.
+
+- Since component names should always be multi-word, this convention prevents you from having to choose an arbitrary prefix for simple component wrappers (e.g. `MyButton`, `VueButton`).
+
+- Since these components are so frequently used, you may want to simply make them global instead of importing them everywhere. A prefix makes this possible with Webpack:
+
+  ``` js
+  var requireComponent = require.context("./src", true, /Base[A-Z]\w+\.(vue|js)$/)
+  requireComponent.keys().forEach(function (fileName) {
+    var baseComponentConfig = requireComponent(fileName)
+    baseComponentConfig = baseComponentConfig.default || baseComponentConfig
+    var baseComponentName = baseComponentConfig.name || (
+      fileName
+        .replace(/^.+\//, '')
+        .replace(/\.\w+$/, '')
+    )
+    Vue.component(baseComponentName, baseComponentConfig)
+  })
+  ```
+
 {% raw %}</details>{% endraw %}
 
 {% raw %}<div class="style-example example-bad">{% endraw %}
 #### Bad
 
-``` js
-Vue.component('some-comp', {
-  data: {
-    foo: 'bar'
-  }
-})
 ```
-
-``` js
-export default {
-  data: {
-    foo: 'bar'
-  }
-}
+components/
+|- MyButton.vue
+|- VueTable.vue
+|- Icon.vue
 ```
 {% raw %}</div>{% endraw %}
 
 {% raw %}<div class="style-example example-good">{% endraw %}
 #### Good
-``` js
-Vue.component('some-comp', {
-  data: function () {
-    return {
-      foo: 'bar'
-    }
-  }
-})
+
+```
+components/
+|- BaseButton.vue
+|- BaseTable.vue
+|- BaseIcon.vue
 ```
 
-``` js
-// In a .vue file
-export default {
-  data () {
-    return {
-      foo: 'bar'
-    }
-  }
-}
+```
+components/
+|- AppButton.vue
+|- AppTable.vue
+|- AppIcon.vue
 ```
 
-``` js
-// It's OK to use an object directly in a root
-// Vue instance, since only a single instance
-// will ever exist.
-new Vue({
-  data: {
-    foo: 'bar'
-  }
-})
+```
+components/
+|- VButton.vue
+|- VTable.vue
+|- VIcon.vue
 ```
 {% raw %}</div>{% endraw %}
 
+### DO prefix single-instance component names with "The"
 
+Components that should only ever have a single active instance should begin with the `The` prefix, to denote that there can be only one.
 
-### Prop definitions <sup data-p="a">essential</sup>
+This does not mean the component is only used in a single page, but it will only be used once _per page_. These components never accept any props, since they are specific to your app, not their context within your app. If you find the need to add props, it's a good indication that this is actually a reusable component that is only used once per page _for now_.
 
-**Prop definitions should be as detailed as possible.**
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
 
-In committed code, prop definitions should always be as detailed as possible, specifying at least type(s).
+```
+components/
+|- Heading.vue
+|- MySidebar.vue
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+```
+components/
+|- TheHeading.vue
+|- TheSidebar.vue
+```
+{% raw %}</div>{% endraw %}
+
+### PREFER prefixing tightly-coupled components' names with the parent component name
+
+If a component only makes sense in the context of a single parent component, that relationship should be evident in its name. Since editors typically organize files alphabetically, this also keeps these related files next to each other.
 
 {% raw %}
 <details>
@@ -189,10 +166,232 @@ In committed code, prop definitions should always be as detailed as possible, sp
 </summary>
 {% endraw %}
 
-Detailed [prop definitions](https://vuejs.org/v2/guide/components.html#Prop-Validation) have two advantages:
+You might be tempted to solve this problem by nesting child components in directories named after their parent. For example:
 
-- They document the API of the component, so that it's easy to see how the component is meant to be used.
-- In development, Vue will warn you if a component is ever provided incorrectly formatted props, helping you catch potential sources of error.
+```
+components/
+|- TodoList/
+   |- Item/
+      |- index.vue
+      |- Button.vue
+   |- index.vue
+```
+
+or:
+
+```
+components/
+|- TodoList/
+   |- Item/
+      |- Button.vue
+   |- Item.vue
+|- TodoList.vue
+```
+
+This isn't recommended, as it results in:
+
+- Many files with similar names, making rapid file switching in code editors more difficult.
+- Many nested sub-directories, which increases the time it takes to browse components in an editor's sidebar.
+
+{% raw %}</details>{% endraw %}
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+```
+components/
+|- TodoList.vue
+|- TodoItem.vue
+|- TodoButton.vue
+```
+
+```
+components/
+|- SearchSidebar.vue
+|- NavigationForSearchSidebar.vue
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+```
+components/
+|- TodoList.vue
+|- TodoListItem.vue
+|- TodoListItemButton.vue
+```
+
+```
+components/
+|- SearchSidebar.vue
+|- SearchSidebarNavigation.vue
+```
+{% raw %}</div>{% endraw %}
+
+### DO use a consistent order of words in component names
+
+Component names should start with the highest-level (often most general) words and end with descriptive modifying words.
+
+{% raw %}
+<details>
+<summary>
+  <h4>Detailed Explanation</h4>
+</summary>
+{% endraw %}
+
+You may be wondering:
+
+> "Why would we force component names to use less natural language?"
+
+In natural English, adjectives and other descriptors do typically appear before the nouns, while exceptions require connector words. For example:
+
+- Coffee _with_ milk
+- Soup _of the_ day
+- Visitor _to the_ museum
+
+You can definitely include these connector words in component names if you'd like, but the order is still important.
+
+Also note that **what's considered "highest-level" will be contextual to your app**. For example, imagine an app with a search form. It may include components like this one:
+
+```
+components/
+|- ClearSearchButton.vue
+|- ExcludeFromSearchInput.vue
+|- LaunchOnStartupCheckbox.vue
+|- RunSearchButton.vue
+|- SearchInput.vue
+|- TermsCheckbox.vue
+```
+
+As you might notice, it's quite difficult to see which components are specific to the search. Now let's rename the components according to the rule:
+
+```
+components/
+|- SearchButtonClear.vue
+|- SearchButtonRun.vue
+|- SearchInputExcludeGlob.vue
+|- SearchInputQuery.vue
+|- SettingsCheckboxLaunchOnStartup.vue
+|- SettingsCheckboxTerms.vue
+```
+
+Since editors typically organize files alphabetically, all the important relationships between components are now evident at a glance.
+
+You might be tempted to solve this problem differently, nesting all the search components under a "search" directory, then all the settings components under a "settings" directory. We only recommend considering this approach in very large apps (e.g. 100+ components), for these reasons:
+
+- It generally takes more time to navigate through nested sub-directories, than scrolling through a single `components` directory.
+- Name conflicts (e.g. multiple `ButtonDelete.vue` components) make it more difficult to quickly navigate to a specific component in a code editor.
+- Refactoring becomes more difficult, because find-and-replace often isn't sufficient to update relative references to a moved component.
+
+{% raw %}</details>{% endraw %}
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+```
+components/
+|- ClearSearchButton.vue
+|- ExcludeFromSearchInput.vue
+|- LaunchOnStartupCheckbox.vue
+|- RunSearchButton.vue
+|- SearchInput.vue
+|- TermsCheckbox.vue
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+```
+components/
+|- SearchButtonClear.vue
+|- SearchButtonRun.vue
+|- SearchInputQuery.vue
+|- SearchInputExcludeGlob.vue
+|- SettingsCheckboxTerms.vue
+|- SettingsCheckboxLaunchOnStartup.vue
+```
+{% raw %}</div>{% endraw %}
+
+### AVOID abbreviations in component names
+
+Component names should prefer full words over abbreviations. The autocompletion in editors make the cost of writing longer names very low, while the clarity they provide is invaluable. Uncommon abbreviations, in particular, should always be avoided.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+```
+components/
+|- SdSettings.vue
+|- UProfOpts.vue
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+```
+components/
+|- StudentDashboardSettings.vue
+|- UserProfileOptions.vue
+```
+{% raw %}</div>{% endraw %}
+
+
+## Casing
+
+### PREFER using PascalCase or kebab-case for single-file component filename
+
+Filenames of [single-file components](../guide/single-file-components.html) should either be always PascalCase or always kebab-case.
+
+PascalCase works best with autocompletion in code editors, as it's consistent with how we reference components in JS(X) and templates, wherever possible. However, mixed case filenames can sometimes create issues on case-insensitive file systems, which is why kebab-case is also perfectly acceptable.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+```
+components/
+|- mycomponent.vue
+```
+
+```
+components/
+|- myComponent.vue
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+```
+components/
+|- MyComponent.vue
+```
+
+```
+components/
+|- my-component.vue
+```
+{% raw %}</div>{% endraw %}
+
+### PREFER using PascalCase for component names in TS/JS(X)
+
+Component names in TS/TSX/JS/[JSX](../guide/render-function.html#JSX) should always be PascalCase, though they may be kebab-case inside strings for simpler applications that only use global component registration through `Vue.component`.
+
+{% raw %}
+<details>
+<summary>
+  <h4>Detailed Explanation</h4>
+</summary>
+{% endraw %}
+
+In JavaScript, PascalCase is the convention for classes and prototype constructors - essentially, anything that can have distinct instances. Vue components also have instances, so it makes sense to also use PascalCase. As an added benefit, using PascalCase within JSX (and templates) allows readers of the code to more easily distinguish between components and HTML elements.
+
+However, for applications that use **only** global component definitions via `Vue.component`, we recommend kebab-case instead. The reasons are:
+
+- It's rare that global components are ever referenced in JavaScript, so following a convention for JavaScript makes less sense.
+- These applications always include many in-DOM templates, where [kebab-case **must** be used](#Component-name-casing-in-templates-strongly-recommended).
 
 {% raw %}</details>{% endraw %}
 
@@ -200,8 +399,27 @@ Detailed [prop definitions](https://vuejs.org/v2/guide/components.html#Prop-Vali
 #### Bad
 
 ``` js
-// This is only OK when prototyping
-props: ['status']
+Vue.component('myComponent', {
+  // ...
+})
+```
+
+``` js
+import myComponent from './MyComponent.vue'
+```
+
+``` js
+export default {
+  name: 'myComponent',
+  // ...
+}
+```
+
+``` js
+export default {
+  name: 'my-component',
+  // ...
+}
 ```
 {% raw %}</div>{% endraw %}
 
@@ -209,35 +427,119 @@ props: ['status']
 #### Good
 
 ``` js
-props: {
-  status: String
-}
+Vue.component('MyComponent', {
+  // ...
+})
 ```
 
 ``` js
-// Even better!
-props: {
-  status: {
-    type: String,
-    required: true,
-    validator: function (value) {
-      return [
-        'syncing',
-        'synced',
-        'version-conflict',
-        'error'
-      ].indexOf(value) !== -1
-    }
-  }
+Vue.component('my-component', {
+  // ...
+})
+```
+
+``` js
+import MyComponent from './MyComponent.vue'
+```
+
+``` js
+export default {
+  name: 'MyComponent',
+  // ...
 }
 ```
 {% raw %}</div>{% endraw %}
 
+### PREFER using PascalCase for component tag names in templates
+
+In most projects, component names should always be PascalCase in [single-file components](../guide/single-file-components.html) and string templates - but kebab-case in DOM templates.
+
+PascalCase has a few advantages over kebab-case:
+
+- Editors can autocomplete component names in templates, because PascalCase is also used in JavaScript.
+- `<MyComponent>` is more visually distinct from a single-word HTML element than `<my-component>`, because there are two character differences (the two capitals), rather than just one (a hyphen).
+- If you use any non-Vue custom elements in your templates, such as a web component, PascalCase ensures that your Vue components remain distinctly visible.
+
+Unfortunately, due to HTML's case insensitivity, DOM templates must still use kebab-case.
+
+Also note that if you've already invested heavily in kebab-case, consistency with HTML conventions and being able to use the same casing across all your projects may be more important than the advantages listed above. In those cases, **using kebab-case everywhere is also acceptable.**
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` html
+<!-- In single-file components and string templates -->
+<mycomponent/>
+```
+
+``` html
+<!-- In single-file components and string templates -->
+<myComponent/>
+```
+
+``` html
+<!-- In DOM templates -->
+<MyComponent></MyComponent>
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` html
+<!-- In single-file components and string templates -->
+<MyComponent/>
+```
+
+``` html
+<!-- In DOM templates -->
+<my-component></my-component>
+```
+
+OR
+
+``` html
+<!-- Everywhere -->
+<my-component></my-component>
+```
+{% raw %}</div>{% endraw %}
+
+### PREFER camelCase for prop names declaration and kebab-case in templates and JSX
+
+We're simply following the conventions of each language. Within JavaScript, camelCase is more natural. Within HTML, kebab-case is.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` js
+props: {
+  'greeting-text': String
+}
+```
+
+{% codeblock lang:html %}
+<WelcomeMessage greetingText="hi"/>
+{% endcodeblock %}
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` js
+props: {
+  greetingText: String
+}
+```
+
+{% codeblock lang:html %}
+<WelcomeMessage greeting-text="hi"/>
+{% endcodeblock %}
+{% raw %}</div>{% endraw %}
 
 
-### Keyed `v-for` <sup data-p="a">essential</sup>
+## Templating
 
-**Always use `key` with `v-for`.**
+### DO use `key` with `v-for`
 
 `key` with `v-for` is _always_ required on components, in order to maintain internal component state down the subtree. Even for elements though, it's a good practice to maintain predictable behavior, such as [object constancy](https://bost.ocks.org/mike/constancy/) in animations.
 
@@ -302,13 +604,9 @@ In our experience, it's better to _always_ add a unique key, so that you and you
 ```
 {% raw %}</div>{% endraw %}
 
+### AVOID `v-if` with `v-for`
 
-
-### Avoid `v-if` with `v-for` <sup data-p="a">essential</sup>
-
-**Never use `v-if` on the same element as `v-for`.**
-
-There are two common cases where this can be tempting:
+Never use `v-if` on the same element as `v-for`. There are two common cases where this can be tempting:
 
 - To filter items in a list (e.g. `v-for="user in users" v-if="user.isActive"`). In these cases, replace `users` with a new computed property that returns your filtered list (e.g. `activeUsers`).
 
@@ -461,11 +759,235 @@ By moving the `v-if` to a container element, we're no longer checking `shouldSho
 ```
 {% raw %}</div>{% endraw %}
 
+### CONSIDER using `v-if`/`v-else-if`/`v-else` with `key` on elements of the same type
+
+It's usually best to use `key` with `v-if` + `v-else`, if they are the same element type (e.g. both `<div>` elements).
+
+By default, Vue updates the DOM as efficiently as possible. That means when switching between elements of the same type, it simply patches the existing element, rather than removing it and adding a new one in its place. This can have [unintended consequences](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-priority-d-rules-unintended-consequences) if these elements should not actually be considered the same.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` html
+<div v-if="error">
+  Error: {{ error }}
+</div>
+<div v-else>
+  {{ results }}
+</div>
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` html
+<div
+  v-if="error"
+  key="search-status"
+>
+  Error: {{ error }}
+</div>
+<div
+  v-else
+  key="search-results"
+>
+  {{ results }}
+</div>
+```
+{% raw %}</div>{% endraw %}
+
+### PREFER self-closing component tags
+
+Component tags with no content should be self-closing in [single-file components](../guide/single-file-components.html), string templates, and [JSX](../guide/render-function.html#JSX) - but never in DOM templates.
+
+Self-closing component tags communicate that they not only have no content, but are **meant** to have no content. It's the difference between a blank page in a book and one labeled "This page intentionally left blank." Your code is also cleaner without the unnecessary closing tag.
+
+Unfortunately, HTML doesn't allow custom elements to be self-closing - only [official "void" elements](https://www.w3.org/TR/html/syntax.html#void-elements). That's why the strategy is only possible when Vue's template compiler can reach the template before the DOM, then serve the DOM spec-compliant HTML.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` html
+<!-- In single-file components, string templates, and JSX -->
+<MyComponent></MyComponent>
+```
+
+``` html
+<!-- In DOM templates -->
+<my-component/>
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` html
+<!-- In single-file components, string templates, and JSX -->
+<MyComponent/>
+```
+
+``` html
+<!-- In DOM templates -->
+<my-component></my-component>
+```
+{% raw %}</div>{% endraw %}
+
+### PREFER putting each element attribute on its own line
+
+In JavaScript, splitting objects with multiple properties over multiple lines is widely considered a good convention, because it's much easier to read. Our templates and [JSX](../guide/render-function.html#JSX) deserve the same consideration: Elements with multiple attributes should span multiple lines, with one attribute per line.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` html
+<img src="https://vuejs.org/images/logo.png" alt="Vue Logo">
+```
+
+``` html
+<MyComponent foo="a" bar="b" baz="c"/>
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` html
+<img
+  src="https://vuejs.org/images/logo.png"
+  alt="Vue Logo"
+>
+```
+
+``` html
+<MyComponent
+  foo="a"
+  bar="b"
+  baz="c"
+/>
+```
+{% raw %}</div>{% endraw %}
+
+### DO quote attribute values
+
+Non-empty HTML attribute values should always be inside quotes (single or double, whichever is not used in JS).
+
+While attribute values without any spaces are not required to have quotes in HTML, this practice often leads to _avoiding_ spaces, making attribute values less readable.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` html
+<input type=text>
+```
+
+``` html
+<AppSidebar :style={width:sidebarWidth+'px'}>
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` html
+<input type="text">
+```
+
+``` html
+<AppSidebar :style="{ width: sidebarWidth + 'px' }">
+```
+{% raw %}</div>{% endraw %}
+
+### DO have a consistent usage strategy for directive shorthands
+
+Directive shorthands (`:` for `v-bind:`, `@` for `v-on:` and `#` for `v-slot`) should be used either _always_ or _never_.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` html
+<input
+  v-bind:value="newTodoText"
+  :placeholder="newTodoInstructions"
+>
+```
+
+``` html
+<input
+  v-on:input="onInput"
+  @focus="onFocus"
+>
+```
+
+``` html
+<template v-slot:header>
+  <h1>Here might be a page title</h1>
+</template>
+
+<template #footer>
+  <p>Here's some contact info</p>
+</template>
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` html
+<input
+  :value="newTodoText"
+  :placeholder="newTodoInstructions"
+>
+```
+
+``` html
+<input
+  v-bind:value="newTodoText"
+  v-bind:placeholder="newTodoInstructions"
+>
+```
+
+``` html
+<input
+  @input="onInput"
+  @focus="onFocus"
+>
+```
+
+``` html
+<input
+  v-on:input="onInput"
+  v-on:focus="onFocus"
+>
+```
+
+``` html
+<template v-slot:header>
+  <h1>Here might be a page title</h1>
+</template>
+
+<template v-slot:footer>
+  <p>Here's some contact info</p>
+</template>
+```
+
+``` html
+<template #header>
+  <h1>Here might be a page title</h1>
+</template>
+
+<template #footer>
+  <p>Here's some contact info</p>
+</template>
+```
+{% raw %}</div>{% endraw %}
 
 
-### Component style scoping <sup data-p="a">essential</sup>
+## Styles
 
-**For applications, styles in a top-level `App` component and in layout components may be global, but all other components should always be scoped.**
+### PREFER using scoped styles over global
+
+For applications, styles in a top-level `App` component and in layout components may be global, but all other components should always be scoped.
 
 This is only relevant for [single-file components](../guide/single-file-components.html). It does _not_ require that the [`scoped` attribute](https://vue-loader.vuejs.org/en/features/scoped-css.html) be used. Scoping could be through [CSS modules](https://vue-loader.vuejs.org/en/features/css-modules.html), a class-based strategy such as [BEM](http://getbem.com/), or another library/convention.
 
@@ -562,9 +1084,460 @@ Beyond the `scoped` attribute, using unique class names can help ensure that 3rd
 
 
 
-### Private property names <sup data-p="a">essential</sup>
+### PREFER class over element selectors with `scoped` styles
 
-**Use module scoping to keep private functions inaccessible from the outside. If that's not possible, always use the `$_` prefix for custom private properties in a plugin, mixin, etc that should not be considered public API. Then to avoid conflicts with code by other authors, also include a named scope (e.g. `$_yourPluginName_`).**
+Prefer class selectors over element selectors in `scoped` styles, because large numbers of element selectors are slow.
+
+{% raw %}
+<details>
+<summary>
+  <h4>Detailed Explanation</h4>
+</summary>
+{% endraw %}
+
+To scope styles, Vue adds a unique attribute to component elements, such as `data-v-f3f3eg9`. Then selectors are modified so that only matching elements with this attribute are selected (e.g. `button[data-v-f3f3eg9]`).
+
+The problem is that large numbers of [element-attribute selectors](http://stevesouders.com/efws/css-selectors/csscreate.php?n=1000&sel=a%5Bhref%5D&body=background%3A+%23CFD&ne=1000) (e.g. `button[data-v-f3f3eg9]`) will be considerably slower than [class-attribute selectors](http://stevesouders.com/efws/css-selectors/csscreate.php?n=1000&sel=.class%5Bhref%5D&body=background%3A+%23CFD&ne=1000) (e.g. `.btn-close[data-v-f3f3eg9]`), so class selectors should be preferred whenever possible.
+
+{% raw %}</details>{% endraw %}
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` html
+<template>
+  <button>X</button>
+</template>
+
+<style scoped>
+button {
+  background-color: red;
+}
+</style>
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` html
+<template>
+  <button class="btn btn-close">X</button>
+</template>
+
+<style scoped>
+.btn-close {
+  background-color: red;
+}
+</style>
+```
+{% raw %}</div>{% endraw %}
+
+
+## Ordering
+
+### CONSIDER having a consistent order for element attributes
+
+This is the default order we recommend for component options. They're split into categories, so you'll know where to add custom attributes and directives.
+
+1. **Definition** (provides the component options)
+  - `is`
+
+2. **List Rendering** (creates multiple variations of the same element)
+  - `v-for`
+
+3. **Conditionals** (whether the element is rendered/shown)
+  - `v-if`
+  - `v-else-if`
+  - `v-else`
+  - `v-show`
+  - `v-cloak`
+
+4. **Render Modifiers** (changes the way the element renders)
+  - `v-pre`
+  - `v-once`
+
+5. **Global Awareness** (requires knowledge beyond the component)
+  - `id`
+
+6. **Unique Attributes** (attributes that require unique values)
+  - `ref`
+  - `key`
+
+7. **Two-Way Binding** (combining binding and events)
+  - `v-model`
+
+8. **Other Attributes** (all unspecified bound & unbound attributes)
+
+9. **Events** (component event listeners)
+  - `v-on`
+
+10. **Content** (overrides the content of the element)
+  - `v-html`
+  - `v-text`
+
+### CONSIDER having a consistent order for component/instance options
+
+This is the default order we recommend for component options. They're split into categories, so you'll know where to add new properties from plugins.
+
+1. **Side Effects** (triggers effects outside the component)
+  - `el`
+
+2. **Global Awareness** (requires knowledge beyond the component)
+  - `name`
+  - `parent`
+
+3. **Component Type** (changes the type of the component)
+  - `functional`
+
+4. **Template Modifiers** (changes the way templates are compiled)
+  - `delimiters`
+  - `comments`
+
+5. **Template Dependencies** (assets used in the template)
+  - `components`
+  - `directives`
+  - `filters`
+
+6. **Composition** (merges properties into the options)
+  - `extends`
+  - `mixins`
+
+7. **Interface** (the interface to the component)
+  - `inheritAttrs`
+  - `model`
+  - `props`/`propsData`
+
+8. **Local State** (local reactive properties)
+  - `data`
+  - `computed`
+
+9. **Events** (callbacks triggered by reactive events)
+  - `watch`
+  - Lifecycle Events (in the order they are called)
+    - `beforeCreate`
+    - `created`
+    - `beforeMount`
+    - `mounted`
+    - `beforeUpdate`
+    - `updated`
+    - `activated`
+    - `deactivated`
+    - `beforeDestroy`
+    - `destroyed`
+
+10. **Non-Reactive Properties** (instance properties independent of the reactivity system)
+  - `methods`
+
+11. **Rendering** (the declarative description of the component output)
+  - `template`/`render`
+  - `renderError`
+
+### CONSIDER having a consistent order for top-level elements in single-file components
+
+[Single-file components](../guide/single-file-components.html) should always order `<script>`, `<template>`, and `<style>` tags consistently, with `<style>` last, because at least one of the other two is always necessary.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` html
+<style>/* ... */</style>
+<script>/* ... */</script>
+<template>...</template>
+```
+
+``` html
+<!-- ComponentA.vue -->
+<script>/* ... */</script>
+<template>...</template>
+<style>/* ... */</style>
+
+<!-- ComponentB.vue -->
+<template>...</template>
+<script>/* ... */</script>
+<style>/* ... */</style>
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` html
+<!-- ComponentA.vue -->
+<script>/* ... */</script>
+<template>...</template>
+<style>/* ... */</style>
+
+<!-- ComponentB.vue -->
+<script>/* ... */</script>
+<template>...</template>
+<style>/* ... */</style>
+```
+
+``` html
+<!-- ComponentA.vue -->
+<template>...</template>
+<script>/* ... */</script>
+<style>/* ... */</style>
+
+<!-- ComponentB.vue -->
+<template>...</template>
+<script>/* ... */</script>
+<style>/* ... */</style>
+```
+{% raw %}</div>{% endraw %}
+
+
+## Patterns and Practices
+
+### CONSIDER splitting complex computed properties into multiple simple ones
+
+Complex computed properties should be split into as many simpler properties as possible. This makes the code easier to read, reuse, and test.
+
+{% raw %}
+<details>
+<summary>
+  <h4>Detailed Explanation</h4>
+</summary>
+{% endraw %}
+
+Simpler, well-named computed properties are:
+
+- __Easier to test__
+
+  When each computed property contains only a very simple expression, with very few dependencies, it's much easier to write tests confirming that it works correctly.
+
+- __Easier to read__
+
+  Simplifying computed properties forces you to give each value a descriptive name, even if it's not reused. This makes it much easier for other developers (and future you) to focus on the code they care about and figure out what's going on.
+
+- __More adaptable to changing requirements__
+
+  Any value that can be named might be useful to the view. For example, we might decide to display a message telling the user how much money they saved. We might also decide to calculate sales tax, but perhaps display it separately, rather than as part of the final price.
+
+  Small, focused computed properties make fewer assumptions about how information will be used, so require less refactoring as requirements change.
+
+{% raw %}</details>{% endraw %}
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` js
+computed: {
+  price: function () {
+    var basePrice = this.manufactureCost / (1 - this.profitMargin)
+    return (
+      basePrice -
+      basePrice * (this.discountPercent || 0)
+    )
+  }
+}
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` js
+computed: {
+  basePrice: function () {
+    return this.manufactureCost / (1 - this.profitMargin)
+  },
+  discount: function () {
+    return this.basePrice * (this.discountPercent || 0)
+  },
+  finalPrice: function () {
+    return this.basePrice - this.discount
+  }
+}
+```
+{% raw %}</div>{% endraw %}
+
+### PREFER computed properties or methods over expressions
+
+Component templates should only include simple expressions, with more complex expressions refactored into computed properties or methods.
+
+Complex expressions in your templates make them less declarative. We should strive to describe _what_ should appear, not _how_ we're computing that value. Computed properties and methods also allow the code to be reused.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` html
+{{
+  fullName.split(' ').map(function (word) {
+    return word[0].toUpperCase() + word.slice(1)
+  }).join(' ')
+}}
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` html
+<!-- In a template -->
+{{ normalizedFullName }}
+```
+
+``` js
+// The complex expression has been moved to a computed property
+computed: {
+  normalizedFullName: function () {
+    return this.fullName.split(' ').map(function (word) {
+      return word[0].toUpperCase() + word.slice(1)
+    }).join(' ')
+  }
+}
+```
+{% raw %}</div>{% endraw %}
+
+### DO use a function for component `data`
+
+When using the `data` property on a component (i.e. anywhere except on `new Vue`), the value must be a function that returns an object.
+
+{% raw %}
+<details>
+<summary>
+  <h4>Detailed Explanation</h4>
+</summary>
+{% endraw %}
+
+When the value of `data` is an object, it's shared across all instances of a component. Imagine, for example, a `TodoList` component with this data:
+
+``` js
+data: {
+  listTitle: '',
+  todos: []
+}
+```
+
+We might want to reuse this component, allowing users to maintain multiple lists (e.g. for shopping, wishlists, daily chores, etc). There's a problem though. Since every instance of the component references the same data object, changing the title of one list will also change the title of every other list. The same is true for adding/editing/deleting a todo.
+
+Instead, we want each component instance to only manage its own data. For that to happen, each instance must generate a unique data object. In JavaScript, this can be accomplished by returning the object in a function:
+
+``` js
+data: function () {
+  return {
+    listTitle: '',
+    todos: []
+  }
+}
+```
+{% raw %}</details>{% endraw %}
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` js
+Vue.component('some-comp', {
+  data: {
+    foo: 'bar'
+  }
+})
+```
+
+``` js
+export default {
+  data: {
+    foo: 'bar'
+  }
+}
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+``` js
+Vue.component('some-comp', {
+  data: function () {
+    return {
+      foo: 'bar'
+    }
+  }
+})
+```
+
+``` js
+// In a .vue file
+export default {
+  data () {
+    return {
+      foo: 'bar'
+    }
+  }
+}
+```
+
+``` js
+// It's OK to use an object directly in a root
+// Vue instance, since only a single instance
+// will ever exist.
+new Vue({
+  data: {
+    foo: 'bar'
+  }
+})
+```
+{% raw %}</div>{% endraw %}
+
+### DO provide as many details as possible for prop definitions
+
+In committed code, prop definitions should always be as detailed as possible, specifying at least type(s).
+
+{% raw %}
+<details>
+<summary>
+  <h4>Detailed Explanation</h4>
+</summary>
+{% endraw %}
+
+Detailed [prop definitions](https://vuejs.org/v2/guide/components.html#Prop-Validation) have two advantages:
+
+- They document the API of the component, so that it's easy to see how the component is meant to be used.
+- In development, Vue will warn you if a component is ever provided incorrectly formatted props, helping you catch potential sources of error.
+
+{% raw %}</details>{% endraw %}
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` js
+// This is only OK when prototyping
+props: ['status']
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` js
+props: {
+  status: String
+}
+```
+
+``` js
+// Even better!
+props: {
+  status: {
+    type: String,
+    required: true,
+    validator: function (value) {
+      return [
+        'syncing',
+        'synced',
+        'version-conflict',
+        'error'
+      ].indexOf(value) !== -1
+    }
+  }
+}
+```
+{% raw %}</div>{% endraw %}
+
+### DO keep private functions inaccessible from outside
+
+Use module scoping to keep private functions inaccessible from the outside. If that's not possible, always use the `$_` prefix for custom private properties in a plugin, mixin, etc that should not be considered public API. Then to avoid conflicts with code by other authors, also include a named scope (e.g. `$_yourPluginName_`).
 
 {% raw %}
 <details>
@@ -664,1191 +1637,9 @@ export default myGreatMixin
 ```
 {% raw %}</div>{% endraw %}
 
+### PREFER props and events over `this.$parent` or prop mutation for parent-child component communication
 
-
-## Priority B Rules: Strongly Recommended (Improving Readability)
-
-
-
-### Component files <sup data-p="b">strongly recommended</sup>
-
-**Whenever a build system is available to concatenate files, each component should be in its own file.**
-
-This helps you to more quickly find a component when you need to edit it or review how to use it.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` js
-Vue.component('TodoList', {
-  // ...
-})
-
-Vue.component('TodoItem', {
-  // ...
-})
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-```
-components/
-|- TodoList.js
-|- TodoItem.js
-```
-
-```
-components/
-|- TodoList.vue
-|- TodoItem.vue
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Single-file component filename casing <sup data-p="b">strongly recommended</sup>
-
-**Filenames of [single-file components](../guide/single-file-components.html) should either be always PascalCase or always kebab-case.**
-
-PascalCase works best with autocompletion in code editors, as it's consistent with how we reference components in JS(X) and templates, wherever possible. However, mixed case filenames can sometimes create issues on case-insensitive file systems, which is why kebab-case is also perfectly acceptable.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-```
-components/
-|- mycomponent.vue
-```
-
-```
-components/
-|- myComponent.vue
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-```
-components/
-|- MyComponent.vue
-```
-
-```
-components/
-|- my-component.vue
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Base component names <sup data-p="b">strongly recommended</sup>
-
-**Base components (a.k.a. presentational, dumb, or pure components) that apply app-specific styling and conventions should all begin with a specific prefix, such as `Base`, `App`, or `V`.**
-
-{% raw %}
-<details>
-<summary>
-  <h4>Detailed Explanation</h4>
-</summary>
-{% endraw %}
-
-These components lay the foundation for consistent styling and behavior in your application. They may **only** contain:
-
-- HTML elements,
-- other base components, and
-- 3rd-party UI components.
-
-But they'll **never** contain global state (e.g. from a Vuex store).
-
-Their names often include the name of an element they wrap (e.g. `BaseButton`, `BaseTable`), unless no element exists for their specific purpose (e.g. `BaseIcon`). If you build similar components for a more specific context, they will almost always consume these components (e.g. `BaseButton` may be used in `ButtonSubmit`).
-
-Some advantages of this convention:
-
-- When organized alphabetically in editors, your app's base components are all listed together, making them easier to identify.
-
-- Since component names should always be multi-word, this convention prevents you from having to choose an arbitrary prefix for simple component wrappers (e.g. `MyButton`, `VueButton`).
-
-- Since these components are so frequently used, you may want to simply make them global instead of importing them everywhere. A prefix makes this possible with Webpack:
-
-  ``` js
-  var requireComponent = require.context("./src", true, /Base[A-Z]\w+\.(vue|js)$/)
-  requireComponent.keys().forEach(function (fileName) {
-    var baseComponentConfig = requireComponent(fileName)
-    baseComponentConfig = baseComponentConfig.default || baseComponentConfig
-    var baseComponentName = baseComponentConfig.name || (
-      fileName
-        .replace(/^.+\//, '')
-        .replace(/\.\w+$/, '')
-    )
-    Vue.component(baseComponentName, baseComponentConfig)
-  })
-  ```
-
-{% raw %}</details>{% endraw %}
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-```
-components/
-|- MyButton.vue
-|- VueTable.vue
-|- Icon.vue
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-```
-components/
-|- BaseButton.vue
-|- BaseTable.vue
-|- BaseIcon.vue
-```
-
-```
-components/
-|- AppButton.vue
-|- AppTable.vue
-|- AppIcon.vue
-```
-
-```
-components/
-|- VButton.vue
-|- VTable.vue
-|- VIcon.vue
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Single-instance component names <sup data-p="b">strongly recommended</sup>
-
-**Components that should only ever have a single active instance should begin with the `The` prefix, to denote that there can be only one.**
-
-This does not mean the component is only used in a single page, but it will only be used once _per page_. These components never accept any props, since they are specific to your app, not their context within your app. If you find the need to add props, it's a good indication that this is actually a reusable component that is only used once per page _for now_.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-```
-components/
-|- Heading.vue
-|- MySidebar.vue
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-```
-components/
-|- TheHeading.vue
-|- TheSidebar.vue
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Tightly coupled component names <sup data-p="b">strongly recommended</sup>
-
-**Child components that are tightly coupled with their parent should include the parent component name as a prefix.**
-
-If a component only makes sense in the context of a single parent component, that relationship should be evident in its name. Since editors typically organize files alphabetically, this also keeps these related files next to each other.
-
-{% raw %}
-<details>
-<summary>
-  <h4>Detailed Explanation</h4>
-</summary>
-{% endraw %}
-
-You might be tempted to solve this problem by nesting child components in directories named after their parent. For example:
-
-```
-components/
-|- TodoList/
-   |- Item/
-      |- index.vue
-      |- Button.vue
-   |- index.vue
-```
-
-or:
-
-```
-components/
-|- TodoList/
-   |- Item/
-      |- Button.vue
-   |- Item.vue
-|- TodoList.vue
-```
-
-This isn't recommended, as it results in:
-
-- Many files with similar names, making rapid file switching in code editors more difficult.
-- Many nested sub-directories, which increases the time it takes to browse components in an editor's sidebar.
-
-{% raw %}</details>{% endraw %}
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-```
-components/
-|- TodoList.vue
-|- TodoItem.vue
-|- TodoButton.vue
-```
-
-```
-components/
-|- SearchSidebar.vue
-|- NavigationForSearchSidebar.vue
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-```
-components/
-|- TodoList.vue
-|- TodoListItem.vue
-|- TodoListItemButton.vue
-```
-
-```
-components/
-|- SearchSidebar.vue
-|- SearchSidebarNavigation.vue
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Order of words in component names <sup data-p="b">strongly recommended</sup>
-
-**Component names should start with the highest-level (often most general) words and end with descriptive modifying words.**
-
-{% raw %}
-<details>
-<summary>
-  <h4>Detailed Explanation</h4>
-</summary>
-{% endraw %}
-
-You may be wondering:
-
-> "Why would we force component names to use less natural language?"
-
-In natural English, adjectives and other descriptors do typically appear before the nouns, while exceptions require connector words. For example:
-
-- Coffee _with_ milk
-- Soup _of the_ day
-- Visitor _to the_ museum
-
-You can definitely include these connector words in component names if you'd like, but the order is still important.
-
-Also note that **what's considered "highest-level" will be contextual to your app**. For example, imagine an app with a search form. It may include components like this one:
-
-```
-components/
-|- ClearSearchButton.vue
-|- ExcludeFromSearchInput.vue
-|- LaunchOnStartupCheckbox.vue
-|- RunSearchButton.vue
-|- SearchInput.vue
-|- TermsCheckbox.vue
-```
-
-As you might notice, it's quite difficult to see which components are specific to the search. Now let's rename the components according to the rule:
-
-```
-components/
-|- SearchButtonClear.vue
-|- SearchButtonRun.vue
-|- SearchInputExcludeGlob.vue
-|- SearchInputQuery.vue
-|- SettingsCheckboxLaunchOnStartup.vue
-|- SettingsCheckboxTerms.vue
-```
-
-Since editors typically organize files alphabetically, all the important relationships between components are now evident at a glance.
-
-You might be tempted to solve this problem differently, nesting all the search components under a "search" directory, then all the settings components under a "settings" directory. We only recommend considering this approach in very large apps (e.g. 100+ components), for these reasons:
-
-- It generally takes more time to navigate through nested sub-directories, than scrolling through a single `components` directory.
-- Name conflicts (e.g. multiple `ButtonDelete.vue` components) make it more difficult to quickly navigate to a specific component in a code editor.
-- Refactoring becomes more difficult, because find-and-replace often isn't sufficient to update relative references to a moved component.
-
-{% raw %}</details>{% endraw %}
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-```
-components/
-|- ClearSearchButton.vue
-|- ExcludeFromSearchInput.vue
-|- LaunchOnStartupCheckbox.vue
-|- RunSearchButton.vue
-|- SearchInput.vue
-|- TermsCheckbox.vue
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-```
-components/
-|- SearchButtonClear.vue
-|- SearchButtonRun.vue
-|- SearchInputQuery.vue
-|- SearchInputExcludeGlob.vue
-|- SettingsCheckboxTerms.vue
-|- SettingsCheckboxLaunchOnStartup.vue
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Self-closing components <sup data-p="b">strongly recommended</sup>
-
-**Components with no content should be self-closing in [single-file components](../guide/single-file-components.html), string templates, and [JSX](../guide/render-function.html#JSX) - but never in DOM templates.**
-
-Components that self-close communicate that they not only have no content, but are **meant** to have no content. It's the difference between a blank page in a book and one labeled "This page intentionally left blank." Your code is also cleaner without the unnecessary closing tag.
-
-Unfortunately, HTML doesn't allow custom elements to be self-closing - only [official "void" elements](https://www.w3.org/TR/html/syntax.html#void-elements). That's why the strategy is only possible when Vue's template compiler can reach the template before the DOM, then serve the DOM spec-compliant HTML.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` html
-<!-- In single-file components, string templates, and JSX -->
-<MyComponent></MyComponent>
-```
-
-``` html
-<!-- In DOM templates -->
-<my-component/>
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` html
-<!-- In single-file components, string templates, and JSX -->
-<MyComponent/>
-```
-
-``` html
-<!-- In DOM templates -->
-<my-component></my-component>
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Component name casing in templates <sup data-p="b">strongly recommended</sup>
-
-**In most projects, component names should always be PascalCase in [single-file components](../guide/single-file-components.html) and string templates - but kebab-case in DOM templates.**
-
-PascalCase has a few advantages over kebab-case:
-
-- Editors can autocomplete component names in templates, because PascalCase is also used in JavaScript.
-- `<MyComponent>` is more visually distinct from a single-word HTML element than `<my-component>`, because there are two character differences (the two capitals), rather than just one (a hyphen).
-- If you use any non-Vue custom elements in your templates, such as a web component, PascalCase ensures that your Vue components remain distinctly visible.
-
-Unfortunately, due to HTML's case insensitivity, DOM templates must still use kebab-case.
-
-Also note that if you've already invested heavily in kebab-case, consistency with HTML conventions and being able to use the same casing across all your projects may be more important than the advantages listed above. In those cases, **using kebab-case everywhere is also acceptable.**
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` html
-<!-- In single-file components and string templates -->
-<mycomponent/>
-```
-
-``` html
-<!-- In single-file components and string templates -->
-<myComponent/>
-```
-
-``` html
-<!-- In DOM templates -->
-<MyComponent></MyComponent>
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` html
-<!-- In single-file components and string templates -->
-<MyComponent/>
-```
-
-``` html
-<!-- In DOM templates -->
-<my-component></my-component>
-```
-
-OR
-
-``` html
-<!-- Everywhere -->
-<my-component></my-component>
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Component name casing in JS/JSX <sup data-p="b">strongly recommended</sup>
-
-**Component names in JS/[JSX](../guide/render-function.html#JSX) should always be PascalCase, though they may be kebab-case inside strings for simpler applications that only use global component registration through `Vue.component`.**
-
-{% raw %}
-<details>
-<summary>
-  <h4>Detailed Explanation</h4>
-</summary>
-{% endraw %}
-
-In JavaScript, PascalCase is the convention for classes and prototype constructors - essentially, anything that can have distinct instances. Vue components also have instances, so it makes sense to also use PascalCase. As an added benefit, using PascalCase within JSX (and templates) allows readers of the code to more easily distinguish between components and HTML elements.
-
-However, for applications that use **only** global component definitions via `Vue.component`, we recommend kebab-case instead. The reasons are:
-
-- It's rare that global components are ever referenced in JavaScript, so following a convention for JavaScript makes less sense.
-- These applications always include many in-DOM templates, where [kebab-case **must** be used](#Component-name-casing-in-templates-strongly-recommended).
-
-{% raw %}</details>{% endraw %}
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` js
-Vue.component('myComponent', {
-  // ...
-})
-```
-
-``` js
-import myComponent from './MyComponent.vue'
-```
-
-``` js
-export default {
-  name: 'myComponent',
-  // ...
-}
-```
-
-``` js
-export default {
-  name: 'my-component',
-  // ...
-}
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` js
-Vue.component('MyComponent', {
-  // ...
-})
-```
-
-``` js
-Vue.component('my-component', {
-  // ...
-})
-```
-
-``` js
-import MyComponent from './MyComponent.vue'
-```
-
-``` js
-export default {
-  name: 'MyComponent',
-  // ...
-}
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Full-word component names <sup data-p="b">strongly recommended</sup>
-
-**Component names should prefer full words over abbreviations.**
-
-The autocompletion in editors make the cost of writing longer names very low, while the clarity they provide is invaluable. Uncommon abbreviations, in particular, should always be avoided.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-```
-components/
-|- SdSettings.vue
-|- UProfOpts.vue
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-```
-components/
-|- StudentDashboardSettings.vue
-|- UserProfileOptions.vue
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Prop name casing <sup data-p="b">strongly recommended</sup>
-
-**Prop names should always use camelCase during declaration, but kebab-case in templates and [JSX](../guide/render-function.html#JSX).**
-
-We're simply following the conventions of each language. Within JavaScript, camelCase is more natural. Within HTML, kebab-case is.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` js
-props: {
-  'greeting-text': String
-}
-```
-
-{% codeblock lang:html %}
-<WelcomeMessage greetingText="hi"/>
-{% endcodeblock %}
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` js
-props: {
-  greetingText: String
-}
-```
-
-{% codeblock lang:html %}
-<WelcomeMessage greeting-text="hi"/>
-{% endcodeblock %}
-{% raw %}</div>{% endraw %}
-
-
-
-### Multi-attribute elements <sup data-p="b">strongly recommended</sup>
-
-**Elements with multiple attributes should span multiple lines, with one attribute per line.**
-
-In JavaScript, splitting objects with multiple properties over multiple lines is widely considered a good convention, because it's much easier to read. Our templates and [JSX](../guide/render-function.html#JSX) deserve the same consideration.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` html
-<img src="https://vuejs.org/images/logo.png" alt="Vue Logo">
-```
-
-``` html
-<MyComponent foo="a" bar="b" baz="c"/>
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` html
-<img
-  src="https://vuejs.org/images/logo.png"
-  alt="Vue Logo"
->
-```
-
-``` html
-<MyComponent
-  foo="a"
-  bar="b"
-  baz="c"
-/>
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Simple expressions in templates <sup data-p="b">strongly recommended</sup>
-
-**Component templates should only include simple expressions, with more complex expressions refactored into computed properties or methods.**
-
-Complex expressions in your templates make them less declarative. We should strive to describe _what_ should appear, not _how_ we're computing that value. Computed properties and methods also allow the code to be reused.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` html
-{{
-  fullName.split(' ').map(function (word) {
-    return word[0].toUpperCase() + word.slice(1)
-  }).join(' ')
-}}
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` html
-<!-- In a template -->
-{{ normalizedFullName }}
-```
-
-``` js
-// The complex expression has been moved to a computed property
-computed: {
-  normalizedFullName: function () {
-    return this.fullName.split(' ').map(function (word) {
-      return word[0].toUpperCase() + word.slice(1)
-    }).join(' ')
-  }
-}
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Simple computed properties <sup data-p="b">strongly recommended</sup>
-
-**Complex computed properties should be split into as many simpler properties as possible.**
-
-{% raw %}
-<details>
-<summary>
-  <h4>Detailed Explanation</h4>
-</summary>
-{% endraw %}
-
-Simpler, well-named computed properties are:
-
-- __Easier to test__
-
-  When each computed property contains only a very simple expression, with very few dependencies, it's much easier to write tests confirming that it works correctly.
-
-- __Easier to read__
-
-  Simplifying computed properties forces you to give each value a descriptive name, even if it's not reused. This makes it much easier for other developers (and future you) to focus on the code they care about and figure out what's going on.
-
-- __More adaptable to changing requirements__
-
-  Any value that can be named might be useful to the view. For example, we might decide to display a message telling the user how much money they saved. We might also decide to calculate sales tax, but perhaps display it separately, rather than as part of the final price.
-
-  Small, focused computed properties make fewer assumptions about how information will be used, so require less refactoring as requirements change.
-
-{% raw %}</details>{% endraw %}
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` js
-computed: {
-  price: function () {
-    var basePrice = this.manufactureCost / (1 - this.profitMargin)
-    return (
-      basePrice -
-      basePrice * (this.discountPercent || 0)
-    )
-  }
-}
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` js
-computed: {
-  basePrice: function () {
-    return this.manufactureCost / (1 - this.profitMargin)
-  },
-  discount: function () {
-    return this.basePrice * (this.discountPercent || 0)
-  },
-  finalPrice: function () {
-    return this.basePrice - this.discount
-  }
-}
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Quoted attribute values <sup data-p="b">strongly recommended</sup>
-
-**Non-empty HTML attribute values should always be inside quotes (single or double, whichever is not used in JS).**
-
-While attribute values without any spaces are not required to have quotes in HTML, this practice often leads to _avoiding_ spaces, making attribute values less readable.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` html
-<input type=text>
-```
-
-``` html
-<AppSidebar :style={width:sidebarWidth+'px'}>
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` html
-<input type="text">
-```
-
-``` html
-<AppSidebar :style="{ width: sidebarWidth + 'px' }">
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Directive shorthands <sup data-p="b">strongly recommended</sup>
-
-**Directive shorthands (`:` for `v-bind:`, `@` for `v-on:` and `#` for `v-slot`) should be used always or never.**
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` html
-<input
-  v-bind:value="newTodoText"
-  :placeholder="newTodoInstructions"
->
-```
-
-``` html
-<input
-  v-on:input="onInput"
-  @focus="onFocus"
->
-```
-
-``` html
-<template v-slot:header>
-  <h1>Here might be a page title</h1>
-</template>
-
-<template #footer>
-  <p>Here's some contact info</p>
-</template>
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` html
-<input
-  :value="newTodoText"
-  :placeholder="newTodoInstructions"
->
-```
-
-``` html
-<input
-  v-bind:value="newTodoText"
-  v-bind:placeholder="newTodoInstructions"
->
-```
-
-``` html
-<input
-  @input="onInput"
-  @focus="onFocus"
->
-```
-
-``` html
-<input
-  v-on:input="onInput"
-  v-on:focus="onFocus"
->
-```
-
-``` html
-<template v-slot:header>
-  <h1>Here might be a page title</h1>
-</template>
-
-<template v-slot:footer>
-  <p>Here's some contact info</p>
-</template>
-```
-
-``` html
-<template #header>
-  <h1>Here might be a page title</h1>
-</template>
-
-<template #footer>
-  <p>Here's some contact info</p>
-</template>
-```
-{% raw %}</div>{% endraw %}
-
-
-
-
-## Priority C Rules: Recommended (Minimizing Arbitrary Choices and Cognitive Overhead)
-
-
-
-### Component/instance options order <sup data-p="c">recommended</sup>
-
-**Component/instance options should be ordered consistently.**
-
-This is the default order we recommend for component options. They're split into categories, so you'll know where to add new properties from plugins.
-
-1. **Side Effects** (triggers effects outside the component)
-  - `el`
-
-2. **Global Awareness** (requires knowledge beyond the component)
-  - `name`
-  - `parent`
-
-3. **Component Type** (changes the type of the component)
-  - `functional`
-
-4. **Template Modifiers** (changes the way templates are compiled)
-  - `delimiters`
-  - `comments`
-
-5. **Template Dependencies** (assets used in the template)
-  - `components`
-  - `directives`
-  - `filters`
-
-6. **Composition** (merges properties into the options)
-  - `extends`
-  - `mixins`
-
-7. **Interface** (the interface to the component)
-  - `inheritAttrs`
-  - `model`
-  - `props`/`propsData`
-
-8. **Local State** (local reactive properties)
-  - `data`
-  - `computed`
-
-9. **Events** (callbacks triggered by reactive events)
-  - `watch`
-  - Lifecycle Events (in the order they are called)
-    - `beforeCreate`
-    - `created`
-    - `beforeMount`
-    - `mounted`
-    - `beforeUpdate`
-    - `updated`
-    - `activated`
-    - `deactivated`
-    - `beforeDestroy`
-    - `destroyed`
-
-10. **Non-Reactive Properties** (instance properties independent of the reactivity system)
-  - `methods`
-
-11. **Rendering** (the declarative description of the component output)
-  - `template`/`render`
-  - `renderError`
-
-
-
-### Element attribute order <sup data-p="c">recommended</sup>
-
-**The attributes of elements (including components) should be ordered consistently.**
-
-This is the default order we recommend for component options. They're split into categories, so you'll know where to add custom attributes and directives.
-
-1. **Definition** (provides the component options)
-  - `is`
-
-2. **List Rendering** (creates multiple variations of the same element)
-  - `v-for`
-
-3. **Conditionals** (whether the element is rendered/shown)
-  - `v-if`
-  - `v-else-if`
-  - `v-else`
-  - `v-show`
-  - `v-cloak`
-
-4. **Render Modifiers** (changes the way the element renders)
-  - `v-pre`
-  - `v-once`
-
-5. **Global Awareness** (requires knowledge beyond the component)
-  - `id`
-
-6. **Unique Attributes** (attributes that require unique values)
-  - `ref`
-  - `key`
-
-7. **Two-Way Binding** (combining binding and events)
-  - `v-model`
-
-8. **Other Attributes** (all unspecified bound & unbound attributes)
-
-9. **Events** (component event listeners)
-  - `v-on`
-
-10. **Content** (overrides the content of the element)
-  - `v-html`
-  - `v-text`
-
-
-
-### Empty lines in component/instance options <sup data-p="c">recommended</sup>
-
-**You may want to add one empty line between multi-line properties, particularly if the options can no longer fit on your screen without scrolling.**
-
-When components begin to feel cramped or difficult to read, adding spaces between multi-line properties can make them easier to skim again. In some editors, such as Vim, formatting options like this can also make them easier to navigate with the keyboard.
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` js
-props: {
-  value: {
-    type: String,
-    required: true
-  },
-
-  focused: {
-    type: Boolean,
-    default: false
-  },
-
-  label: String,
-  icon: String
-},
-
-computed: {
-  formattedValue: function () {
-    // ...
-  },
-
-  inputClasses: function () {
-    // ...
-  }
-}
-```
-
-``` js
-// No spaces are also fine, as long as the component
-// is still easy to read and navigate.
-props: {
-  value: {
-    type: String,
-    required: true
-  },
-  focused: {
-    type: Boolean,
-    default: false
-  },
-  label: String,
-  icon: String
-},
-computed: {
-  formattedValue: function () {
-    // ...
-  },
-  inputClasses: function () {
-    // ...
-  }
-}
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Single-file component top-level element order <sup data-p="c">recommended</sup>
-
-**[Single-file components](../guide/single-file-components.html) should always order `<script>`, `<template>`, and `<style>` tags consistently, with `<style>` last, because at least one of the other two is always necessary.**
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` html
-<style>/* ... */</style>
-<script>/* ... */</script>
-<template>...</template>
-```
-
-``` html
-<!-- ComponentA.vue -->
-<script>/* ... */</script>
-<template>...</template>
-<style>/* ... */</style>
-
-<!-- ComponentB.vue -->
-<template>...</template>
-<script>/* ... */</script>
-<style>/* ... */</style>
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` html
-<!-- ComponentA.vue -->
-<script>/* ... */</script>
-<template>...</template>
-<style>/* ... */</style>
-
-<!-- ComponentB.vue -->
-<script>/* ... */</script>
-<template>...</template>
-<style>/* ... */</style>
-```
-
-``` html
-<!-- ComponentA.vue -->
-<template>...</template>
-<script>/* ... */</script>
-<style>/* ... */</style>
-
-<!-- ComponentB.vue -->
-<template>...</template>
-<script>/* ... */</script>
-<style>/* ... */</style>
-```
-{% raw %}</div>{% endraw %}
-
-
-
-## Priority D Rules: Use with Caution (Potentially Dangerous Patterns)
-
-
-
-### `v-if`/`v-else-if`/`v-else` without `key` <sup data-p="d">use with caution</sup>
-
-**It's usually best to use `key` with `v-if` + `v-else`, if they are the same element type (e.g. both `<div>` elements).**
-
-By default, Vue updates the DOM as efficiently as possible. That means when switching between elements of the same type, it simply patches the existing element, rather than removing it and adding a new one in its place. This can have [unintended consequences](https://codesandbox.io/s/github/vuejs/vuejs.org/tree/master/src/v2/examples/vue-20-priority-d-rules-unintended-consequences) if these elements should not actually be considered the same.
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` html
-<div v-if="error">
-  Error: {{ error }}
-</div>
-<div v-else>
-  {{ results }}
-</div>
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` html
-<div
-  v-if="error"
-  key="search-status"
->
-  Error: {{ error }}
-</div>
-<div
-  v-else
-  key="search-results"
->
-  {{ results }}
-</div>
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Element selectors with `scoped` <sup data-p="d">use with caution</sup>
-
-**Element selectors should be avoided with `scoped`.**
-
-Prefer class selectors over element selectors in `scoped` styles, because large numbers of element selectors are slow.
-
-{% raw %}
-<details>
-<summary>
-  <h4>Detailed Explanation</h4>
-</summary>
-{% endraw %}
-
-To scope styles, Vue adds a unique attribute to component elements, such as `data-v-f3f3eg9`. Then selectors are modified so that only matching elements with this attribute are selected (e.g. `button[data-v-f3f3eg9]`).
-
-The problem is that large numbers of [element-attribute selectors](http://stevesouders.com/efws/css-selectors/csscreate.php?n=1000&sel=a%5Bhref%5D&body=background%3A+%23CFD&ne=1000) (e.g. `button[data-v-f3f3eg9]`) will be considerably slower than [class-attribute selectors](http://stevesouders.com/efws/css-selectors/csscreate.php?n=1000&sel=.class%5Bhref%5D&body=background%3A+%23CFD&ne=1000) (e.g. `.btn-close[data-v-f3f3eg9]`), so class selectors should be preferred whenever possible.
-
-{% raw %}</details>{% endraw %}
-
-{% raw %}<div class="style-example example-bad">{% endraw %}
-#### Bad
-
-``` html
-<template>
-  <button>X</button>
-</template>
-
-<style scoped>
-button {
-  background-color: red;
-}
-</style>
-```
-{% raw %}</div>{% endraw %}
-
-{% raw %}<div class="style-example example-good">{% endraw %}
-#### Good
-
-``` html
-<template>
-  <button class="btn btn-close">X</button>
-</template>
-
-<style scoped>
-.btn-close {
-  background-color: red;
-}
-</style>
-```
-{% raw %}</div>{% endraw %}
-
-
-
-### Implicit parent-child communication <sup data-p="d">use with caution</sup>
-
-**Props and events should be preferred for parent-child component communication, instead of `this.$parent` or mutating props.**
-
-An ideal Vue application is props down, events up. Sticking to this convention makes your components much easier to understand. However, there are edge cases where prop mutation or `this.$parent` can simplify two components that are already deeply coupled.
+An ideal Vue application is _props down, events up_. Sticking to this convention makes your components much easier to understand. However, there are edge cases where prop mutation or `this.$parent` can simplify two components that are already deeply coupled.
 
 The problem is, there are also many _simple_ cases where these patterns may offer convenience. Beware: do not be seduced into trading simplicity (being able to understand the flow of your state) for short-term convenience (writing less code).
 
@@ -1935,15 +1726,11 @@ Vue.component('TodoItem', {
 ```
 {% raw %}</div>{% endraw %}
 
+### CONSIDER using Vuex for global state management in a non-trivial application
 
+Managing state on `this.$root` and/or using a [global event bus](https://vuejs.org/v2/guide/migration.html#dispatch-and-broadcast-replaced) can be convenient for very simple cases, but will be increasingly harder to reason about once the application grows more complex.
 
-### Non-flux state management <sup data-p="d">use with caution</sup>
-
-**[Vuex](https://github.com/vuejs/vuex) should be preferred for global state management, instead of `this.$root` or a global event bus.**
-
-Managing state on `this.$root` and/or using a [global event bus](https://vuejs.org/v2/guide/migration.html#dispatch-and-broadcast-replaced) can be convenient for very simple cases, but it is not appropriate for most applications.
-
-Vuex is the [official flux-like implementation](https://vuejs.org/v2/guide/state-management.html#Official-Flux-Like-Implementation) for Vue, and offers not only a central place to manage state, but also tools for organizing, tracking, and debugging state changes. It integrates well in the Vue ecosystem (including full [Vue DevTools](https://vuejs.org/v2/guide/installation.html#Vue-Devtools) support).
+[Vuex](https://github.com/vuejs/vuex) is the [official flux-like implementation](https://vuejs.org/v2/guide/state-management.html#Official-Flux-Like-Implementation) for Vue, and offers not only a central place to manage state, but also tools for organizing, tracking, and debugging state changes. It integrates well in the Vue ecosystem (including full [Vue DevTools](https://vuejs.org/v2/guide/installation.html#Vue-Devtools) support).
 
 {% raw %}</details>{% endraw %}
 
@@ -2059,3 +1846,101 @@ export default {
 })()
 </script>
 {% endraw %}
+
+
+## Miscellaneous
+### PREFER putting each component in its own file
+
+Whenever a build system is available to concatenate files, each component should be in its own file. This helps you to more quickly find a component when you need to edit it or review how to use it.
+
+{% raw %}<div class="style-example example-bad">{% endraw %}
+#### Bad
+
+``` js
+Vue.component('TodoList', {
+  // ...
+})
+
+Vue.component('TodoItem', {
+  // ...
+})
+```
+{% raw %}</div>{% endraw %}
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+```
+components/
+|- TodoList.js
+|- TodoItem.js
+```
+
+```
+components/
+|- TodoList.vue
+|- TodoItem.vue
+```
+{% raw %}</div>{% endraw %}
+
+### CONSIDER adding an empty line between multi-line properties
+
+**You may want to add one empty line between multi-line properties, particularly if the options can no longer fit on your screen without scrolling.**
+
+When components begin to feel cramped or difficult to read, adding spaces between multi-line properties can make them easier to skim again. In some editors, such as Vim, formatting options like this can also make them easier to navigate with the keyboard.
+
+{% raw %}<div class="style-example example-good">{% endraw %}
+#### Good
+
+``` js
+props: {
+  value: {
+    type: String,
+    required: true
+  },
+
+  focused: {
+    type: Boolean,
+    default: false
+  },
+
+  label: String,
+  icon: String
+},
+
+computed: {
+  formattedValue: function () {
+    // ...
+  },
+
+  inputClasses: function () {
+    // ...
+  }
+}
+```
+
+``` js
+// No spaces are also fine, as long as the component
+// is still easy to read and navigate.
+props: {
+  value: {
+    type: String,
+    required: true
+  },
+  focused: {
+    type: Boolean,
+    default: false
+  },
+  label: String,
+  icon: String
+},
+computed: {
+  formattedValue: function () {
+    // ...
+  },
+  inputClasses: function () {
+    // ...
+  }
+}
+```
+{% raw %}</div>{% endraw %}


### PR DESCRIPTION
As discussed, this is my attempt to revamp our Style Guide with inspiration taken from [Dart](https://dart.dev/guides/language/effective-dart/design). The list of changes is as follow:

- Instead of priorities ("essential," "strongly recommended" etc.) we use descriptive verbs: DO, DON'T, AVOID, PREFER, and CONSIDER for the guidelines
- As a side effect, each guideline's header (which is presented in the sidebar) is now a complete sentence, making it easier to skim through
- Since priorities are no longer a thing, the guidelines are now grouped by what they target, for example, "naming," "templating," "patterns & practice" etc. This, however, can use some suggestions from the team. 
