### PR TITLE
Fix link to the video in the Guide intro

### DIFF
--- a/src/v2/guide/index.md
+++ b/src/v2/guide/index.md
@@ -8,7 +8,7 @@ order: 2
 
 Vue (pronounced /vjuː/, like **view**) is a **progressive framework** for building user interfaces. Unlike other monolithic frameworks, Vue is designed from the ground up to be incrementally adoptable. The core library is focused on the view layer only, and is easy to pick up and integrate with other libraries or existing projects. On the other hand, Vue is also perfectly capable of powering sophisticated Single-Page Applications when used in combination with [modern tooling](single-file-components.html) and [supporting libraries](https://github.com/vuejs/awesome-vue#components--libraries).
 
-If you’d like to learn more about Vue before diving in, we <a id="modal-player"  href="#">created a video</a> walking through the core principles and a sample project.
+If you’d like to learn more about Vue before diving in, we <a id="modal-player"  href="https://www.vuemastery.com/courses/intro-to-vue-js/vue-instance/" target="_blank" rel="sponsored noopener" title="Free Vue.js Course">created a video</a> walking through the core principles and a sample project.
 
 If you are an experienced frontend developer and want to know how Vue compares to other libraries/frameworks, check out the [Comparison with Other Frameworks](comparison.html).
 


### PR DESCRIPTION
The link to the intro video doesn't take you to the video. This PR fixes that.