### PR TITLE
Update Vue School Summer Sale banner

### DIFF
--- a/themes/vue/layout/partials/vueschool_banner.ejs
+++ b/themes/vue/layout/partials/vueschool_banner.ejs
@@ -10,7 +10,7 @@
       <img src="/images/banners/vs-backpack.png" alt="Backpack">
     </div>
     <div class="vs-slogan">
-      Less than <span class="vs-slogan-light">48 hours</span> left for the Vue School offer
+      Extended! <span class="vs-slogan-light">Last few hours</span> for the Vue School offer
     </div>
     <div class="vs-button">
       GET ACCESS

--- a/themes/vue/source/css/_vueschool.styl
+++ b/themes/vue/source/css/_vueschool.styl
@@ -103,7 +103,7 @@ body.has-vs-banner
     align-items: center
 
     .vs-backpack
-      margin-right: 14px
+      margin-right: 4px
       img
         height: 50px
         @media (min-width: 680px)
@@ -113,7 +113,7 @@ body.has-vs-banner
       color: #FFF
       font-weight: bold
       font-size: 14px
-      width: 150px
+      width: 180px
       text-align: center
       margin-left: 40px
       @media (min-width: 400px)
@@ -131,7 +131,7 @@ body.has-vs-banner
           display: inline
 
     .vs-button
-      margin-left: 43px
+      margin-left: 12px
       color: #FFF
       padding: 13px 24px
       border-radius: 40px
@@ -140,6 +140,8 @@ body.has-vs-banner
       font-weight: bold
       @media (min-width: 680px)
         display: inline-block
+      @media (min-width: 900px)
+        margin-left: 43px
 
   .vs-close
       right: 10px


### PR DESCRIPTION
This PR changes the banner on top of vuejs.org to inform visitors that it's only a few hours before the Summer Sale expires.

Please merge on **2021-06-24** around **5:00 pm CEST**.

[Click here to see the visuals of the banner.](https://imgur.com/a/DmFYvGj)

Related to [PR 2829](https://github.com/vuejs/vuejs.org/pull/2829)
