### PR TITLE
update Dynamic Argument misleading property name

### DIFF
--- a/src/v2/guide/syntax.md
+++ b/src/v2/guide/syntax.md
@@ -147,10 +147,10 @@ Here `attributeName` will be dynamically evaluated as a JavaScript expression, a
 Similarly, you can use dynamic arguments to bind a handler to a dynamic event name:
 
 ``` html
-<a v-on:[eventName]="doSomething"> ... </a>
+<a v-on:[event]="doSomething"> ... </a>
 ```
 
-In this example, when `eventName`'s value is `"focus"`, `v-on:[eventName]` will be equivalent to `v-on:focus`.
+In this example, when `event`'s value is `"focus"`, `v-on:[event]` will be equivalent to `v-on:focus`.
 
 #### Dynamic Argument Value Constraints
 


### PR DESCRIPTION
changed eventName to event without uppercase since it converts to all lowercase `eventname` and this won't work when users first try until read the constraint part

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
