### PR TITLE
Remove Vue School's Black Friday banner

### DIFF
--- a/themes/vue/layout/layout.ejs
+++ b/themes/vue/layout/layout.ejs
@@ -1,6 +1,6 @@
 <% var isIndex = page.path === 'index.html' %>
 <% var isThemes = page.path === 'resources/themes.html' %>
-<% var hasVueSchoolBanner = true %>
+<% var hasVueSchoolBanner = false %>
 
 <!DOCTYPE html>
 <html lang="en" class="with-v3-banner">

--- a/themes/vue/source/css/index.styl
+++ b/themes/vue/source/css/index.styl
@@ -4,7 +4,6 @@
 @import "_sponsors-index"
 @import "_modal"
 @import "_themes"
-@import "_vueschool.styl"
 
 $width = 900px
 $space = 40px

--- a/themes/vue/source/css/page.styl
+++ b/themes/vue/source/css/page.styl
@@ -16,7 +16,6 @@
 @import "_scrimba"
 @import "_vue-mastery"
 @import "_themes"
-@import "_vueschool.styl"
 
 #header
   box-shadow: 0 0 1px rgba(0,0,0,.25)

--- a/themes/vue/source/js/common.js
+++ b/themes/vue/source/js/common.js
@@ -3,7 +3,6 @@
   initMobileMenu()
   initVideoModal()
   initNewNavLinks()
-  initVueSchoolBanner()
   if (PAGE_TYPE) {
     initVersionSelect()
     initApiSpecLinks()


### PR DESCRIPTION
This PR removes the Vue School Black Friday banner from the top of vuejs.org.

Please merge this PR after **Dec 3th 21 PM (Central European Time)**

The landing page will keep working after the promo ends, so the link (https://vueschool.io/sales/blackfriday?friend=vuejs) will still be valid.

Related to [PR 2908](https://github.com/vuejs/vuejs.org/pull/2908)