### PR TITLE
Add Airbrake integration to errorHandler docs

### DIFF
--- a/src/v2/api/index.md
+++ b/src/v2/api/index.md
@@ -86,7 +86,7 @@ type: api
 
   > In 2.6.0+, this hook also captures errors thrown inside `v-on` DOM listeners. In addition, if any of the covered hooks or handlers returns a Promise chain (e.g. async functions), the error from that Promise chain will also be handled.
 
-  > Error tracking services [Sentry](https://sentry.io/for/vue/) and [Bugsnag](https://docs.bugsnag.com/platforms/browsers/vue/) provide official integrations using this option.
+  > Error tracking services [Sentry](https://sentry.io/for/vue/), [Bugsnag](https://docs.bugsnag.com/platforms/browsers/vue/) and [Airbrake](https://airbrake.io/docs/installing-airbrake/installing-airbrake-in-a-vuejs-app/) provide official integrations using this option.
 
 ### warnHandler
 


### PR DESCRIPTION
I work for Airbrake. While working on a Vue app I stumbled upon the docs that
mention error handling with 3rd party services (Sentry, Bugsnag). I also saw a
PR adding Bugsnag: https://github.com/vuejs/vuejs.org/pull/1311

I thought, it would be nice to mention Airbrake as well, since we have also have
a decent support for Vue.

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
