### PR TITLE
Update packaging-sfc-for-npm.md

### DIFF
--- a/src/v2/cookbook/packaging-sfc-for-npm.md
+++ b/src/v2/cookbook/packaging-sfc-for-npm.md
@@ -117,7 +117,8 @@ There is no need to write your module multiple times. It is possible to prepare 
     "@rollup/plugin-commonjs": "^11.1.0",
     "rollup-plugin-vue": "^5.0.1",
     "vue": "^2.6.10",
-    "vue-template-compiler": "^2.6.10"
+    "vue-template-compiler": "^2.6.10",
+    "@vue/compiler-sfc": "^3.2.2"
     ...
   },
   ...


### PR DESCRIPTION
add missing dependency to packaging-sfc-for-npm.md file

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
