### PR TITLE
Update debugging-in-vscode.md

### DIFF
--- a/src/v2/cookbook/debugging-in-vscode.md
+++ b/src/v2/cookbook/debugging-in-vscode.md
@@ -12,10 +12,7 @@ This recipe shows how to debug [Vue CLI](https://github.com/vuejs/vue-cli) appli
 
 ## Prerequisites
 
-Make sure you have VS Code and the browser of your choice installed, and the latest version of the corresponding Debugger extension installed and enabled:
-
-* [Debugger for Chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome)
-* [Debugger for Firefox](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-firefox-debug)
+Make sure you have VS Code and either Chrome or Firefox browser installed.
 
 Install and create a project with the [vue-cli](https://github.com/vuejs/vue-cli), following the instructions in the [Vue CLI Guide](https://cli.vuejs.org/). Change into the newly created application directory and open VS Code.
 


### PR DESCRIPTION
Chrome and firefox addons are deprecated

VS Code has a bundled JS Debugger

Note
====
This repository is for Vue 1.x and 2.x only. Issues and pull requests related to 3.x are managed in the v3 doc repo: https://github.com/vuejs/docs-next.
