### PR TITLE
Update events.md

### DIFF
--- a/src/v2/guide/events.md
+++ b/src/v2/guide/events.md
@@ -104,6 +104,8 @@ var example2 = new Vue({
 </script>
 {% endraw %}
 
+<p class="tip">Note that `event.target` might reference a child element of the element on which the `v-on` was set. Use `event.currentTarget` to get the element of the `v-on`.</p>
+
 ## Methods in Inline Handlers
 
 Instead of binding directly to a method name, we can also use methods in an inline JavaScript statement:


### PR DESCRIPTION
Added a note on `event.target` vs `event.currentTarget` with respect to referencing the clicked element or potential child elements.
Although this is somewhat outside of the Vue code base, it might be confusing from the given example.
See [this documentation](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget) for reference.

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
